### PR TITLE
Notebook/geometry api new functionalities

### DIFF
--- a/notebooks/geometry_api.ipynb
+++ b/notebooks/geometry_api.ipynb
@@ -84,8 +84,7 @@
     "        splitsurfacewithsection=True,\n",
     "    )\n",
     "\n",
-    "    return ms\n",
-    "    \n"
+    "    return ms"
    ]
   },
   {
@@ -94,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def get_mesh_coordinates(mesh_path: pathlib.Path) -> MeshSet:\n",
+    "def get_mesh_coordinates(mesh_path: pathlib.Path) -> tuple[np.ndarray, np.ndarray]:\n",
     "    triangles, normals = read_stl(mesh_path)\n",
     "    \n",
     "    return triangles, normals"
@@ -403,7 +402,7 @@
     "df_save[\"nz\"] = normals[:, 2]\n",
     "\n",
     "\n",
-    "df_save.to_csv(root_path / \"simulation_data/artifacts/csvs/bottom_offset.csv\", index=False)\n"
+    "df_save.to_csv(root_path / \"simulation_data/artifacts/csvs/bottom_offset.csv\", index=False)"
    ]
   }
  ],
@@ -423,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
New functionalities added to the notebook geometry_api:
- Cut square from surface: uses the function `slice_surface` repeatedly to crop an stl and leave a central square.
- Extract stl vertices coordinates and export to csv
- Given a csv with xy coordinates, finds the corresponding z coordinate in a stl. Useful to generate a set of probes aligned with a stl.