### PR TITLE
corrected optional import in cfdmod utils

### DIFF
--- a/cfdmod/use_cases/altimetry/figure.py
+++ b/cfdmod/use_cases/altimetry/figure.py
@@ -1,0 +1,18 @@
+import pathlib
+
+import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
+
+from cfdmod.utils import create_folders_for_file
+
+
+def savefig_to_file(fig: Figure, filename: pathlib.Path):
+    """Creates folders to save given file
+
+    Args:
+        fig (Figure): Figure object to save
+        filename (pathlib.Path): Filename to setup folder
+    """
+    create_folders_for_file(filename)
+    fig.savefig(filename.as_posix())
+    plt.close(fig)

--- a/cfdmod/use_cases/altimetry/main.py
+++ b/cfdmod/use_cases/altimetry/main.py
@@ -6,8 +6,8 @@ from typing import List
 import trimesh
 
 from cfdmod.use_cases.altimetry import AltimetryProbe, AltimetrySection, Shed
+from cfdmod.use_cases.altimetry.figure import savefig_to_file
 from cfdmod.use_cases.altimetry.plots import plot_altimetry_profiles
-from cfdmod.utils import savefig_to_file
 
 
 @dataclass

--- a/cfdmod/utils.py
+++ b/cfdmod/utils.py
@@ -1,21 +1,7 @@
 import pathlib
 from typing import Any
 
-import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
 from ruamel.yaml import YAML
-
-
-def savefig_to_file(fig: Figure, filename: pathlib.Path):
-    """Creates folders to save given file
-
-    Args:
-        fig (Figure): Figure object to save
-        filename (pathlib.Path): Filename to setup folder
-    """
-    create_folders_for_file(filename)
-    fig.savefig(filename.as_posix())
-    plt.close(fig)
 
 
 def create_folders_for_file(filename: pathlib.Path):

--- a/tests/use_cases/altimetry/test_altimetry.py
+++ b/tests/use_cases/altimetry/test_altimetry.py
@@ -5,8 +5,8 @@ import numpy as np
 import trimesh
 
 from cfdmod.use_cases.altimetry import AltimetryProbe, AltimetrySection, Shed
+from cfdmod.use_cases.altimetry.figure import savefig_to_file
 from cfdmod.use_cases.altimetry.plots import plot_altimetry_profiles, plot_profiles, plot_surface
-from cfdmod.utils import savefig_to_file
 
 
 class TestAltimetryUseCase(unittest.TestCase):


### PR DESCRIPTION
When consuming cfdmod in Insight, there was a bug because of the optional matplotlib dependency.

To fix this issue, the functions that saved figures in cfdmod.utils were moved inside the modules.
In that way, Insight can consume cfdmod without breaking matplotlib dependency while using functions from the utils.