### PR TITLE
release: v2.1.0 + relax dependency bounds for library use

### DIFF
--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -1,6 +1,17 @@
 # Release Notes
 
-## Unreleased
+## v2.1.0
+
+Minor release on top of v2.0.1. Three geometry-preprocessing
+subpackages land -- the triangle-grouping pipeline
+(`cfdmod.geometry.grouping`), the regroup module (`cfdmod.regroup`),
+and the remesh module (`cfdmod.remesh`) -- all exported from the
+top-level `cfdmod` package and driven from the new notebooks. The
+release also relaxes the dependency version bounds so `aerosim-cfdmod`
+can be co-installed as a library without forcing resolution conflicts
+on consumers. No breaking changes to existing public APIs; the legacy
+`sub_bodies` YAML form and the v2.0 Cp/Cf/Cm/Ce output layout are
+unchanged.
 
 ### Triangle-grouping pipeline (`cfdmod.geometry.grouping`)
 
@@ -84,6 +95,64 @@ write_processing_metadata(h5, "/", {
 
 See `fixtures/tests/pressure/Cf_params_groupings.yaml` for the new
 explicit YAML form, and the API reference for the full surface.
+
+### Regroup module (`cfdmod.regroup`)
+
+A standalone preprocessing module that takes a geometry plus a
+per-triangle HDF5 timeseries (Cp-style: rows = timesteps, columns =
+parent triangle ids), applies a chain of triangle-grouping specs
+(Ce-style 90-degree zoning cuts, connectivity-based container
+separation, etc.), and writes two aligned outputs:
+
+- a new `LnasFormat` mesh with one named surface per group, and
+- a new HDF5 timeseries whose columns line up with the new triangle
+  order (`per_triangle` mode) or whose values are area-weighted
+  aggregates per group broadcast over each group's triangles
+  (`area_weighted_mean` mode).
+
+It reuses `cfdmod.geometry.grouping` for all binning kinds and adds
+one regroup-local spec, `BySizeRoundedPerComponent`, that fans out
+per-component target-size subdivisions (resolved by `run_regroup`).
+The module follows the standard domain layout (config / cli / run /
+functions) and is runnable as `python -m cfdmod.regroup`. New public
+symbols exported from the top-level package: `RegroupConfig`,
+`RegroupSpec`, `RegroupIndex`, `BySizeRoundedPerComponent`,
+`build_regroup_mapping`, `build_regrouped_mesh`,
+`apply_regroup_to_timeseries`, `expand_regroup_chain`, `run_regroup`.
+Driven end-to-end from the new `notebooks/regroup_containers.ipynb`,
+which folds slice + per-face aggregation + remesh into a single
+in-memory pipeline.
+
+### Remesh module (`cfdmod.remesh`)
+
+Per-group triangle coarsening for grouped `LnasFormat` meshes. The
+default path is exact coplanar-fan merging: within each group,
+adjacent triangles that share a plane are replaced by the minimum
+triangulation of their joined region (a flat NxN-subdivided square
+collapses to 2 triangles). It is lossless, deterministic, and pulls
+in no external dependency. An opt-in path runs Quadric Error Metrics
+(QEM) decimation on top via `fast-simplification` (MIT-licensed,
+available through the new `remesh` extra) for groups on curved
+surfaces where coplanar merge cannot reduce the count further.
+
+API surface only -- no CLI, no YAML config, no HDF5 I/O -- intended
+for in-process use from notebooks and debugging scripts. New public
+symbols exported from the top-level package: `merge_coplanar`,
+`decimate_qem`, `remesh_per_group`.
+
+### Relaxed dependency bounds
+
+The runtime dependency pins were loosened from capped ranges to
+floors-only so `aerosim-cfdmod` can be co-installed as a library
+without forcing version-resolution conflicts on downstream projects
+(for example one that needs pandas 3.x). The upper caps were dropped
+from `numpy`, `scipy`, `pandas`, `pydantic`, `ruamel-yaml`,
+`colorama`, `matplotlib`, `pyarrow`, and `aerosim-lnas`, and from the
+`geometry`, `remesh`, and `vtk` optional extras. Lower bounds (the
+minimum tested versions) are unchanged. The `legacy`/`dev` `tables`
+pin keeps its `<4` cap, which guards Python 3.10 support. Consuming
+applications should pin exact versions themselves; this library only
+declares floors.
 
 ## v2.0.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerosim-cfdmod"
-version = "2.0.1"
+version = "2.1.0"
 description = "Tools for analysis of CFD cases"
 authors = [
     { name = "Waine Oliveira Jr", email = "waine@aerosim.io" },
@@ -8,16 +8,20 @@ authors = [
 requires-python = ">=3.10"
 readme = "README.md"
 license = "Apache-2.0"
+# Lower bounds are the minimum tested versions; upper caps are intentionally
+# omitted so this library can be co-installed as a dependency without forcing
+# resolution conflicts on consumers (e.g. a project that needs pandas 3.x).
+# Keep these as floors only -- pin in the consuming application, not here.
 dependencies = [
-    "numpy>=2.0,<3",
-    "scipy>=1.13,<2",
-    "pandas>=2.2,<3",
-    "pydantic>=2.10,<3",
-    "ruamel-yaml>=0.18.5,<0.20",
-    "colorama>=0.4.6,<0.5",
-    "matplotlib>=3.9,<4",
-    "pyarrow>=19.0.0,<25",
-    "aerosim-lnas>=0.6.9,<0.7",
+    "numpy>=2.0",
+    "scipy>=1.13",
+    "pandas>=2.2",
+    "pydantic>=2.10",
+    "ruamel-yaml>=0.18.5",
+    "colorama>=0.4.6",
+    "matplotlib>=3.9",
+    "pyarrow>=19.0.0",
+    "aerosim-lnas>=0.6.9",
     "openpyxl>=3.1.5",
     "h5py>=3.15.1",
     "typer>=0.24.1",
@@ -33,10 +37,10 @@ dependencies = [
 # is the approved QEM decimator: MIT-licensed, wraps the
 # Fast-Quadric-Mesh-Simplification C++ implementation.
 geometry = [
-    "trimesh>=4.0,<5",
+    "trimesh>=4.0",
 ]
 remesh = [
-    "fast-simplification>=0.1,<1",
+    "fast-simplification>=0.1",
 ]
 docs = [
     "shibuya>=2026.0",
@@ -52,8 +56,8 @@ notebook = [
     "ipykernel>=6.25.2,<8",
 ]
 vtk = [
-    "vtk>=9.2.6,<10",
-    "pyvista>=0.44,<0.50",
+    "vtk>=9.2.6",
+    "pyvista>=0.44",
 ]
 # Required only for the legacy pandas-HDFStore compat readers in
 # cfdmod.inflow, cfdmod.hfpi.static, and cfdmod.pressure.migrate.

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "aerosim-cfdmod"
-version = "2.0.1"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aerosim-lnas" },
@@ -47,6 +47,9 @@ notebook = [
     { name = "ipython" },
     { name = "jupyter" },
 ]
+remesh = [
+    { name = "fast-simplification" },
+]
 vtk = [
     { name = "pyvista" },
     { name = "vtk" },
@@ -67,33 +70,34 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aerosim-lnas", specifier = ">=0.6.9,<0.7" },
-    { name = "colorama", specifier = ">=0.4.6,<0.5" },
+    { name = "aerosim-lnas", specifier = ">=0.6.9" },
+    { name = "colorama", specifier = ">=0.4.6" },
+    { name = "fast-simplification", marker = "extra == 'remesh'", specifier = ">=0.1" },
     { name = "h5py", specifier = ">=3.15.1" },
     { name = "ipykernel", marker = "extra == 'notebook'", specifier = ">=6.25.2,<8" },
     { name = "ipython", marker = "extra == 'notebook'", specifier = ">=8.15.0,<10" },
     { name = "jupyter", marker = "extra == 'notebook'", specifier = ">=1.0.0,<2" },
-    { name = "matplotlib", specifier = ">=3.9,<4" },
+    { name = "matplotlib", specifier = ">=3.9" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=4.0,<6" },
     { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.9.3,<0.10" },
-    { name = "numpy", specifier = ">=2.0,<3" },
+    { name = "numpy", specifier = ">=2.0" },
     { name = "openpyxl", specifier = ">=3.1.5" },
-    { name = "pandas", specifier = ">=2.2,<3" },
-    { name = "pyarrow", specifier = ">=19.0.0,<25" },
-    { name = "pydantic", specifier = ">=2.10,<3" },
-    { name = "pyvista", marker = "extra == 'vtk'", specifier = ">=0.44,<0.50" },
-    { name = "ruamel-yaml", specifier = ">=0.18.5,<0.20" },
-    { name = "scipy", specifier = ">=1.13,<2" },
+    { name = "pandas", specifier = ">=2.2" },
+    { name = "pyarrow", specifier = ">=19.0.0" },
+    { name = "pydantic", specifier = ">=2.10" },
+    { name = "pyvista", marker = "extra == 'vtk'", specifier = ">=0.44" },
+    { name = "ruamel-yaml", specifier = ">=0.18.5" },
+    { name = "scipy", specifier = ">=1.13" },
     { name = "shibuya", marker = "extra == 'docs'", specifier = ">=2026.0" },
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = ">=2021.3.14" },
     { name = "sphinx-sitemap", marker = "extra == 'docs'", specifier = ">=2.6" },
     { name = "sphinxcontrib-bibtex", marker = "extra == 'docs'", specifier = ">=2.6.1,<3" },
     { name = "tables", marker = "extra == 'legacy'", specifier = ">=3.9.1,<4" },
-    { name = "trimesh", marker = "extra == 'geometry'", specifier = ">=4.0,<5" },
+    { name = "trimesh", marker = "extra == 'geometry'", specifier = ">=4.0" },
     { name = "typer", specifier = ">=0.24.1" },
-    { name = "vtk", marker = "extra == 'vtk'", specifier = ">=9.2.6,<10" },
+    { name = "vtk", marker = "extra == 'vtk'", specifier = ">=9.2.6" },
 ]
-provides-extras = ["geometry", "docs", "notebook", "vtk", "legacy"]
+provides-extras = ["geometry", "remesh", "docs", "notebook", "vtk", "legacy"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -767,6 +771,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/91/50/a9d80c47ff289c611ff12e63f7c5d13942c65d68125160cefd768c73e6e4/executing-2.2.0.tar.gz", hash = "sha256:5d108c028108fe2551d1a7b2e8b713341e2cb4fc0aa7dcf966fa4327a5226755", size = 978693, upload-time = "2025-01-22T15:41:29.403Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl", hash = "sha256:11387150cad388d62750327a53d3339fad4888b39a6fe233c3afbb54ecffd3aa", size = 26702, upload-time = "2025-01-22T15:41:25.929Z" },
+]
+
+[[package]]
+name = "fast-simplification"
+version = "0.1.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/c7/e000571f3f271fb88b92f2bf0fbe48a12993c77cde8093c490997df46a6d/fast_simplification-0.1.13.tar.gz", hash = "sha256:5e95c966ad4ddf04b0a49013c92e5a06a3b888c6e02bb3c7ab3817fc8ba0f03f", size = 27136, upload-time = "2025-12-19T16:57:40.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/97/812aa10436c0d0d397ad9738cd4c98cf185438b9eccc4f6e53c19a7019e7/fast_simplification-0.1.13-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c95bd92a4817eb96d994e792df38ead3457ea01d58a095d81d53cb0fb4e1578", size = 247902, upload-time = "2025-12-19T16:57:23.639Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6b/0de466b754eab24c04ced934ac5912e780a7ea2bd07e7ecd328a4dae115e/fast_simplification-0.1.13-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9fad0599c569fc8d56429a42812431f51f732cd56046b06f5e061f8cb6e7a54d", size = 235507, upload-time = "2025-12-19T16:57:24.918Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1c/c596ad29a46665ce8f77579446fae46df2a23a8ac7f8bb62bf104fb24643/fast_simplification-0.1.13-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da89a8787fdc76ed5dea5d373dc95f941044e658dce65e23fca32a624ce5d440", size = 1702166, upload-time = "2025-12-19T16:57:26.767Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4c/5fbce7b06b15815be0e8f54cc9456e1ada9a26f5c4df236526c0d7344dea/fast_simplification-0.1.13-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6c82a25fff7892b39eb4147b6286fea4ff42dd62d1137591197d0b6b2f68a78", size = 1725700, upload-time = "2025-12-19T16:57:28.617Z" },
+    { url = "https://files.pythonhosted.org/packages/89/68/745d696cdffa34a383a388d0b0f2e73ed7e43dedfe9c423a64cdf2f4f91d/fast_simplification-0.1.13-cp310-cp310-win_amd64.whl", hash = "sha256:c57db49c27452168a60b00c6ab643ff8ed97b8ebb2d121315ec2553992adc6c0", size = 388224, upload-time = "2025-12-19T16:57:30.279Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/81/ea0026164dd9dbaf6904176dbc716b8361548bbff7c0a273c14e2137ed27/fast_simplification-0.1.13-cp311-abi3-macosx_10_9_x86_64.whl", hash = "sha256:4a89d1d0ecbb547528048ab6333bf2287767dbba727fa0553b18a138802d9b61", size = 225697, upload-time = "2025-12-19T16:57:31.776Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1c/ea8c057ebf02a3b24eddc79619bdc1c844a2354dbdf66176d86750755846/fast_simplification-0.1.13-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:f3bcd10b5de2a85fe41d4ba27ccdf3adc723c2a0f5a1afb47f01e95c6c158651", size = 221602, upload-time = "2025-12-19T16:57:32.941Z" },
+    { url = "https://files.pythonhosted.org/packages/34/64/4ecbf504f3207a36e7713013b473d40fb56d1b665b7d6ee80ffd3b217f81/fast_simplification-0.1.13-cp311-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ed45b1f07d718832aec76ae92c91ab8e84001d935055379ce0089b0cfb87870", size = 1613145, upload-time = "2025-12-19T16:57:34.13Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/44/ae0b556d62ed6a8c6f290435f4764fae9944f6857171b60613ab35f0f1a7/fast_simplification-0.1.13-cp311-abi3-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c694f0f0bbafbaf29acf7043de603b4c85259f2eae7b802d4946d47976e9959d", size = 1638154, upload-time = "2025-12-19T16:57:35.609Z" },
+    { url = "https://files.pythonhosted.org/packages/33/44/3208d9c3f76b5cadcc43b96a0db21c62926b3aa35be2cf16deb88cc7d4d1/fast_simplification-0.1.13-cp311-abi3-win_amd64.whl", hash = "sha256:94565811e708828f77c0a30eb8f05278e8f5826f2cbf1791cc470f6471dd0dce", size = 378277, upload-time = "2025-12-19T16:57:38.783Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prepares the **v2.1.0** release and relaxes the runtime dependency bounds so `aerosim-cfdmod` can be co-installed as a library without forcing resolution conflicts on downstream consumers.

### Dependency relaxation (the motivating change)
Runtime pins go from capped ranges to **floors-only**. This unblocks consumers like the aerosim repo that need a newer major (e.g. pandas 3.x) -- the old `pandas>=2.2,<3` cap made co-installation impossible.

- Upper caps dropped from: `numpy`, `scipy`, `pandas`, `pydantic`, `ruamel-yaml`, `colorama`, `matplotlib`, `pyarrow`, `aerosim-lnas`, and the `geometry` / `remesh` / `vtk` optional extras.
- Lower bounds (minimum tested versions) are **unchanged**.
- `tables` keeps its `<4` cap on purpose -- its comment documents that it guards Python 3.10 support, and `requires-python` is still `>=3.10`.
- Rationale: libraries should declare floors and let the consuming **application** pin exact versions.

### Release prep
- Version bump `2.0.1 -> 2.1.0` (minor: whole new public modules landed since v2.0.1).
- `docs/source/release_notes.md`: promoted `## Unreleased` -> `## v2.1.0` and documented the two modules that were merged **without** release notes:
  - **Regroup module** (`cfdmod.regroup`) + `regroup_containers.ipynb`
  - **Remesh module** (`cfdmod.remesh`) + new `remesh` extra
  - (the triangle-grouping pipeline notes were already present)
  - added a "Relaxed dependency bounds" entry
- `uv.lock` regenerated.

## How releases ship here
Merging this does **not** publish. Publishing is tag-driven: creating a GitHub Release for tag `v2.1.0` triggers `publish_pypi.yml` (`uv build` + `uv publish`) and `build_and_deploy_artifacts.yaml` (wheel/sdist + docs zip). Do that after merge.

## Notes
- `aerosim-lnas` upper cap (`<0.7`) was also dropped -- flag if you'd rather keep a ceiling on the internal package.
- Pre-existing unrelated working-tree changes (`plot_config.py`, `position_roughness_radial.ipynb`) were intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)