### PR TITLE
Notebook to auto convert multiple STLs into LNAS

### DIFF
--- a/notebooks/stl2lnas.ipynb
+++ b/notebooks/stl2lnas.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Turn lots of stl files into lnas files"
+    "# Turn lots of stl files into lnas files\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## define main variables and initialize code"
+    "## define main variables and initialize code\n"
    ]
   },
   {
@@ -31,24 +31,28 @@
     "\n",
     "pp = pprint.PrettyPrinter()\n",
     "\n",
-    "file_mode_dir_root = pathlib.Path(\"/mnt/d/codigos/dev01_nassu_data/consulting/026-PrologisCajamar4/project_data/STLs_files\")\n",
-    "folder_mode_dir_root = pathlib.Path(\"/mnt/d/codigos/dev01_nassu_data/consulting/026-PrologisCajamar4/project_data/STLs_folders\")\n",
+    "file_mode_dir_root = pathlib.Path(\n",
+    "    \"/mnt/d/codigos/dev01_nassu_data/consulting/026-PrologisCajamar4/project_data/STLs_files\"\n",
+    ")\n",
+    "folder_mode_dir_root = pathlib.Path(\n",
+    "    \"/mnt/d/codigos/dev01_nassu_data/consulting/026-PrologisCajamar4/project_data/STLs_folders\"\n",
+    ")\n",
     "stl2lnas_repository_path = pathlib.Path(\"/mnt/d/codigos/stl2lnas\")\n",
-    "cargo_bin = pathlib.Path(\"/home/aerosim/.cargo/bin/cargo\")\n"
+    "cargo_bin = pathlib.Path(\"/home/aerosim/.cargo/bin/cargo\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Functions definitions"
+    "## Functions definitions\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Yaml and file tree handling"
+    "### Yaml and file tree handling\n"
    ]
   },
   {
@@ -85,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### file mode"
+    "### file mode\n"
    ]
   },
   {
@@ -98,7 +102,7 @@
     "    cfgs_root = dir_root.parent / \"lnas_cfg\"\n",
     "    output_root = dir_root.parent / \"lnas\"\n",
     "    path_relative = stl_file.relative_to(dir_root)\n",
-    "    \n",
+    "\n",
     "    yaml_cfg_dict = {}\n",
     "    file_name = stl_file.stem\n",
     "    yaml_cfg_dict[\"name\"] = file_name\n",
@@ -108,7 +112,7 @@
     "    yaml_cfg_dict[\"stl\"][\"folders\"] = []\n",
     "    yaml_cfg_dict[\"output\"] = {}\n",
     "    yaml_cfg_dict[\"output\"][\"folder\"] = str(output_root / path_relative.parent / file_name)\n",
-    "    config_filename = (cfgs_root / path_relative.parent / (\"convert_\" + file_name + \".yaml\"))\n",
+    "    config_filename = cfgs_root / path_relative.parent / (\"convert_\" + file_name + \".yaml\")\n",
     "    save_yaml(config_filename, data=yaml_cfg_dict)\n",
     "    return config_filename"
    ]
@@ -130,7 +134,9 @@
     "        elif key.is_dir():\n",
     "            cfg_dir_path_relative = key.relative_to(dir_root)\n",
     "            cfg_dir_path = cfgs_root / cfg_dir_path_relative\n",
-    "            cfg_files_tree[cfg_dir_path] = file_mode_generate_config_files_from_directory(dir_root, dir_tree[key])\n",
+    "            cfg_files_tree[cfg_dir_path] = file_mode_generate_config_files_from_directory(\n",
+    "                dir_root, dir_tree[key]\n",
+    "            )\n",
     "    return cfg_files_tree"
    ]
   },
