### PR TITLE
fix(core): correct dual-default on TimeAxis.time_normalized_offset

### DIFF
--- a/cfdmod/core/time_axis.py
+++ b/cfdmod/core/time_axis.py
@@ -60,13 +60,13 @@ class TimeAxis(BaseModel):
     time_normalized_offset: Annotated[
         float | None,
         Field(
-            default=None,
+            None,
             description=(
                 "Offset for reporting normalized time. None -> use initial_time, so "
                 "time_normalized[0] == 0."
             ),
         ),
-    ] = None
+    ]
 
     @model_validator(mode="after")
     def _check_step(self) -> "TimeAxis":


### PR DESCRIPTION
Follow-up to #144 / #145. Fixes the last remaining field that declared its default in two places.

## The problem
`cfdmod/core/time_axis.py` `TimeAxis.time_normalized_offset` specified the default **twice**:
```python
time_normalized_offset: Annotated[
    float | None,
    Field(default=None, description=(...)),
] = None            # <- redundant: default also given inside Field
```
Same footgun as `ElementMeta.annotations` (fixed in #144): the default belongs in exactly one place. `Annotated[..., Field(...)]` is the right tool - the `Annotated` stays; the trailing `= None` is what's wrong.

## The fix
Match the Nassu config idiom (`nassu/cfg/schemes/checkpoint.py`): the default is the **first positional argument of `Field`**, and there is **no trailing assignment**:
```python
time_normalized_offset: Annotated[
    float | None,
    Field(None, description=(...)),
]
```

## Verification
- Behavior unchanged: field still defaults to `None`, `normalization_offset` still resolves to `initial_time`.
- Full test suite: 410 passed, 4 skipped on pinned pydantic 2.10.6; ruff clean.
- Clean import + construct on pydantic 2.13.4.
- Confirmed via an exhaustive scan that no other field closes an `Annotated[..., Field(...)]` with a trailing `= <default>` - topology.py (#144) and this were the only two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)