### PR TITLE
test(v3): property-based testing for the data-source layer (#141)

### DIFF
--- a/.github/workflows/property_tests.yaml
+++ b/.github/workflows/property_tests.yaml
@@ -1,0 +1,39 @@
+name: Property Tests (nightly)
+
+# The property-marked hypothesis tests (issue #141) run in the normal test
+# pipeline at hypothesis' default example budget. This job reruns only those
+# tests on a schedule with a much larger budget so rare falsifying inputs get
+# found without slowing every PR. Also runnable on demand.
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  property:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          pip install uv
+          uv venv
+
+      - name: Install dependencies with uv
+        run: uv pip install .[vtk,lnas,geometry]
+
+      - name: Run property tests with a large example budget
+        # The "ci" hypothesis profile (registered in tests/conftest.py) raises
+        # max_examples to 1000; the property tests do not pin their own budget.
+        run: uv run pytest -m property --hypothesis-profile ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ dev = [
     "tox>=4.53",
     "json-schema-for-humans>=1.5",
     "pytest>=9",
+    # Property-based / fuzz testing for the v3 data-source layer (issue #141).
+    # Test-only; drives the strategies in tests/strategies.py and the
+    # ``property``-marked tests.
+    "hypothesis>=6",
     "ruff>=0.15",
     # tests/inflow + tests/pressure/test_migrate exercise the legacy
     # HDFStore compat readers, so dev installs need pytables.
@@ -112,6 +116,7 @@ markers = [
     "unit: pure-function tests with no real-data fixtures or pipeline orchestration",
     "integration: end-to-end pipeline tests that exercise multiple components together",
     "perf: pipeline performance benchmarks on synthetic big data; opt-in via -m perf",
+    "property: hypothesis-driven generative tests over the v3 data-source layer; run with a larger example budget nightly via -m property",
 ]
 
 [tool.ruff]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,27 @@ Auto-marks any test that does not already carry a ``unit`` /
 selector ``pytest -m "unit or integration"`` actually runs the whole
 suite (previously only the handful of explicitly-marked files ran, and
 everything else was silently deselected). ``perf`` stays opt-in.
+
+Also registers the hypothesis example-budget profiles used by the
+``property``-marked tests (issue #141). The property tests deliberately do
+*not* pin ``max_examples`` themselves, so the active profile governs the count:
+
+- ``default`` -- 50 examples, used by every normal PR / local run.
+- ``dev`` -- 15 examples, for a quick inner loop (``--hypothesis-profile dev``).
+- ``ci`` -- 1000 examples, for the nightly job (``--hypothesis-profile ci``).
+
+``deadline=None`` on all profiles avoids spurious timing failures on shared CI
+runners; correctness, not per-example latency, is what these tests assert.
 """
 
 from __future__ import annotations
+
+from hypothesis import settings
+
+settings.register_profile("default", max_examples=50, deadline=None)
+settings.register_profile("dev", max_examples=15, deadline=None)
+settings.register_profile("ci", max_examples=1000, deadline=None)
+settings.load_profile("default")
 
 _SELECTION_MARKERS = {"unit", "integration", "perf"}
 

--- a/tests/core/test_property_algebra.py
+++ b/tests/core/test_property_algebra.py
@@ -1,0 +1,122 @@
+"""Property-based algebra tests (issue #141 phase 2).
+
+Exercises the four broadcasting rules in :mod:`cfdmod.core.algebra` over many
+random inputs. Float caveats baked in:
+
+- Commutativity is asserted only for the ``elementwise`` and ``constant`` rules.
+  ``classify_broadcast`` is asymmetric -- ``column`` needs the rhs to be the
+  single-element operand and ``row`` needs exactly one side time-aggregated --
+  so ``a op b`` and ``b op a`` do not generally classify the same way.
+- ``a - a`` is exactly zero for finite floats; ``(a * k) / k == a`` is only
+  recovered up to a floating-point tolerance.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core import algebra
+from cfdmod.core.data_source import PointsDataSource
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+
+pytestmark = pytest.mark.property
+
+FIELD = "v"
+
+
+def _points(arr: np.ndarray) -> PointsDataSource:
+    """A points source carrying ``arr`` under field ``v``.
+
+    A 1-D array is treated as a time-aggregated source; a 2-D array as a
+    time-resolved one with ``n_timesteps == arr.shape[1]``.
+    """
+    arr = np.asarray(arr, dtype=np.float64)
+    n = arr.shape[0]
+    if arr.ndim == 1:
+        time = TimeAxis(initial_time=0.0, timestep_size=0.0, n_timesteps=0)
+    else:
+        time = TimeAxis(initial_time=0.0, timestep_size=1.0, n_timesteps=arr.shape[1])
+    return PointsDataSource(
+        time=time,
+        topology=Topology.points(np.zeros((n, 3), dtype=np.float64)),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({FIELD: arr}),
+    )
+
+
+def _finite(**kw):
+    return st.floats(allow_nan=False, allow_infinity=False, width=64, **kw)
+
+
+@st.composite
+def _arrays(draw, *, allow_1d: bool = True):
+    """A finite float64 array, 1-D (aggregated) or 2-D (time-resolved)."""
+    n = draw(st.integers(min_value=1, max_value=6))
+    ndim = draw(st.sampled_from([1, 2])) if allow_1d else 2
+    shape = (n,) if ndim == 1 else (n, draw(st.integers(min_value=1, max_value=5)))
+    return draw(hnp.arrays(np.float64, shape, elements=_finite(min_value=-1e6, max_value=1e6)))
+
+
+@settings(max_examples=50)
+@given(arr=_arrays())
+def test_sub_self_is_zero(arr: np.ndarray) -> None:
+    a = _points(arr)
+    out = algebra.sub(a, a, field=FIELD)
+    assert np.array_equal(out.fields.read(FIELD), np.zeros_like(arr))
+
+
+@settings(max_examples=50)
+@given(
+    arr=_arrays(),
+    k=st.one_of(_finite(min_value=1e-3, max_value=1e3), _finite(min_value=-1e3, max_value=-1e-3)),
+)
+def test_mul_then_div_recovers_original(arr: np.ndarray, k: float) -> None:
+    a = _points(arr)
+    scaled = algebra.mul(a, k, field=FIELD)
+    back = algebra.div(scaled, k, field=FIELD)
+    assert np.allclose(back.fields.read(FIELD), arr, rtol=1e-9, atol=1e-9)
+
+
+@settings(max_examples=50)
+@given(data=st.data())
+def test_add_and_mul_commute_elementwise(data) -> None:
+    arr1 = data.draw(_arrays())
+    # Second operand shares the exact shape so the rule is elementwise.
+    arr2 = data.draw(
+        hnp.arrays(np.float64, arr1.shape, elements=_finite(min_value=-1e6, max_value=1e6))
+    )
+    a, b = _points(arr1), _points(arr2)
+    assert np.array_equal(
+        algebra.add(a, b, field=FIELD).fields.read(FIELD),
+        algebra.add(b, a, field=FIELD).fields.read(FIELD),
+    )
+    assert np.array_equal(
+        algebra.mul(a, b, field=FIELD).fields.read(FIELD),
+        algebra.mul(b, a, field=FIELD).fields.read(FIELD),
+    )
+
+
+@settings(max_examples=50)
+@given(
+    n=st.integers(min_value=1, max_value=6),
+    nt=st.integers(min_value=1, max_value=5),
+    rule=st.sampled_from(["constant", "elementwise", "column", "row"]),
+)
+def test_broadcast_result_shape_matches_lhs(n: int, nt: int, rule: str) -> None:
+    lhs = _points(np.ones((n, nt), dtype=np.float64))
+    if rule == "constant":
+        out = algebra.mul(lhs, 2.0, field=FIELD)
+    elif rule == "elementwise":
+        out = algebra.mul(lhs, _points(np.full((n, nt), 3.0)), field=FIELD)
+    elif rule == "column":
+        # rhs single element, same time axis -> broadcast across elements.
+        out = algebra.mul(lhs, _points(np.full((1, nt), 3.0)), field=FIELD)
+    else:  # row: rhs time-aggregated (n,) -> broadcast across the time axis.
+        out = algebra.mul(lhs, _points(np.full((n,), 3.0)), field=FIELD)
+    assert out.fields.read(FIELD).shape == lhs.fields.read(FIELD).shape == (n, nt)

--- a/tests/core/test_property_algebra.py
+++ b/tests/core/test_property_algebra.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as hnp
 
@@ -63,7 +63,6 @@ def _arrays(draw, *, allow_1d: bool = True):
     return draw(hnp.arrays(np.float64, shape, elements=_finite(min_value=-1e6, max_value=1e6)))
 
 
-@settings(max_examples=50)
 @given(arr=_arrays())
 def test_sub_self_is_zero(arr: np.ndarray) -> None:
     a = _points(arr)
@@ -71,7 +70,6 @@ def test_sub_self_is_zero(arr: np.ndarray) -> None:
     assert np.array_equal(out.fields.read(FIELD), np.zeros_like(arr))
 
 
-@settings(max_examples=50)
 @given(
     arr=_arrays(),
     k=st.one_of(_finite(min_value=1e-3, max_value=1e3), _finite(min_value=-1e3, max_value=-1e-3)),
@@ -83,7 +81,6 @@ def test_mul_then_div_recovers_original(arr: np.ndarray, k: float) -> None:
     assert np.allclose(back.fields.read(FIELD), arr, rtol=1e-9, atol=1e-9)
 
 
-@settings(max_examples=50)
 @given(data=st.data())
 def test_add_and_mul_commute_elementwise(data) -> None:
     arr1 = data.draw(_arrays())
@@ -102,7 +99,6 @@ def test_add_and_mul_commute_elementwise(data) -> None:
     )
 
 
-@settings(max_examples=50)
 @given(
     n=st.integers(min_value=1, max_value=6),
     nt=st.integers(min_value=1, max_value=5),

--- a/tests/core/test_property_data_source.py
+++ b/tests/core/test_property_data_source.py
@@ -1,0 +1,125 @@
+"""Property-based DataSource-invariant tests (issue #141 phase 2).
+
+The frozen :class:`~cfdmod.core.data_source.DataSource` advertises that every
+functional update either returns a source that still passes
+``_check_consistency`` or raises -- it never silently produces a shape-
+inconsistent frozen object. That exact bug (a functional update bypassing the
+validators) is one of the regressions pinned in
+``tests/core/test_review_regressions.py``; here we assert it generatively.
+
+Note: pydantic v2 wraps the ``ValueError`` raised inside a model validator in a
+:class:`pydantic.ValidationError` (which is *not* a ``ValueError`` subclass), so
+inconsistency-should-raise assertions accept either type.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from pydantic import ValidationError
+
+from cfdmod.core.grouping import Grouping
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta
+from tests import strategies as sty
+
+pytestmark = pytest.mark.property
+
+_INCONSISTENT = (ValueError, ValidationError)
+
+
+def _revalidates(ds) -> bool:
+    """True if ``ds`` still satisfies every model validator."""
+    type(ds).model_validate(dict(ds.__dict__))
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Positive: metadata-only updates stay consistent and preserve n_elements.
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_metadata_updates_preserve_n_elements(ds) -> None:
+    n = ds.n_elements
+    # with_attrs and without_grouping take the plain-model_copy path (no
+    # re-validation), so they are the most likely to drift; assert they stay
+    # consistent and n_elements is stable.
+    with_attrs = ds.with_attrs(note="x")
+    assert with_attrs.n_elements == n
+    assert _revalidates(with_attrs)
+
+    dropped = ds.without_grouping("does-not-exist")
+    assert dropped.n_elements == n
+    assert _revalidates(dropped)
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_compatible_with_time_preserves_shape(ds) -> None:
+    # A translate keeps n_timesteps, so field shapes still match -> consistent.
+    new_time = ds.time.translate(ds.time.initial_time + 5.0)
+    updated = ds.with_time(new_time)
+    assert updated.n_elements == ds.n_elements
+    assert updated.time.n_timesteps == ds.time.n_timesteps
+    assert _revalidates(updated)
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_valid_with_field_stays_consistent(ds) -> None:
+    n = ds.n_elements
+    shape = (n,) if ds.time.is_time_aggregated else (n, ds.time.n_timesteps)
+    updated = ds.with_field("extra", np.ones(shape, dtype=np.float64))
+    assert updated.n_elements == n
+    assert "extra" in updated.field_names
+    assert _revalidates(updated)
+
+
+# ---------------------------------------------------------------------------
+# Negative: an inconsistent update must raise, never silently succeed.
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_with_field_wrong_leading_axis_raises(ds) -> None:
+    bad = np.zeros((ds.n_elements + 1,), dtype=np.float64)
+    with pytest.raises(_INCONSISTENT):
+        ds.with_field("bad", bad)
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_with_grouping_wrong_size_raises(ds) -> None:
+    bad = Grouping(name="bad", indices=np.zeros(ds.n_elements + 1, dtype=np.int32))
+    with pytest.raises(_INCONSISTENT):
+        ds.with_grouping(bad)
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_with_elements_wrong_size_raises(ds) -> None:
+    bad = ElementMeta(position=np.zeros((ds.n_elements + 1, 3), dtype=np.float64))
+    with pytest.raises(_INCONSISTENT):
+        ds.with_elements(bad)
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_with_time_incompatible_axis_raises(ds) -> None:
+    if ds.time.is_time_aggregated:
+        # Aggregated source: fields are 1-D, so attaching a real time axis
+        # makes the field time-length (0) disagree with n_timesteps.
+        bad_time = TimeAxis(initial_time=0.0, timestep_size=1.0, n_timesteps=2)
+    else:
+        # Time-resolved: change the length so field time axes no longer match.
+        bad_time = TimeAxis(
+            initial_time=ds.time.initial_time,
+            timestep_size=ds.time.timestep_size,
+            n_timesteps=ds.time.n_timesteps + 1,
+        )
+    with pytest.raises(_INCONSISTENT):
+        ds.with_time(bad_time)

--- a/tests/core/test_property_data_source.py
+++ b/tests/core/test_property_data_source.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from pydantic import ValidationError
 
 from cfdmod.core.grouping import Grouping
@@ -40,7 +40,6 @@ def _revalidates(ds) -> bool:
 # ---------------------------------------------------------------------------
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_metadata_updates_preserve_n_elements(ds) -> None:
     n = ds.n_elements
@@ -56,7 +55,6 @@ def test_metadata_updates_preserve_n_elements(ds) -> None:
     assert _revalidates(dropped)
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_compatible_with_time_preserves_shape(ds) -> None:
     # A translate keeps n_timesteps, so field shapes still match -> consistent.
@@ -67,7 +65,6 @@ def test_compatible_with_time_preserves_shape(ds) -> None:
     assert _revalidates(updated)
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_valid_with_field_stays_consistent(ds) -> None:
     n = ds.n_elements
@@ -83,7 +80,6 @@ def test_valid_with_field_stays_consistent(ds) -> None:
 # ---------------------------------------------------------------------------
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_with_field_wrong_leading_axis_raises(ds) -> None:
     bad = np.zeros((ds.n_elements + 1,), dtype=np.float64)
@@ -91,7 +87,6 @@ def test_with_field_wrong_leading_axis_raises(ds) -> None:
         ds.with_field("bad", bad)
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_with_grouping_wrong_size_raises(ds) -> None:
     bad = Grouping(name="bad", indices=np.zeros(ds.n_elements + 1, dtype=np.int32))
@@ -99,7 +94,6 @@ def test_with_grouping_wrong_size_raises(ds) -> None:
         ds.with_grouping(bad)
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_with_elements_wrong_size_raises(ds) -> None:
     bad = ElementMeta(position=np.zeros((ds.n_elements + 1, 3), dtype=np.float64))
@@ -107,7 +101,6 @@ def test_with_elements_wrong_size_raises(ds) -> None:
         ds.with_elements(bad)
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_with_time_incompatible_axis_raises(ds) -> None:
     if ds.time.is_time_aggregated:

--- a/tests/core/test_property_loader.py
+++ b/tests/core/test_property_loader.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 
 from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
@@ -94,7 +94,6 @@ def _raises(thunk) -> bool:
         return True
 
 
-@settings(max_examples=60)
 @given(
     mutation=st.sampled_from(MUTATIONS),
     factor=st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False),

--- a/tests/core/test_property_loader.py
+++ b/tests/core/test_property_loader.py
@@ -1,0 +1,112 @@
+"""Property-based pipeline-loader tests (issue #141 phase 3).
+
+The static check (:func:`validate_template`) and the runtime
+(:func:`run_template`, which calls ``validate_template`` first) must not
+diverge: a template the static check accepts must run, and one it rejects must
+fail the runtime too. We assert that agreement generatively by starting from a
+valid template and applying one of several structural mutations, then checking
+that both entry points make the *same* accept/reject decision.
+
+The valid case is executed end-to-end against a :class:`MemoryStorage` preloaded
+with the declared input, so "accepted by validate" is confirmed to actually run
+rather than merely pass the static walk.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.core.data_source import PointsDataSource
+from cfdmod.core.pipeline_yaml import (
+    InputSpec,
+    OpSpec,
+    OutputSpec,
+    PipelineTemplate,
+    run_template,
+    validate_template,
+)
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+
+pytestmark = pytest.mark.property
+
+MUTATIONS = [
+    "valid",
+    "unknown_kind",
+    "dangling_source",
+    "rhs_on_unary",
+    "duplicate_id",
+    "missing_param",
+    "dangling_output",
+]
+
+
+def _storage_with_input() -> MemoryStorage:
+    storage = MemoryStorage()
+    src = PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.0, n_timesteps=0),
+        topology=Topology.points(np.zeros((2, 3), dtype=np.float64)),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"v": np.array([1.0, 2.0], dtype=np.float64)}),
+    )
+    storage.write_data_source("inp", src)
+    return storage
+
+
+def _build(mutation: str, factor: float) -> PipelineTemplate:
+    """A valid single-step scale template, optionally broken one way."""
+    step = OpSpec(id="scaled", kind="scale", source="inp", field="v", factor=factor)
+    pipeline = [step]
+    outputs = {"out": OutputSpec(source="scaled", path="out")}
+
+    if mutation == "unknown_kind":
+        step.kind = "no_such_op"
+    elif mutation == "dangling_source":
+        step.source = "ghost"
+    elif mutation == "rhs_on_unary":
+        step.rhs = "inp"  # scale is unary
+    elif mutation == "duplicate_id":
+        pipeline = [step, OpSpec(id="scaled", kind="scale", source="inp", field="v", factor=1.0)]
+    elif mutation == "missing_param":
+        step = OpSpec(id="scaled", kind="scale", source="inp", field="v")  # no factor
+        pipeline = [step]
+    elif mutation == "dangling_output":
+        outputs = {"out": OutputSpec(source="ghost", path="out")}
+
+    return PipelineTemplate(
+        name="t",
+        root=None,
+        inputs={"inp": InputSpec(kind="points", path="inp")},
+        pipeline=pipeline,
+        outputs=outputs,
+    )
+
+
+def _raises(thunk) -> bool:
+    try:
+        thunk()
+        return False
+    except Exception:
+        return True
+
+
+@settings(max_examples=60)
+@given(
+    mutation=st.sampled_from(MUTATIONS),
+    factor=st.floats(min_value=-1e3, max_value=1e3, allow_nan=False, allow_infinity=False),
+)
+def test_validate_and_run_agree(mutation: str, factor: float) -> None:
+    template = _build(mutation, factor)
+    storage = _storage_with_input()
+
+    validate_raised = _raises(lambda: validate_template(template))
+    run_raised = _raises(lambda: run_template(template, storage=storage))
+
+    # No divergence: the static check and the runtime reach the same verdict.
+    assert validate_raised == run_raised
+    # And the sole valid shape must be accepted (both must succeed).
+    assert (mutation == "valid") == (not validate_raised)

--- a/tests/core/test_property_roundtrip.py
+++ b/tests/core/test_property_roundtrip.py
@@ -83,7 +83,6 @@ def _assert_persisted_equal(a: DataSource, b: DataSource) -> None:
 # ---------------------------------------------------------------------------
 
 
-@settings(max_examples=50)
 @given(ds=sty.data_sources())
 def test_memory_roundtrip_preserves_source(ds: DataSource) -> None:
     storage = MemoryStorage()
@@ -101,11 +100,7 @@ def test_memory_roundtrip_preserves_source(ds: DataSource) -> None:
 # ---------------------------------------------------------------------------
 
 
-@settings(
-    max_examples=50,
-    deadline=None,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
-)
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(ds=sty.roundtrippable_data_sources())
 def test_xdmf_h5_roundtrip_preserves_persisted_subset(
     ds: DataSource, tmp_path: pathlib.Path
@@ -122,11 +117,7 @@ def test_xdmf_h5_roundtrip_preserves_persisted_subset(
 # ---------------------------------------------------------------------------
 
 
-@settings(
-    max_examples=50,
-    deadline=None,
-    suppress_health_check=[HealthCheck.function_scoped_fixture],
-)
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
 @given(ds=sty.roundtrippable_data_sources())
 def test_backends_agree(ds: DataSource, tmp_path: pathlib.Path) -> None:
     key = _key_for(ds)

--- a/tests/core/test_property_roundtrip.py
+++ b/tests/core/test_property_roundtrip.py
@@ -1,0 +1,139 @@
+"""Property-based storage round-trip tests for the v3 data-source layer.
+
+The highest-value invariant of the storage seam is a literal contract:
+``write -> read`` returns an equal source. These tests assert it generatively
+over many randomly-generated sources instead of the single hand-written shapes
+in ``tests/adapters/test_conformance.py``.
+
+Scope of "equal" differs by backend:
+
+- :class:`MemoryStorage` keeps the whole frozen object, so everything survives
+  (topology, time axis, element metadata, fields).
+- :class:`XdmfH5Storage` persists only the v2 byte layout -- triangles/geometry,
+  the affine time axis, and the field arrays. Element metadata, groupings, and
+  ``attrs`` are deliberately *not* on disk, so the round-trip equality here is
+  over the persisted subset. ``n_timesteps == 1`` cannot carry a timestep size
+  (a single sample has no delta), so that assertion is skipped for that case.
+
+These tests are marked ``property`` so a nightly job can rerun them with a
+larger ``max_examples`` budget.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import numpy as np
+import pytest
+from hypothesis import HealthCheck, given, settings
+
+from cfdmod.adapters.memory import MemoryStorage
+from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+from cfdmod.core.data_source import DataSource, PointsDataSource
+from tests import strategies as sty
+
+pytestmark = pytest.mark.property
+
+
+def _key_for(ds: DataSource) -> str:
+    """A storage key whose prefix makes the H5 adapter read back the right kind."""
+    return "points.gen" if isinstance(ds, PointsDataSource) else "cp_t.gen"
+
+
+def _assert_topology_equal(a: DataSource, b: DataSource) -> None:
+    # GroupsDataSource carries no topology of its own (it is chained to a
+    # parent); both sides must agree on that.
+    assert (a.topology is None) == (b.topology is None)
+    if a.topology is None:
+        return
+    assert a.topology.cell_type == b.topology.cell_type
+    assert np.array_equal(a.topology.connectivity, b.topology.connectivity)
+    assert np.allclose(a.topology.vertices, b.topology.vertices)
+
+
+def _assert_fields_equal(a: DataSource, b: DataSource) -> None:
+    assert sorted(a.fields.keys()) == sorted(b.fields.keys())
+    for name in a.fields.keys():
+        arr_a = a.fields.read(name)
+        arr_b = b.fields.read(name)
+        assert arr_a.shape == arr_b.shape, f"shape mismatch for field {name!r}"
+        assert np.allclose(arr_a, arr_b), f"values differ for field {name!r}"
+
+
+def _assert_persisted_equal(a: DataSource, b: DataSource) -> None:
+    """Equality over what any backend must preserve: kind, topology, time, fields."""
+    assert a.kind == b.kind
+    _assert_topology_equal(a, b)
+    assert a.time.n_timesteps == b.time.n_timesteps
+    # A time-aggregated source has no time axis: the H5 layout stores no
+    # meta/time_steps, so the affine origin (initial_time) is deliberately not
+    # preserved -- only "is aggregated" is meaningful. Compare the origin/step
+    # only when there actually is a time axis.
+    if not a.time.is_time_aggregated:
+        assert np.isclose(a.time.initial_time, b.time.initial_time)
+        # A single-sample axis has no delta to store; the H5 adapter reads it
+        # back as 1.0 by construction, so only compare the step when n >= 2.
+        if a.time.n_timesteps >= 2:
+            assert np.isclose(a.time.timestep_size, b.time.timestep_size)
+    _assert_fields_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# MemoryStorage: the whole object survives.
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=50)
+@given(ds=sty.data_sources())
+def test_memory_roundtrip_preserves_source(ds: DataSource) -> None:
+    storage = MemoryStorage()
+    storage.write_data_source("k", ds)
+    back = storage.read_data_source("k")
+    assert type(back) is type(ds)
+    _assert_persisted_equal(ds, back)
+    # Memory keeps the element metadata too (it is not serialised away).
+    assert np.allclose(back.elements.position, ds.elements.position)
+    assert np.allclose(back.elements.area, ds.elements.area)
+
+
+# ---------------------------------------------------------------------------
+# XdmfH5Storage: the persisted subset survives a real file round-trip.
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(ds=sty.roundtrippable_data_sources())
+def test_xdmf_h5_roundtrip_preserves_persisted_subset(
+    ds: DataSource, tmp_path: pathlib.Path
+) -> None:
+    storage = XdmfH5Storage(tmp_path)
+    key = _key_for(ds)
+    storage.write_data_source(key, ds)
+    back = storage.read_data_source(key)
+    _assert_persisted_equal(ds, back)
+
+
+# ---------------------------------------------------------------------------
+# Backend equivalence: the two backends agree on the same source.
+# ---------------------------------------------------------------------------
+
+
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+@given(ds=sty.roundtrippable_data_sources())
+def test_backends_agree(ds: DataSource, tmp_path: pathlib.Path) -> None:
+    key = _key_for(ds)
+    mem = MemoryStorage()
+    h5 = XdmfH5Storage(tmp_path)
+    mem.write_data_source(key, ds)
+    h5.write_data_source(key, ds)
+    from_mem = mem.read_data_source(key)
+    from_h5 = h5.read_data_source(key)
+    _assert_persisted_equal(from_mem, from_h5)

--- a/tests/core/test_property_stats_grouping.py
+++ b/tests/core/test_property_stats_grouping.py
@@ -1,0 +1,124 @@
+"""Property-based statistics and grouping-aggregation tests (issue #141 phase 2).
+
+Two computational cores are fuzzed against a numpy reference and their own
+ordering invariants:
+
+- :func:`cfdmod.core.grouping.aggregate_rows` -- ``min <= mean <= max``,
+  ``area_weighted_mean == mean`` for equal weights, and ``sum == mean * n`` for
+  a full group.
+- :func:`cfdmod.core.ops.data_source_create.statistics.compute_statistics` --
+  ``mean``/``min``/``max``/``rms`` match numpy on random arrays, and
+  ``min <= mean <= max``.
+
+All arrays are finite by default; sum/mean identities are compared with a
+floating-point tolerance rather than exact equality.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core.data_source import PointsDataSource
+from cfdmod.core.grouping import aggregate_rows
+from cfdmod.core.ops.data_source_create.statistics import (
+    StatisticsParams,
+    compute_statistics,
+)
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+
+pytestmark = pytest.mark.property
+
+
+def _finite(**kw):
+    return st.floats(allow_nan=False, allow_infinity=False, width=64, **kw)
+
+
+@st.composite
+def _row_arrays(draw):
+    """A 2-D finite array (n_rows, n_cols) plus a non-empty member index set."""
+    n_rows = draw(st.integers(min_value=1, max_value=8))
+    n_cols = draw(st.integers(min_value=1, max_value=4))
+    arr = draw(
+        hnp.arrays(np.float64, (n_rows, n_cols), elements=_finite(min_value=-1e6, max_value=1e6))
+    )
+    members = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=n_rows - 1),
+            min_size=1,
+            max_size=n_rows,
+            unique=True,
+        )
+    )
+    return arr, np.array(sorted(members), dtype=np.int64)
+
+
+@settings(max_examples=75)
+@given(payload=_row_arrays())
+def test_aggregate_min_le_mean_le_max(payload) -> None:
+    arr, members = payload
+    mn = aggregate_rows(arr, members, "min")
+    me = aggregate_rows(arr, members, "mean")
+    mx = aggregate_rows(arr, members, "max")
+    assert np.all(mn <= me + 1e-9)
+    assert np.all(me <= mx + 1e-9)
+
+
+@settings(max_examples=75)
+@given(payload=_row_arrays(), weight=_finite(min_value=1e-3, max_value=1e3))
+def test_area_weighted_mean_equals_mean_for_equal_weights(payload, weight: float) -> None:
+    arr, members = payload
+    weights = np.full(arr.shape[0], weight, dtype=np.float64)
+    aw = aggregate_rows(arr, members, "area_weighted_mean", weights=weights)
+    me = aggregate_rows(arr, members, "mean")
+    assert np.allclose(aw, me, rtol=1e-9, atol=1e-9)
+
+
+@settings(max_examples=75)
+@given(payload=_row_arrays())
+def test_sum_equals_mean_times_n_for_full_group(payload) -> None:
+    arr, _members = payload
+    full = np.arange(arr.shape[0], dtype=np.int64)
+    total = aggregate_rows(arr, full, "sum")
+    mean = aggregate_rows(arr, full, "mean")
+    assert np.allclose(total, mean * arr.shape[0], rtol=1e-9, atol=1e-6)
+
+
+def _points_timeseries(arr: np.ndarray) -> PointsDataSource:
+    n = arr.shape[0]
+    return PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=1.0, n_timesteps=arr.shape[1]),
+        topology=Topology.points(np.zeros((n, 3), dtype=np.float64)),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"p": arr}),
+    )
+
+
+@st.composite
+def _timeseries_arrays(draw):
+    n = draw(st.integers(min_value=1, max_value=6))
+    nt = draw(st.integers(min_value=2, max_value=6))  # >= 2 so rms (ddof=1) is defined
+    return draw(hnp.arrays(np.float64, (n, nt), elements=_finite(min_value=-1e6, max_value=1e6)))
+
+
+@settings(max_examples=75)
+@given(arr=_timeseries_arrays())
+def test_statistics_match_numpy(arr: np.ndarray) -> None:
+    ds = _points_timeseries(arr)
+    out = compute_statistics(ds, StatisticsParams(kinds=["mean", "min", "max", "rms"], field="p"))
+    mean = out.fields.read("mean")
+    mn = out.fields.read("min")
+    mx = out.fields.read("max")
+    rms = out.fields.read("rms")
+    assert np.allclose(mean, arr.mean(axis=1))
+    assert np.allclose(mn, arr.min(axis=1))
+    assert np.allclose(mx, arr.max(axis=1))
+    assert np.allclose(rms, arr.std(axis=1, ddof=1))
+    # Ordering invariant.
+    assert np.all(mn <= mean + 1e-9)
+    assert np.all(mean <= mx + 1e-9)

