### PR TITLE
docs: remove internal issue references from public documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,14 @@
   Use plain ASCII only: `->` not arrows, `x` not multiplication sign, `u_mean` not Greek letters, `^2` not superscripts.
   For equations in legends, feel free to use Latex notation for equations and special symbols in Latex representation.
 - **No inline comments in python3 -c "..." terminal commands** (shell escaping issues).
+- **NEVER reference internal GitHub issues or PRs in public documentation.** This is a
+  HARD RULE. Anything under `docs/`, `README.md`, tutorial/notebook READMEs, docstrings,
+  or any other user-facing published text must NOT contain issue/PR numbers, `#<n>`
+  references, `gh issue`/`github.com/.../issues` links, or phrasings like
+  "(issue #131)". Issue and PR references are internal-only (commit messages, PR
+  descriptions, and issue comments). Release notes describe *what changed* for users, not
+  which issue tracked it - do not cite issue numbers there either. When documenting a
+  feature, describe the behavior, not the work item that produced it.
 - Python >= 3.10; formatting, import-sorting, and linting all via ruff (`ruff format` + `ruff check`).
 - Configuration via YAML + Pydantic v2 `BaseModel` with `from_file(path)` classmethods.
 - External mesh format: `aerosim-lnas` (`LnasFormat`, `LnasGeometry`). Prefer lnas over trimesh for loading STL/LNAS surfaces.

--- a/docs/source/architecture/data_sources.md
+++ b/docs/source/architecture/data_sources.md
@@ -1,6 +1,6 @@
 # Data sources, ops, and pipelines (v3 paradigm)
 
-Status: design doc for the v3 paradigm introduced by issue #131.
+Status: design doc for the v3 paradigm.
 
 This document captures the locked decisions for the new abstraction layer
 shipped under `cfdmod/core/` and `cfdmod/adapters/`. It is the durable
@@ -151,7 +151,7 @@ YAML schemas are not touched in phases 1-3. New schemas land under
   per the odt, these stay outside the paradigm. Pedestrian comfort
   takes climate data as a non-pipeline input.
 
-## 11. Consuming cfdmod as a service (issue #147)
+## 11. Consuming cfdmod as a service
 
 The v3 core is usable not just as a library you call but as a contract a
 service can reflect on and drive from a UI (e.g. a node-based pipeline

--- a/docs/source/architecture/v3_migration.md
+++ b/docs/source/architecture/v3_migration.md
@@ -1,4 +1,4 @@
-# Migrating to the v3 paradigm (issue #131)
+# Migrating to the v3 paradigm
 
 The v3 paradigm introduces a small set of composable primitives --
 `DataSource`, `Pipeline`, `Container`, `Storage` -- and a library of

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -3,7 +3,7 @@
 ## v3.1.0
 
 Minor release. Turns the v3 core from "a library you call" into "a
-contract a service can reflect on and drive from a UI" (issue #147),
+contract a service can reflect on and drive from a UI",
 additively -- no public symbol is removed or changed in signature, and
 every new error subclasses the builtin it replaced, so existing
 `except (KeyError, ValueError)` handlers keep working.
@@ -57,7 +57,7 @@ every new error subclasses the builtin it replaced, so existing
 
 ## v3.0.0
 
-Major release. Introduces the v3 data-source paradigm (issue #131) and
+Major release. Introduces the v3 data-source paradigm and
 **hard-removes the v2 pressure module**. All Cp/Cf/Cm/Ce work now flows
 through pipeline-as-YAML templates executed via `cfdmod run
 <template.yaml>` or the Python `run_template` API. This is a breaking

--- a/notebooks/tutorials/README.md
+++ b/notebooks/tutorials/README.md
@@ -1,6 +1,6 @@
 # cfdmod tutorials
 
-Four short notebooks introducing the v3 paradigm (issue #131). Run in order; each builds on concepts from the previous.
+Four short notebooks introducing the v3 paradigm. Run in order; each builds on concepts from the previous.
 
 | Notebook | What you learn |
 |---|---|


### PR DESCRIPTION
## What

Internal GitHub issue numbers had leaked into the **public** Sphinx documentation. Issue/PR references are internal-only and must never appear in user-facing docs. This PR strips all of them and adds a hard rule to prevent recurrence.

## Removed references

- `docs/source/architecture/v3_migration.md` - page title `(issue #131)`
- `docs/source/architecture/data_sources.md` - status line `(issue #131)` and section 11 heading `(issue #147)`
- `docs/source/release_notes.md` - `(issue #131)` in v3.0.0 and `(issue #147)` in v3.1.0
- `notebooks/tutorials/README.md` - intro `(issue #131)`

No content is lost - only the parenthetical issue numbers are dropped; each doc still describes the behavior/feature itself.

## Guardrail added

`CLAUDE.md` now carries a hard rule: never reference internal GitHub issues or PRs in any public documentation (docs, READMEs, release notes, docstrings). Issue/PR references belong only in commit messages, PR descriptions, and issue comments.

## Verification

`grep` over `docs/source/`, `README.md`, and tutorial READMEs confirms zero remaining issue/PR references. `docs/build/` is gitignored (not tracked), so no generated HTML needs fixing - it regenerates cleanly from the corrected source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)