@@ -138,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### folder mode"
+    "### folder mode\n"
    ]
   },
   {
@@ -151,7 +157,7 @@
     "    cfgs_root = dir_root.parent / \"lnas_cfg\"\n",
     "    output_root = dir_root.parent / \"lnas\"\n",
     "    path_relative = stl_folder.relative_to(dir_root)\n",
-    "    \n",
+    "\n",
     "    yaml_cfg_dict = {}\n",
     "    dir_name = stl_folder.stem\n",
     "    yaml_cfg_dict[\"name\"] = dir_name\n",
@@ -161,7 +167,7 @@
     "    yaml_cfg_dict[\"stl\"][\"folders\"].append(str(stl_folder))\n",
     "    yaml_cfg_dict[\"output\"] = {}\n",
     "    yaml_cfg_dict[\"output\"][\"folder\"] = str(output_root / path_relative)\n",
-    "    config_filename = (cfgs_root / path_relative.parent / (\"convert_\" + dir_name + \".yaml\"))\n",
+    "    config_filename = cfgs_root / path_relative.parent / (\"convert_\" + dir_name + \".yaml\")\n",
     "    save_yaml(config_filename, data=yaml_cfg_dict)\n",
     "    return config_filename"
    ]
@@ -176,17 +182,19 @@
     "    cfgs_root = dir_root.parent / \"lnas_cfg\"\n",
     "    cfg_files_tree = {}\n",
     "    cfg_files_tree[\"_files\"] = []\n",
-    "    \n",
+    "\n",
     "    for key in dir_tree:\n",
     "        if key == \"_files\":\n",
     "            continue\n",
     "        elif key.is_dir():\n",
     "            cfg_dir_path_relative = key.relative_to(dir_root)\n",
     "            cfg_dir_path = cfgs_root / cfg_dir_path_relative\n",
-    "            if len(dir_tree[key]) == 1: # '_files' is always defined\n",
+    "            if len(dir_tree[key]) == 1:  # '_files' is always defined\n",
     "                cfg_files_tree[\"_files\"].append(generate_cfg_for_stl_folder(dir_root, key))\n",
     "            else:\n",
-    "                cfg_files_tree[cfg_dir_path] = folder_mode_generate_config_files_from_directory(dir_root, dir_tree=dir_tree[key])\n",
+    "                cfg_files_tree[cfg_dir_path] = folder_mode_generate_config_files_from_directory(\n",
+    "                    dir_root, dir_tree=dir_tree[key]\n",
+    "                )\n",
     "    return cfg_files_tree"
    ]
   },
@@ -194,7 +202,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### lnas handling"
+    "### lnas handling\n"
    ]
   },
   {
@@ -235,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Execution"
+    "# Execution\n"
    ]
   },
   {
@@ -254,8 +262,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "file_mode_cfg_path_tree = file_mode_generate_config_files_from_directory(file_mode_dir_root, file_mode_dir_tree)\n",
-    "folder_mode_cfg_path_tree = folder_mode_generate_config_files_from_directory(folder_mode_dir_root, folder_mode_dir_tree)"
+    "file_mode_cfg_path_tree = file_mode_generate_config_files_from_directory(\n",
+    "    file_mode_dir_root, file_mode_dir_tree\n",
+    ")\n",
+    "folder_mode_cfg_path_tree = folder_mode_generate_config_files_from_directory(\n",
+    "    folder_mode_dir_root, folder_mode_dir_tree\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
In real applications of the software it is often necessary to generate a few dozen STLs that must be converted one by one into LNAS, each requiring its own config file. This commit contains a notebook that automatizes this task, considering specifications to fit engineering applications (with multiple wind directions and multi-surface bodies).
There are 2 execution modes: "file-mode" and "folder-mode":
- In ***file-mode*** the script will search through a directory tree and will generate a config file (and a LNAS) for each STL found.
- In ***folder-mode*** the script will search through a directory tree and will generate a config file (and a LNAS) for each directory without sub-directories. Every STL found inside this directory will be part of the same LNAS as a separate surface.

STLs that are intended to be processed in different modes must be contained in different root-directories, since there is no other configuration indicating the execution mode for each STL individually.

The script allows the root-directory to contain a sub-directory tree of arbitrary depth, and will preserve the tree structure in the config files and lnas created.
For example, given this directory-tree:
``` markdown
- STLs_folder
  - G100
    - list of many stls.
  - G200
    - ...
- STLs_files
  - 000
    - loft_windward.stl
    - loft_leeward.stl
  - 045
    - ...
  - 090
    - ..
  - terrain_kernel.stl
```

Would result in this LNAS diretory-tree structure:
``` markdown
- lnas
  - G100
  - G200
  - 000
    - loft_windward
    - loft_leeward
  - 045
    - ...
  - 090
    - ...
  - terrain_kernel
```