--- a/tests/core/test_property_stats_grouping.py
+++ b/tests/core/test_property_stats_grouping.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as hnp
 
@@ -58,7 +58,6 @@ def _row_arrays(draw):
     return arr, np.array(sorted(members), dtype=np.int64)
 
 
-@settings(max_examples=75)
 @given(payload=_row_arrays())
 def test_aggregate_min_le_mean_le_max(payload) -> None:
     arr, members = payload
@@ -69,7 +68,6 @@ def test_aggregate_min_le_mean_le_max(payload) -> None:
     assert np.all(me <= mx + 1e-9)
 
 
-@settings(max_examples=75)
 @given(payload=_row_arrays(), weight=_finite(min_value=1e-3, max_value=1e3))
 def test_area_weighted_mean_equals_mean_for_equal_weights(payload, weight: float) -> None:
     arr, members = payload
@@ -79,7 +77,6 @@ def test_area_weighted_mean_equals_mean_for_equal_weights(payload, weight: float
     assert np.allclose(aw, me, rtol=1e-9, atol=1e-9)
 
 
-@settings(max_examples=75)
 @given(payload=_row_arrays())
 def test_sum_equals_mean_times_n_for_full_group(payload) -> None:
     arr, _members = payload
@@ -106,7 +103,6 @@ def _timeseries_arrays(draw):
     return draw(hnp.arrays(np.float64, (n, nt), elements=_finite(min_value=-1e6, max_value=1e6)))
 
 
-@settings(max_examples=75)
 @given(arr=_timeseries_arrays())
 def test_statistics_match_numpy(arr: np.ndarray) -> None:
     ds = _points_timeseries(arr)

--- a/tests/core/test_property_time.py
+++ b/tests/core/test_property_time.py
@@ -1,0 +1,122 @@
+"""Property-based time-op tests (issue #141 phase 3).
+
+Covers the affine :class:`~cfdmod.core.time_axis.TimeAxis` primitives and the
+centred moving-average field op:
+
+- ``window(start, end)`` returns a contiguous slice, and the new axis' times
+  equal the original times restricted to that slice.
+- ``rescale(k)`` then ``rescale(1/k)`` recovers the axis (within tolerance).
+- ``moving_average`` with a one-sample window is the identity, always preserves
+  shape, and leaves a constant series unchanged.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core.data_source import PointsDataSource
+from cfdmod.core.ops.field.moving_average import MovingAverageParams, moving_average
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+from tests import strategies as sty
+
+pytestmark = pytest.mark.property
+
+
+def _finite(**kw):
+    return st.floats(allow_nan=False, allow_infinity=False, width=64, **kw)
+
+
+# ---------------------------------------------------------------------------
+# TimeAxis.window: contiguous slice, times restricted to the slice.
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=75)
+@given(axis=sty.time_axes(aggregated=False), data=st.data())
+def test_window_is_contiguous_slice(axis: TimeAxis, data) -> None:
+    times = axis.times()
+    first, last = float(times[0]), float(times[-1])
+    lo = data.draw(_finite(min_value=first, max_value=last))
+    hi = data.draw(_finite(min_value=first, max_value=last))
+    start, end = min(lo, hi), max(lo, hi)
+
+    new_axis, idx = axis.window(start, end)
+    # Contiguous: a plain slice with unit step.
+    assert idx.step in (None, 1)
+    assert 0 <= idx.start < idx.stop <= axis.n_timesteps
+    assert new_axis.n_timesteps == idx.stop - idx.start
+    assert np.allclose(new_axis.times(), times[idx])
+
+
+# ---------------------------------------------------------------------------
+# TimeAxis.rescale: reversible.
+# ---------------------------------------------------------------------------
+
+
+@settings(max_examples=75)
+@given(axis=sty.time_axes(), k=_finite(min_value=1e-3, max_value=1e3))
+def test_rescale_roundtrip_recovers_axis(axis: TimeAxis, k: float) -> None:
+    back = axis.rescale(k).rescale(1.0 / k)
+    assert np.isclose(back.initial_time, axis.initial_time, rtol=1e-9, atol=1e-9)
+    assert np.isclose(back.timestep_size, axis.timestep_size, rtol=1e-9, atol=1e-12)
+    assert back.n_timesteps == axis.n_timesteps
+
+
+# ---------------------------------------------------------------------------
+# moving_average.
+# ---------------------------------------------------------------------------
+
+
+def _timeseries(arr: np.ndarray, dt: float) -> PointsDataSource:
+    n = arr.shape[0]
+    return PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=dt, n_timesteps=arr.shape[1]),
+        topology=Topology.points(np.zeros((n, 3), dtype=np.float64)),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"v": arr}),
+    )
+
+
+@st.composite
+def _timeseries_source(draw):
+    n = draw(st.integers(min_value=1, max_value=5))
+    nt = draw(st.integers(min_value=2, max_value=8))
+    dt = draw(_finite(min_value=1e-2, max_value=10.0))
+    arr = draw(hnp.arrays(np.float64, (n, nt), elements=_finite(min_value=-1e4, max_value=1e4)))
+    return _timeseries(arr, dt)
+
+
+@settings(max_examples=75)
+@given(ds=_timeseries_source())
+def test_moving_average_one_sample_is_identity(ds: PointsDataSource) -> None:
+    # window == dt rounds to a single sample -> identity.
+    dt = ds.time.timestep_size
+    out = moving_average(ds, MovingAverageParams(window=dt, field="v"))
+    assert np.array_equal(out.fields.read("v"), ds.fields.read("v"))
+
+
+@settings(max_examples=75)
+@given(ds=_timeseries_source(), window=_finite(min_value=1e-2, max_value=50.0))
+def test_moving_average_preserves_shape(ds: PointsDataSource, window: float) -> None:
+    out = moving_average(ds, MovingAverageParams(window=window, field="v"))
+    assert out.fields.read("v").shape == ds.fields.read("v").shape
+
+
+@settings(max_examples=75)
+@given(
+    n=st.integers(min_value=1, max_value=4),
+    nt=st.integers(min_value=2, max_value=8),
+    dt=_finite(min_value=1e-2, max_value=10.0),
+    c=_finite(min_value=-1e4, max_value=1e4),
+    window=_finite(min_value=1e-2, max_value=50.0),
+)
+def test_moving_average_of_constant_is_constant(n, nt, dt, c, window) -> None:
+    ds = _timeseries(np.full((n, nt), c, dtype=np.float64), dt)
+    out = moving_average(ds, MovingAverageParams(window=window, field="v"))
+    assert np.allclose(out.fields.read("v"), c)

--- a/tests/core/test_property_time.py
+++ b/tests/core/test_property_time.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from hypothesis import given, settings
+from hypothesis import given
 from hypothesis import strategies as st
 from hypothesis.extra import numpy as hnp
 
@@ -37,7 +37,6 @@ def _finite(**kw):
 # ---------------------------------------------------------------------------
 
 
-@settings(max_examples=75)
 @given(axis=sty.time_axes(aggregated=False), data=st.data())
 def test_window_is_contiguous_slice(axis: TimeAxis, data) -> None:
     times = axis.times()
@@ -59,7 +58,6 @@ def test_window_is_contiguous_slice(axis: TimeAxis, data) -> None:
 # ---------------------------------------------------------------------------
 
 
-@settings(max_examples=75)
 @given(axis=sty.time_axes(), k=_finite(min_value=1e-3, max_value=1e3))
 def test_rescale_roundtrip_recovers_axis(axis: TimeAxis, k: float) -> None:
     back = axis.rescale(k).rescale(1.0 / k)
@@ -92,7 +90,6 @@ def _timeseries_source(draw):
     return _timeseries(arr, dt)
 
 
-@settings(max_examples=75)
 @given(ds=_timeseries_source())
 def test_moving_average_one_sample_is_identity(ds: PointsDataSource) -> None:
     # window == dt rounds to a single sample -> identity.
@@ -101,14 +98,12 @@ def test_moving_average_one_sample_is_identity(ds: PointsDataSource) -> None:
     assert np.array_equal(out.fields.read("v"), ds.fields.read("v"))
 
 
-@settings(max_examples=75)
 @given(ds=_timeseries_source(), window=_finite(min_value=1e-2, max_value=50.0))
 def test_moving_average_preserves_shape(ds: PointsDataSource, window: float) -> None:
     out = moving_average(ds, MovingAverageParams(window=window, field="v"))
     assert out.fields.read("v").shape == ds.fields.read("v").shape
 
 
-@settings(max_examples=75)
 @given(
     n=st.integers(min_value=1, max_value=4),
     nt=st.integers(min_value=2, max_value=8),

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,0 +1,274 @@
+"""Reusable hypothesis strategies for the v3 data-source layer (issue #141).
+
+The :class:`~cfdmod.core.data_source.DataSource` paradigm is a good fit for
+property-based testing: it is a small frozen value object with explicit
+invariants (``_check_consistency``), pure functional updates, and a storage
+round-trip whose contract is literally "read == write". These strategies
+generate *always-consistent* sources so a drawn value already passes every
+model validator at construction; a test then asserts an invariant over many
+such draws rather than a single hand-written shape.
+
+Design notes:
+
+- Every generated array is finite ``float64`` by default. Numpy edge values
+  (NaN, inf) are opt-in per strategy via ``allow_non_finite=True`` so we keep
+  "does the math hold" separate from "how do we treat non-finite inputs" (the
+  latter is its own decision -- see the #141 notes).
+- Array magnitudes are bounded (``|x| <= 1e6``) so float formatting on the
+  XDMF/H5 round-trip and ``np.allclose`` comparisons stay meaningful.
+- Field names are simple ASCII identifiers with no ``/`` and never collide with
+  the reserved h5 root datasets, so a surface/points source also round-trips
+  through :class:`~cfdmod.adapters.xdmf_h5.XdmfH5Storage` (which maps each field
+  to a top-level h5 group).
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "finite_floats",
+    "field_arrays",
+    "time_axes",
+    "element_meta",
+    "groupings",
+    "triangle_topologies",
+    "surface_data_sources",
+    "points_data_sources",
+    "groups_data_sources",
+    "data_sources",
+    "roundtrippable_data_sources",
+]
+
+import numpy as np
+from hypothesis import strategies as st
+from hypothesis.extra import numpy as hnp
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core.data_source import (
+    GroupsDataSource,
+    PointsDataSource,
+    SurfaceDataSource,
+)
+from cfdmod.core.grouping import Grouping
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+
+# Small bounds keep example generation fast and the search space legible.
+MAX_ELEMENTS = 6
+MAX_TIMESTEPS = 5
+MAX_FIELDS = 3
+MAX_VERTICES = 8
+
+# Reserved h5 root datasets/groups; a field named like one of these would not
+# round-trip through the XDMF/H5 adapter, so field-name strategies avoid them.
+_RESERVED_FIELD_NAMES = frozenset({"Triangles", "Geometry", "Connectivity", "meta", "stats"})
+
+
+def finite_floats(*, allow_non_finite: bool = False):
+    """A float strategy: finite and bounded by default, NaN/inf opt-in."""
+    if allow_non_finite:
+        return st.floats(allow_nan=True, allow_infinity=True, width=64)
+    return st.floats(
+        min_value=-1e6,
+        max_value=1e6,
+        allow_nan=False,
+        allow_infinity=False,
+        width=64,
+    )
+
+
+def _float_array(shape: tuple[int, ...], *, allow_non_finite: bool = False):
+    """An ``hnp.arrays`` strategy of the given shape, float64."""
+    return hnp.arrays(
+        dtype=np.float64,
+        shape=shape,
+        elements=finite_floats(allow_non_finite=allow_non_finite),
+    )
+
+
+def field_arrays(n_elements: int, n_timesteps: int, *, allow_non_finite: bool = False):
+    """Field arrays matching a source's shape contract.
+
+    Shape is ``(n_elements,)`` for a time-aggregated source (``n_timesteps ==
+    0``) and ``(n_elements, n_timesteps)`` otherwise -- exactly what
+    ``_check_consistency`` requires.
+    """
+    shape: tuple[int, ...] = (n_elements,) if n_timesteps == 0 else (n_elements, n_timesteps)
+    return _float_array(shape, allow_non_finite=allow_non_finite)
+
+
+def _field_names(min_size: int = 1, max_size: int = MAX_FIELDS):
+    """A set of distinct, round-trip-safe field names."""
+    ident = st.text(
+        alphabet=st.characters(min_codepoint=ord("a"), max_codepoint=ord("z")),
+        min_size=1,
+        max_size=6,
+    ).filter(lambda s: s not in _RESERVED_FIELD_NAMES)
+    return st.lists(ident, min_size=min_size, max_size=max_size, unique=True)
+
+
+@st.composite
+def time_axes(draw, *, aggregated: bool | None = None) -> TimeAxis:
+    """A valid :class:`TimeAxis`.
+
+    ``aggregated=True`` forces the no-time-axis form (``n_timesteps == 0``);
+    ``aggregated=False`` forces a real time axis; ``None`` draws either.
+    """
+    if aggregated is None:
+        aggregated = draw(st.booleans())
+    initial = draw(st.floats(min_value=-1e4, max_value=1e4, allow_nan=False, allow_infinity=False))
+    if aggregated:
+        return TimeAxis(initial_time=initial, timestep_size=0.0, n_timesteps=0)
+    n = draw(st.integers(min_value=1, max_value=MAX_TIMESTEPS))
+    dt = draw(st.floats(min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False))
+    return TimeAxis(initial_time=initial, timestep_size=dt, n_timesteps=n)
+
+
+@st.composite
+def element_meta(draw, n_elements: int, *, positive_area: bool = True) -> ElementMeta:
+    """Per-element metadata with a consistent leading axis.
+
+    ``position`` is always set (so a topology-less source can still resolve
+    ``n_elements``); ``area`` is strictly positive by default so
+    ``area_weighted_mean`` is well defined.
+    """
+    position = draw(_float_array((n_elements, 3)))
+    if positive_area:
+        area = draw(
+            hnp.arrays(
+                dtype=np.float64,
+                shape=(n_elements,),
+                elements=st.floats(
+                    min_value=1e-3, max_value=1e3, allow_nan=False, allow_infinity=False
+                ),
+            )
+        )
+    else:
+        area = draw(_float_array((n_elements,)))
+    return ElementMeta(position=position, area=area)
+
+
+@st.composite
+def groupings(draw, n_elements: int, *, name: str | None = None) -> Grouping:
+    """A :class:`Grouping` over ``n_elements`` elements.
+
+    Group ids range over ``[-1, n_elements]`` where ``-1`` marks ungrouped.
+    """
+    if name is None:
+        name = draw(
+            st.text(
+                alphabet=st.characters(min_codepoint=ord("a"), max_codepoint=ord("z")),
+                min_size=1,
+                max_size=6,
+            )
+        )
+    indices = draw(
+        hnp.arrays(
+            dtype=np.int32,
+            shape=(n_elements,),
+            elements=st.integers(min_value=-1, max_value=n_elements),
+        )
+    )
+    return Grouping(name=name, indices=indices)
+
+
+@st.composite
+def triangle_topologies(draw, *, n_elements: int | None = None) -> Topology:
+    """A valid triangle :class:`Topology` with in-range connectivity."""
+    n_vertices = draw(st.integers(min_value=3, max_value=MAX_VERTICES))
+    vertices = draw(_float_array((n_vertices, 3)))
+    if n_elements is None:
+        n_elements = draw(st.integers(min_value=1, max_value=MAX_ELEMENTS))
+    connectivity = draw(
+        hnp.arrays(
+            dtype=np.int32,
+            shape=(n_elements, 3),
+            elements=st.integers(min_value=0, max_value=n_vertices - 1),
+        )
+    )
+    return Topology.triangles(connectivity, vertices)
+
+
+@st.composite
+def surface_data_sources(draw, *, allow_non_finite: bool = False) -> SurfaceDataSource:
+    """A consistent :class:`SurfaceDataSource` (triangle topology + fields)."""
+    topology = draw(triangle_topologies())
+    n = topology.n_elements
+    time = draw(time_axes())
+    names = draw(_field_names())
+    arrays = {
+        name: draw(field_arrays(n, time.n_timesteps, allow_non_finite=allow_non_finite))
+        for name in names
+    }
+    return SurfaceDataSource(
+        time=time,
+        topology=topology,
+        elements=draw(element_meta(n)),
+        fields=MemoryFieldStore(arrays),
+    )
+
+
+@st.composite
+def points_data_sources(draw, *, allow_non_finite: bool = False) -> PointsDataSource:
+    """A consistent :class:`PointsDataSource` (point topology + fields)."""
+    n = draw(st.integers(min_value=1, max_value=MAX_ELEMENTS))
+    vertices = draw(_float_array((n, 3)))
+    time = draw(time_axes())
+    names = draw(_field_names())
+    arrays = {
+        name: draw(field_arrays(n, time.n_timesteps, allow_non_finite=allow_non_finite))
+        for name in names
+    }
+    return PointsDataSource(
+        time=time,
+        topology=Topology.points(vertices),
+        elements=draw(element_meta(n)),
+        fields=MemoryFieldStore(arrays),
+    )
+
+
+@st.composite
+def groups_data_sources(draw, *, allow_non_finite: bool = False) -> GroupsDataSource:
+    """A consistent :class:`GroupsDataSource`.
+
+    Carries one row per group; the topology is chained to an independently
+    drawn parent triangle surface plus a grouping over the parent elements.
+    """
+    n_groups = draw(st.integers(min_value=1, max_value=MAX_ELEMENTS))
+    parent_topology = draw(triangle_topologies())
+    parent_grouping = draw(groupings(parent_topology.n_elements, name="parent"))
+    time = draw(time_axes())
+    names = draw(_field_names())
+    arrays = {
+        name: draw(field_arrays(n_groups, time.n_timesteps, allow_non_finite=allow_non_finite))
+        for name in names
+    }
+    return GroupsDataSource(
+        time=time,
+        topology=None,
+        elements=draw(element_meta(n_groups)),
+        fields=MemoryFieldStore(arrays),
+        parent_topology=parent_topology,
+        parent_grouping=parent_grouping,
+    )
+
+
+def data_sources(*, allow_non_finite: bool = False):
+    """Any of the phase-1 concrete kinds (surface / points / groups)."""
+    return st.one_of(
+        surface_data_sources(allow_non_finite=allow_non_finite),
+        points_data_sources(allow_non_finite=allow_non_finite),
+        groups_data_sources(allow_non_finite=allow_non_finite),
+    )
+
+
+def roundtrippable_data_sources(*, allow_non_finite: bool = False):
+    """Kinds the XDMF/H5 adapter reads back as themselves (surface / points).
+
+    A :class:`GroupsDataSource` is intentionally excluded: the adapter
+    broadcasts it onto its parent surface on write, so its storage contract is
+    not "read == write" and it does not belong in a round-trip invariant.
+    """
+    return st.one_of(
+        surface_data_sources(allow_non_finite=allow_non_finite),
+        points_data_sources(allow_non_finite=allow_non_finite),
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -57,6 +57,7 @@ vtk = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "json-schema-for-humans" },
     { name = "pytest" },
     { name = "ruff" },
@@ -98,6 +99,7 @@ provides-extras = ["geometry", "remesh", "docs", "notebook", "vtk", "legacy"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6" },
     { name = "json-schema-for-humans", specifier = ">=1.5" },
     { name = "pytest", specifier = ">=9" },
     { name = "ruff", specifier = ">=0.15" },
@@ -886,6 +888,65 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.156.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "sortedcontainers" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/aa/275cf88c757bd96e91844d9b3aab3bc6a5a1942b70f75df255a3d2114518/hypothesis-6.156.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6ea5a7f3934daa5f81960271d5efbb9ac69871ac3cb2c027b8ce33e69a792e65", size = 749534, upload-time = "2026-07-03T14:31:00.668Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/cf/e657b924ab6f24f29841ad2e461775a0f048c24013df5be5099be98303ca/hypothesis-6.156.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ad6e5960b36452f3b904a3849e85c62377cf4ecc904541706c934dae439ce933", size = 743927, upload-time = "2026-07-03T14:30:55.816Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3f/f8dc6a19776d2a92e0a0b6595213ecc16446e41aeee8aa4b8e3bdd258a48/hypothesis-6.156.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:79b4aa87fbb2e5121a24333906b7b481ddefc0af9d3ccd28463f5504b8d586f2", size = 1071039, upload-time = "2026-07-03T14:30:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1a/60a505991247430fd9e4429526292e2b054381615801f3c7efdfa08dc9fb/hypothesis-6.156.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:63131c150146b44f49dd6be4d417e1ee62390951403569043e759e8513763426", size = 1120853, upload-time = "2026-07-03T14:30:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/14/83/e2f76554ffa6380fb935f09afe0e36cbedc5063114d58064181e821f091b/hypothesis-6.156.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f8385703ba1a03a09f2b2cbbf418344a82beef51b397101933a67535da7d0e19", size = 1245778, upload-time = "2026-07-03T14:30:49.652Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/b82eaf84529bb15f45166386a11ba2f0d43738b781cb4c1e5fb772546d6e/hypothesis-6.156.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b2e48eb61ddbcb8afbcba849fcffa6411bcef43977a34e55bcea582c9d391c11", size = 1288197, upload-time = "2026-07-03T14:30:16.901Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3d/9e19b368974bfedccdba6916b92fca8446f02018e0954a6e8b756d5450c1/hypothesis-6.156.1-cp310-cp310-win_amd64.whl", hash = "sha256:debc9f5a974e50e5806917cd514cb462f31caa18af94a979f3deb4827f034466", size = 640341, upload-time = "2026-07-03T14:31:11.557Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0f/102b24707a8e383e659a6b087d7d1369fe3b4bdce9c669b01010c075b835/hypothesis-6.156.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8063082444d4b75b437c8234cd5f5bcd26a25cb9a5db9d19c93dd9bc0b2094a0", size = 749167, upload-time = "2026-07-03T14:31:22.853Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/5e/7ce63a67026ff547ac99710723b41447fa83f26ec010c018faee6ff36199/hypothesis-6.156.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a712d98f79b8ef14247ff336c4ce1f81d3958bb80b9f0b5cf61c7afc356d2cb3", size = 743704, upload-time = "2026-07-03T14:30:39.2Z" },
+    { url = "https://files.pythonhosted.org/packages/44/01/04757dea40ea3e3a9da566044bdd176e873149cdfc3903ac18aa3786db86/hypothesis-6.156.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ea85fd8ca7be7acbba36c63de7a1450e8e267a29ed3a117a037e638be244c5b6", size = 1070931, upload-time = "2026-07-03T14:31:15.454Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/bf/373cb4e14cc5014b33bf2e26720f983cd93da98964397ca92dc7ef07250f/hypothesis-6.156.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7da5067440cdc83e042ee8d60c3b0b76201dace66dd385f9d4057bdeda8c4f15", size = 1120661, upload-time = "2026-07-03T14:31:02.722Z" },
+    { url = "https://files.pythonhosted.org/packages/28/e8/fd9dbacec4532a9c6815d8babeb36e4828673904a0ebc71fc6bb3915e34a/hypothesis-6.156.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:92f70ba9a29970315916f42cea4f708f5f3019665b7f18034acf2d07d1a82476", size = 1245245, upload-time = "2026-07-03T14:31:07.941Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ee/1e372225c844dce2a95c4dc1bf4d41813c14ee7856b0653db168e5714e79/hypothesis-6.156.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:49bbeaa5efb1abb596f9e4d3a733be400a8e485db53134ef7cd78b4a3f3c3be7", size = 1287877, upload-time = "2026-07-03T14:30:51.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/1e4ae081682a95c141dde10b708711000cf41a8337504c70537a73c66df2/hypothesis-6.156.1-cp311-cp311-win_amd64.whl", hash = "sha256:b386bb3f149ec238dbc4cbfa8ddbae858ad16f489da62db9e3326c9591efb2d6", size = 640180, upload-time = "2026-07-03T14:30:46.336Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3d/1a0e54652f1b3cad354949ba83f6ab211048ff3a6cfb24edcddc748a8be1/hypothesis-6.156.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0409dea0c0b48705cad8413468282af9c5e7d3a017b6c2b94ef80e7ba4b64862", size = 749005, upload-time = "2026-07-03T14:30:26.045Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/e5/c8b6084023faabef7612ea0169fd4df565fdc5fd73f47484e5edf03640fb/hypothesis-6.156.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:72b9305414c20802540ec0cd798478c9e06c8a248ce32d7df04722b64d7150ad", size = 741899, upload-time = "2026-07-03T14:30:34.442Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/51644c53ae055a3a3411906cc8e41e5dd53af487ca76465342256e4f18c1/hypothesis-6.156.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:40584eed6a57c402d8ab32ea5c1779bae6f7390ff33d073c876e09dc8af31941", size = 1069788, upload-time = "2026-07-03T14:31:24.552Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/43/d2ec198fa56f72f8690563247e5e71a81cf5f1c9c42e977008b76338803f/hypothesis-6.156.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76f2aaa6725185f16a8fa7b58e0ba5d5119cafa33eae5e5dec996d6a28cd9dc6", size = 1119541, upload-time = "2026-07-03T14:30:15.15Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/ba8a1bf72988e7b8b743b4f4f30705fe1c2128780a7d93b203cdeb6bae79/hypothesis-6.156.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bac95ae29f7850a923f43bc7e21bbc7ee8b8094bbf07691be4f153e537b5d3db", size = 1243864, upload-time = "2026-07-03T14:30:47.869Z" },
+    { url = "https://files.pythonhosted.org/packages/74/a3/f30ebb96f099f19e71361aefb233542f3763a0fb7c0ba3c84513c353b065/hypothesis-6.156.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8159b5e93a7724920cf55dd4ec743a84fc9c3c457a6736a92283aa4068f54daa", size = 1286401, upload-time = "2026-07-03T14:30:07.762Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a9/19b36a5deb78217f4f6214c7be36a14cf2da8b29392199bcd18a0628b9b8/hypothesis-6.156.1-cp312-cp312-win_amd64.whl", hash = "sha256:d8e7deed3bc76c8c12c30e092e228a6978180f2bcab9483f5fb22240cd8eaa7d", size = 637634, upload-time = "2026-07-03T14:30:40.794Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f7/6f0e4186a6575abddb19047e69cb0042252be27d0be0ddc3528bf3a81edd/hypothesis-6.156.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:da65e6be5461cac9d9d7f98f43d24afb5441932502e4d1b240738aaef84e95d9", size = 749428, upload-time = "2026-07-03T14:31:04.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0c/d45d778b14f22270ac1218faf4ec7de2e9e30d3e40fd91ad86d6b6b5259e/hypothesis-6.156.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:612277e6344defe39012812d5ae620d6323e11fa62c424d64633dfa09caaa387", size = 742070, upload-time = "2026-07-03T14:30:09.175Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8a/9c6863eae555c674e3ab2b7ac738f50350d176f88e7a5ac4fe85340b126f/hypothesis-6.156.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a593ad462c61f252d661ccc3a1093406cf9ca5a26a6b30cefd8911075d508c8", size = 1069945, upload-time = "2026-07-03T14:30:27.45Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/98/44d9ee83542e5cb50c07387091bd2dcfb2d0f9d7eaadd78357ae0962e76d/hypothesis-6.156.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a48cdb91afa09958926a364d241d00b08ece1d105bcd48e0b433428c7b4c29b", size = 1119946, upload-time = "2026-07-03T14:30:58.939Z" },
+    { url = "https://files.pythonhosted.org/packages/09/00/03957d11e4602e60982b535bf107a1995e712e797e32ca5cc9fe53daa11c/hypothesis-6.156.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:72d4115ed2c4da2cc30189026eacd27c81e0891ec4ba9fff6719e0f47874d65c", size = 1244030, upload-time = "2026-07-03T14:30:53.641Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e3/149c3b9de0f9125becdf266af9eba6934885818867c93a457af60d4a3725/hypothesis-6.156.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1e1fecee9c79956ac5e7c38cb1d1374bf22fd4066ff6a9664d45d13a09251b1", size = 1286679, upload-time = "2026-07-03T14:30:57.516Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/1c/f1a35abd3e5ef45badc3d8a128bb133725f6a93c9aa4eadc27db9d6c54c3/hypothesis-6.156.1-cp313-cp313-win_amd64.whl", hash = "sha256:32f512f6028ab2d4c56208b2edebefe384ab78a5880b098b039c65e9d08b62f7", size = 637909, upload-time = "2026-07-03T14:30:04.12Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/60/f81bc004dafc83f4fd3aee41c65ec6140481a4666495229c0102c636e74b/hypothesis-6.156.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3340f22fd71e615f9bca4499bddd7cc4e0987b08a8b4fc38f688aaac416c2aaf", size = 749464, upload-time = "2026-07-03T14:31:17.171Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5d/f884c2e908f5a888b22a6606368130fdf822565430e9eefcde5e765640dd/hypothesis-6.156.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:19612761d128cd15d41e414389da6b65c1883db1f358025a4c1b2df96ba2dfb0", size = 742283, upload-time = "2026-07-03T14:31:06.23Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2e/8843ca9d7103692c06b912aaa06cc664d3cb3c764a44fb2feeb702b3b704/hypothesis-6.156.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c86c00cefcf58793aebb24238247398ad5d9ce281615329293d926d794e6fe5f", size = 1070136, upload-time = "2026-07-03T14:30:19.907Z" },
+    { url = "https://files.pythonhosted.org/packages/62/62/7a1b308b3977e3d3c1920828c5fc5a440caf8036b0d9df2e9ab7722682f8/hypothesis-6.156.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:047a0a6613ff06f191d9b1c7623a9b781baddc0fdebad531157d1417fa876627", size = 1120112, upload-time = "2026-07-03T14:31:13.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/7c691582cd5b0de6314fd712ce5e69960985a89e4f619b0c4b36c8845ce2/hypothesis-6.156.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9ace8e1e885b20ae129c68ff14e86edd55771a30559561b261a15bd8c17edd36", size = 1244289, upload-time = "2026-07-03T14:31:19.175Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ac/d15a7a9820ca05ef7a4e8d9dc95e9a0a70cd91fb8d021913888c69801c60/hypothesis-6.156.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:eb093affaa2257f9fd2d6542b5e242f5b9512bc1009a4f563ade91e30c298e0c", size = 1287201, upload-time = "2026-07-03T14:30:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ca/dcd80b4606d97b5dba2775526aa89a7735086559c5a80eaf5bf60610bc10/hypothesis-6.156.1-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:209b76dab690e2182599a83c079475115d69dd2c16aed38a57bb9db376ba4195", size = 586417, upload-time = "2026-07-03T14:30:42.657Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/b3/555c291b24b9b1f2e6a712d485ad8c52bbe3e31e79a8a509adc5213e42aa/hypothesis-6.156.1-cp314-cp314-win_amd64.whl", hash = "sha256:1ea0711ac7792e3ade5dfe8a6a762eec64ddb79cd00fe63ff34f17fde0ce8109", size = 637729, upload-time = "2026-07-03T14:31:20.948Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a4/25f26e0ed769c127b049b4fb8c9378e74d07a37a44c5938e4f6518710ef6/hypothesis-6.156.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:9b664a859ed5567bd2c0d804da4d96035e14caa15d91062cc50fcd758dc44111", size = 747497, upload-time = "2026-07-03T14:30:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/62/11/25f20b1cdbd8fc73fd8c0603aa4e817da7384400347f6d63ef569c56111e/hypothesis-6.156.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23acc5f333ce6bd2d888e7c6a33779b5c6cff42dac654f3209e9fa552103c3ba", size = 740841, upload-time = "2026-07-03T14:30:37.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/aa/9967dd9380d72d44a7973f7893383145f04277896554ebb2872ae9658de6/hypothesis-6.156.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:15762876a64c66bd6ed18eb95fd8018df93b6961eb0b6c25e63409af9cb672c0", size = 1069108, upload-time = "2026-07-03T14:30:06.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/6e/27999d70710a1d0d9440c1db59db385c63ed2dccca6ade5fe53258e9566f/hypothesis-6.156.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4bab29b39b13603583c9874c38907071f333e7af0c48686af8c8f97f7a6a2398", size = 1119177, upload-time = "2026-07-03T14:31:09.67Z" },
+    { url = "https://files.pythonhosted.org/packages/39/45/fbaaae29a5650da6322737eeb085c78a4eb9066f815862c24c63a25dd5eb/hypothesis-6.156.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3c8831d5748394cab5ab81b3d469bcc543e7b8e1fc8422ed26a80e16b1e51c1b", size = 1243078, upload-time = "2026-07-03T14:30:10.678Z" },
+    { url = "https://files.pythonhosted.org/packages/53/9d/2db20037da6b206701ec22d6bb67d4393e4807281885663979fe7a5ff869/hypothesis-6.156.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:18ef80bdd7422e7823d8da99240c8804708bd44eeeed370fc8a71db56670e1dc", size = 1285519, upload-time = "2026-07-03T14:30:36.172Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/de/4fbc6afc03cb7098f51bea5be6300c7e13fc679c3c2d12cd40629a27278d/hypothesis-6.156.1-cp314-cp314t-win_amd64.whl", hash = "sha256:122963f511d31fb96254a5b3f0b8e3b9c3b9d2b05e10d9e67eca43e573d52d0f", size = 637822, upload-time = "2026-07-03T14:30:31.248Z" },
+    { url = "https://files.pythonhosted.org/packages/03/4f/7538f785ee0ae5a7e2c959e875b3e48210698d91cc99b5802471d87500bb/hypothesis-6.156.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:9d2c65a1294a1e58646f5437cf7924e08ccadf52689e66968960f86d684ecb31", size = 749719, upload-time = "2026-07-03T14:30:24.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/12/af4c5f049c5b3038dcd4f0f488d6b85d09a9a466c03951efbe39af2f9e9e/hypothesis-6.156.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4113a2c5044f79ac961b92e5cbbf4ac6f48ae30a4fd0c8e434fd4b6110041ba9", size = 744324, upload-time = "2026-07-03T14:30:23.018Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/3b/7734d825fda8fb24b94f10c9b00a8851aa86a387d83490a14d3a3ad5e2a1/hypothesis-6.156.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:953553556920478bad3ed8148ae83a383528ada6b6d5b18d25e20baad45980d3", size = 1071349, upload-time = "2026-07-03T14:30:44.195Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/c2/9cd29826a58e88589f2e0603c7f1d4f9251fa4bce6ec3c0ca8d87842f41e/hypothesis-6.156.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2edd308e6907cb31854f8c0879235572c8e9d580bc31291bb1f6246d4242b56b", size = 1121411, upload-time = "2026-07-03T14:30:18.461Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/97/9cadecbfab29d294860b2c892e6c87437ed89611762531addaabae562a07/hypothesis-6.156.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:71a8449f5da886aea7eae097aa8c97fceb5e9e28fb2b268e46e3cbae2ce3cda9", size = 640781, upload-time = "2026-07-03T14:30:33.003Z" },
 ]
 
 [[package]]
@@ -2979,6 +3040,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/44/7b/af302bebf22c749c56c9c3e8ae13190b5b5db37a33d9068652e8f73b7089/snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1", size = 86699, upload-time = "2021-11-16T18:38:38.009Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/dc/c02e01294f7265e63a7315fe086dd1df7dacb9f840a804da846b96d01b96/snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a", size = 93002, upload-time = "2021-11-16T18:38:34.792Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the property-based / fuzz testing proposal in #141 (all three phases) for the v3 data-source layer.

Targets `feat/issue-131-data-source-core` (the v3 branch, #132) rather than `main`, since none of the v3 code is on `main` yet. Non-blocking for #132.

## What's here

**Tooling**
- `hypothesis>=6` added to the `dev` dependency group; a `property` pytest marker registered.
- `tests/conftest.py` registers hypothesis example-budget profiles: `default` (50), `dev` (15), `ci` (1000), all `deadline=None`. Tests intentionally do **not** pin `max_examples`, so the active profile governs the count.
- `tests/strategies.py`: reusable, always-consistent strategies (`data_sources`, `surface/points/groups_data_sources`, `time_axes`, `element_meta`, `groupings`, `triangle_topologies`, `field_arrays`). Arrays are finite/bounded `float64` by default; NaN/inf are opt-in per strategy (`allow_non_finite`).

**Phase 1 - storage round-trip (highest value)** - `tests/core/test_property_roundtrip.py`
- `MemoryStorage` round-trip preserves the source.
- `XdmfH5Storage` round-trip preserves the persisted subset (topology, affine time axis, field arrays).
- Generative backend equivalence (Memory vs XDMF/H5).

**Phase 2 - invariants + algebra/stats**
- `test_property_data_source.py`: every functional update stays consistent or raises (covers the plain-`model_copy` paths and the #132 validator-bypass bug class); `n_elements` stable across metadata-only updates.
- `test_property_algebra.py`: `a-a==0`, `(a*k)/k==a`, commutativity for the elementwise/constant rules only, result-shape==lhs across all four broadcast rules.
- `test_property_stats_grouping.py`: `aggregate_rows` ordering + `area_weighted_mean==mean` (equal weights) + `sum==mean*n`; `compute_statistics` vs numpy.

**Phase 3 - time ops + loader + nightly CI**
- `test_property_time.py`: `TimeAxis.window` contiguity, `rescale` round-trip, `moving_average` identity/shape/constant.
- `test_property_loader.py`: `validate_template` and `run_template` never diverge on a mutated template.
- `.github/workflows/property_tests.yaml`: nightly + on-demand job running `-m property` under the `ci` profile (1000 examples). The property tests also run in the normal pipeline at the default budget.

## Sharpened invariants (vs the issue text)
- Float ops use tolerances; associativity is **not** asserted (not exact in float).
- Commutativity is asserted only for the `elementwise`/`constant` rules - `classify_broadcast` is asymmetric for `column`/`row`.
- `GroupsDataSource` is excluded from the XDMF/H5 round-trip strategy: the adapter broadcasts it onto its parent surface on write, so it isn't a `read==write` contract.

## What the fuzzing surfaced (expected, not bugs)
The XDMF/H5 adapter does not persist `initial_time` for time-aggregated sources (no time axis on disk) and `n_timesteps==1` carries no timestep delta - both matching the existing conformance contract. Assertions encode this explicitly.

## Verification
- `-m property`: 24 tests pass under both the default (50) and `ci` (1000) profiles.
- Full default suite: 410 passed, 4 skipped (skips are pre-existing optional-extra gaps: `fast_simplification`, and 4 `vtk`-dependent files excluded locally).
- `ruff format` + `ruff check` clean; ASCII-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)