### PR TITLE
docs: correct stale v3 migration claims

### DIFF
--- a/docs/source/architecture/data_sources.md
+++ b/docs/source/architecture/data_sources.md
@@ -17,7 +17,10 @@ library of pure transformations on it.
 
 Phases 0-2 of the plan land the abstractions and prove on-disk parity
 with every existing fixture. Phases 3-8 rewrite recipe internals on top
-of the new core. Existing public APIs are not removed before v4.
+of the new core. The v2 pressure entry points have been removed in v3;
+post-processing runs through the v3 recipes and the
+`cfdmod run <template.yaml>` CLI. Geometry, S1, inflow, climate,
+analytical, and IO helpers remain exported unchanged.
 
 ## 2. Data source
 
@@ -131,14 +134,16 @@ Outside (stay standalone): `loft/`, `roughness/`, `snapshot/`,
 `io/geometry/`, `io/vtk/`. They produce inputs to or consume outputs
 from data sources but never participate as filters in a pipeline.
 
-## 9. Migration plan
+## 9. Migration outcome
 
-Parallel API, not a hard cut. v2.x keeps every existing public function
-intact. v3.x rewrites internals on the new core with the old top-level
-functions as thin wrappers. v4.x drops the wrappers.
-
-YAML schemas are not touched in phases 1-3. New schemas land under
-`version: "3"`. `pressure/migrate.py` is the bridge.
+The pressure post-processing surface was cut over to the new core rather
+than kept as parallel wrappers. The `cfdmod.pressure` package and its
+disk-first entry points (`run_cp` / `run_cf` / `run_cm` / `run_ce` /
+`apply_filters` / `MovingAverageFilter`) were removed. The supported
+access paths are the v3 recipes (`cfdmod.recipes`), the op catalog
+(`cfdmod.core_ops`), and version-3 YAML templates executed with
+`cfdmod run <template.yaml>`. Non-pressure public helpers (geometry, S1,
+inflow, climate, analytical, IO) remain exported from `cfdmod`.
 
 ## 10. What is NOT in scope
 

--- a/docs/source/architecture/v3_migration.md
+++ b/docs/source/architecture/v3_migration.md
@@ -2,9 +2,9 @@
 
 The v3 paradigm introduces a small set of composable primitives --
 `DataSource`, `Pipeline`, `Container`, `Storage` -- and a library of
-pure ops. This guide shows how to adopt them. **No legacy public symbol
-has been removed.** Every function exported by `cfdmod` in v2 is still
-exported in v3.
+pure ops. This guide shows how to adopt them. The disk-first v2 pressure
+entry points have been removed: post-processing now runs through the v3
+recipes and the `cfdmod run <template.yaml>` CLI.
 
 ## What changed at the import surface
 
@@ -26,28 +26,21 @@ from cfdmod import (
 )
 ```
 
-### Untouched legacy symbols
+### Removed and relocated symbols
 
-`run_cp`, `run_cf`, `run_cm`, `run_ce`, `apply_filters`,
-`MovingAverageFilter`, `InflowData`, `Profile`, every `*Config` model,
-every `LoftParams` / `RadialParams` /  `WindProfile_*` -- all unchanged.
+The `cfdmod.pressure` package has been removed. `run_cp`, `run_cf`,
+`run_cm`, `run_ce`, `apply_filters`, and `MovingAverageFilter` no longer
+exist; use the v3 recipes (`build_cp`, `cf_pipeline`, `cm_pipeline`,
+`ce_pipeline`) or a YAML template run with `cfdmod run <template.yaml>`.
+The functional filtering that `apply_filters` / `MovingAverageFilter`
+provided is now the `moving_average` field op, composable into any
+pipeline.
 
-## Side-by-side: a Cp pipeline
+Everything else is unchanged: `InflowData`, `Profile`, every `*Config`
+model, and every `LoftParams` / `RadialParams` / `WindProfile_*` are
+still exported from `cfdmod`.
 
-### Legacy (still works)
-
-```python
-from cfdmod import run_cp
-
-run_cp(
-    body_h5="body/cp.h5",
-    probe_h5="probe/cp.h5",
-    cfg_path="cp_config.yaml",
-    output="out/",
-)
-```
-
-### v3 (small-data, no I/O)
+## A Cp pipeline (small-data, no I/O)
 
 ```python
 import numpy as np
@@ -77,14 +70,14 @@ without changing the pipeline -- only the `Storage` adapter swaps.
 
 ## When to reach for v3
 
-- New consulting notebooks: prefer v3. The data flow is explicit and
-  small-data is fast.
-- Existing batch scripts that hit `run_cp` / `run_cf` / etc.: keep using
-  the legacy entry points. They produce the same XDMF + H5 output and
-  will until v4.
+- New consulting notebooks: prefer the recipes. The data flow is
+  explicit and small-data is fast.
+- Batch post-processing: author a YAML template and run it with
+  `cfdmod run <template.yaml>`. The template declares its own inputs,
+  pipeline steps, and outputs, and produces the XDMF + H5 outputs via
+  `XdmfH5Storage`.
 - Any code that wants a custom pipeline (e.g. extra filtering step,
-  alternative aggregation): build a `Pipeline` from `core_ops` rather
-  than fork the legacy.
+  alternative aggregation): build a `Pipeline` from `core_ops`.
 
 ## Recipe reference
 
@@ -111,8 +104,11 @@ Every recipe is `compose(...)` of these ops; you can build your own.
 
 All ops are pure functions: `op(ds, params) -> DataSource`.
 
-## When v4 lands
+## Where the old entry points went
 
-v4 will drop the v2 wrappers. Anything still calling `run_cp` /
-`apply_filters` / `Profile.__truediv__` will need to migrate to the
-recipes above. Until then, both APIs are first-class.
+The v2 pressure entry points (`run_cp`, `apply_filters`, and the
+`cfdmod.pressure` package internals) have been removed. Migrate to the
+recipes above, or express the workflow as a YAML template and run it
+with `cfdmod run <template.yaml>`. The filtering step that
+`apply_filters` / `MovingAverageFilter` provided is now the
+`moving_average` field op.


### PR DESCRIPTION
## What

Fixes the factually-wrong statements in the v3 architecture docs. The migration guide and `data_sources.md` still promised a "parallel API, nothing removed until v4" contract that v3 does not honour.

**Verified against the current package** (not assumed):
- `run_cp` / `run_cf` / `run_cm` / `run_ce` / `apply_filters` / `MovingAverageFilter` are **removed** from `cfdmod` (the whole `cfdmod.pressure` package is gone).
- Real access paths: the recipes (`cfdmod.recipes`: `build_cp`, `cf_pipeline`, `cm_pipeline`, `ce_pipeline`, `build_s1`, `build_dynamic_response`, ...) and the CLI `cfdmod run <template.yaml>` (runs via `XdmfH5Storage`).
- The old filtering (`MovingAverageFilter`) is now the `moving_average` field op.

## Changes

- `v3_migration.md`: drop the "No legacy public symbol has been removed" claim; rename "Untouched legacy symbols" -> "Removed and relocated symbols"; delete the `run_cp` "Legacy (still works)" example; fix the "When to reach for v3" and "When v4 lands" sections to describe the template CLI.
- `data_sources.md`: correct section 1 and rewrite section 9 ("Migration plan" -> "Migration outcome") to match reality.

ASCII-only, zero issue/PR references (per project docs rule). Sphinx build verified locally.

## Scope note

This is the targeted doc-accuracy fix only (the urgent "the docs lie" bug). The broader external-user documentation restructure remains tracked in #124; the HFPI migration is being consolidated into a dedicated issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)