### PR TITLE
fix(docs): unbreak the Sphinx build (import bug + lockfile clobber)

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -32,7 +32,10 @@ jobs:
         run: |
           sudo apt-get install -y pandoc
           cd docs
-          uv run make html  # Build HTML docs
+          # --no-project: build against the docs env installed above without
+          # re-syncing .venv to uv.lock (the lock pins markdown-it-py 3.0.0 as a
+          # transitive dep, which lacks make_fence_rule and breaks myst-parser).
+          uv run --no-project make html  # Build HTML docs
           cd ..
 
       - name: Deploy to GitHub Pages

--- a/cfdmod/core/topology.py
+++ b/cfdmod/core/topology.py
@@ -173,7 +173,7 @@ class ElementMeta(BaseModel):
     annotations: Annotated[
         dict[str, Any],
         Field(default_factory=dict, description="Free-form per-element metadata."),
-    ] = {}
+    ]
 
     @field_validator("position", "normal", mode="before")
     @classmethod


### PR DESCRIPTION
Fixes the `docs` workflow failure on the v3 branch. Two independent root causes:

## 1. `import cfdmod` breaks under pydantic >= 2.13 (real bug)
`cfdmod/core/topology.py` `ElementMeta.annotations` declared **both** `Field(default_factory=dict)` and a literal `= {}` default. pydantic >= 2.13 rejects this (`cannot specify both default and default_factory`), so importing `cfdmod` raised in the docs env (which resolves pydantic to latest, uncapped), and **every autodoc import failed** - the API reference was silently empty (165 import warnings).

Fix: drop the redundant `= {}` (the `default_factory` already provides the empty-dict default). Behavior is unchanged on the pinned pydantic 2.10.6.

> Note: this is a forward-compat bug beyond docs - `import cfdmod` fails on any pydantic >= 2.13. Worth being aware of before bumping the pin.

## 2. CI clobbers the docs env with the lockfile
`.github/workflows/deploy_docs.yml` ran `uv run make html`. Without `--no-project`, `uv run` re-syncs `.venv` to `uv.lock` before building, **downgrading the transitive `markdown-it-py` to the locked `3.0.0`** (which lacks `make_fence_rule`) underneath the pip-installed `myst-parser 5.1.0` -> `ImportError: cannot import name 'make_fence_rule'` at Sphinx startup.

Fix: build with `uv run --no-project` so the env from `uv pip install .[docs]` is used as-is.

## Verification
- `import cfdmod` OK under pydantic 2.13.4.
- Clean `make html` succeeds, `EXIT=0`, zero `default_factory` / `make_fence_rule` errors (remaining 66 warnings are pre-existing benign `ipython3` Pygments-lexer notes + the sitemap `html_baseurl` note).
- Full test suite: 410 passed, 4 skipped on pinned pydantic 2.10.6; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)