### PR TITLE
feat(ops): face_cut - geometric triangle slicing for exact per-slice integration

### DIFF
--- a/cfdmod/core/ops/data_source_create/__init__.py
+++ b/cfdmod/core/ops/data_source_create/__init__.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 __all__ = [
     "StatisticsParams",
     "compute_statistics",
+    "FaceCutParams",
+    "face_cut",
     "FieldSeriesForGroupsParams",
     "field_series_for_groups",
     "FilterByGroupingParams",
@@ -34,6 +36,7 @@ __all__ = [
     "profile_interpolation",
 ]
 
+from cfdmod.core.ops.data_source_create.face_cut import FaceCutParams, face_cut
 from cfdmod.core.ops.data_source_create.field_series_for_groups import (
     FieldSeriesForGroupsParams,
     field_series_for_groups,

--- a/cfdmod/core/ops/data_source_create/face_cut.py
+++ b/cfdmod/core/ops/data_source_create/face_cut.py
@@ -1,0 +1,177 @@
+"""Geometrically slice a surface's triangles along axis-aligned planes.
+
+``face_cut`` cuts each triangle of a :class:`SurfaceDataSource` along a
+set of fixed axis-aligned coordinates and emits a *new* surface whose
+fragments each sit cleanly inside one slice. Every fragment inherits its
+parent triangle's fields (piecewise-constant: a child copies the
+parent's timeseries) and its parent's oriented normal, and recomputes
+its own area / centroid.
+
+This is the exact counterpart to the centroid-based
+:func:`cfdmod.core.ops.geometric.zoning_grouping`: instead of assigning a
+*whole* triangle to one slice by its centroid (an approximation when a
+triangle straddles a boundary), ``face_cut`` splits the triangle so each
+side contributes its real partial area. Downstream,
+``force_contribution`` + ``field_series_for_groups(agg="sum")`` integrate
+per slice unchanged, giving exact force / moment by floor or zone.
+
+The cut arithmetic is the shared, dependency-light core in
+:mod:`cfdmod.io.geometry.triangle_slicing` (also used by the legacy
+``cfdmod.regroup`` pipeline), so this op is an adapter across the storage
+seam rather than new geometry math.
+
+Region ids are 0-indexed integers in raster order
+(``ix + nx * iy + nx * ny * iz``), matching ``zoning_grouping`` so the two
+ops are interchangeable in a template.
+"""
+
+from __future__ import annotations
+
+__all__ = ["FaceCutParams", "face_cut"]
+
+from typing import ClassVar, Literal
+
+import numpy as np
+from pydantic import ConfigDict
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core.data_source import DataSource, SurfaceDataSource
+from cfdmod.core.grouping import Grouping
+from cfdmod.core.ops import OpParams
+from cfdmod.core.topology import ElementMeta, Topology
+from cfdmod.geometry.triangle_slicing import (
+    bin_centroid_to_cell,
+    build_geometry_from_fragments,
+    slice_triangles_with_parents,
+)
+
+
+class FaceCutParams(OpParams):
+    """Parameters for :func:`face_cut`.
+
+    Attributes:
+        x_intervals: Monotone increasing cut planes / bin edges along x.
+            ``n`` edges produce ``n - 1`` bins. Empty list -> open axis
+            (no x cut, everything in x-bin 0). For per-floor slicing set
+            only ``z_intervals`` and leave x/y open.
+        y_intervals: Same convention along y.
+        z_intervals: Same convention along z.
+        name: Grouping name attached on the output (e.g. ``"floor"``).
+        unassigned_policy: ``"drop"`` removes fragments whose centroid
+            falls outside every declared bin; ``"keep_as_unassigned"``
+            keeps them with group id ``-1``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["face_cut"] = "face_cut"
+    x_intervals: list[float] = []
+    y_intervals: list[float] = []
+    z_intervals: list[float] = []
+    name: str = "floor"
+    unassigned_policy: Literal["drop", "keep_as_unassigned"] = "drop"
+
+    chunkable_along: ClassVar[frozenset[str]] = frozenset({"time"})
+    consumes: ClassVar[frozenset[str] | None] = frozenset({"surface"})
+    produces: ClassVar[str] = "surface"
+    requires_element_meta: ClassVar[frozenset[str]] = frozenset({"normal"})
+    produces_element_meta: ClassVar[frozenset[str]] = frozenset({"area", "normal", "position"})
+
+
+def _normalize_intervals(edges: list[float]) -> list[float]:
+    """Empty -> open infinite interval; otherwise pass through."""
+    if not edges:
+        return [float("-inf"), float("inf")]
+    return edges
+
+
+def _triangle_areas(tri_verts: np.ndarray) -> np.ndarray:
+    """Per-triangle area from ``(m, 3, 3)`` vertex arrays."""
+    e1 = tri_verts[:, 1] - tri_verts[:, 0]
+    e2 = tri_verts[:, 2] - tri_verts[:, 0]
+    return 0.5 * np.linalg.norm(np.cross(e1, e2), axis=1)
+
+
+def face_cut(ds: DataSource, p: FaceCutParams) -> SurfaceDataSource:
+    if ds.topology is None or ds.topology.cell_type != "triangle":
+        raise ValueError(
+            "face_cut requires a triangle Topology; got "
+            f"{None if ds.topology is None else ds.topology.cell_type!r}"
+        )
+    if ds.elements.normal is None:
+        raise ValueError(
+            "face_cut requires elements.normal (fragments inherit the parent's "
+            "oriented normal); attach it with mesh_attach first."
+        )
+
+    n_parents = ds.n_elements
+    tri_verts = ds.topology.vertices[ds.topology.connectivity]  # (n, 3, 3)
+    tri_normals = np.asarray(ds.elements.normal, dtype=np.float64)
+    parent_idxs = np.arange(n_parents, dtype=np.int64)
+
+    intervals = (
+        _normalize_intervals(p.x_intervals),
+        _normalize_intervals(p.y_intervals),
+        _normalize_intervals(p.z_intervals),
+    )
+
+    frag_verts, frag_normals, parent_per_fragment = slice_triangles_with_parents(
+        tri_verts, tri_normals, parent_idxs, intervals
+    )
+
+    # Region id per fragment from its centroid bin, in raster order.
+    nx = max(len(intervals[0]) - 1, 1)
+    ny = max(len(intervals[1]) - 1, 1)
+    centroids = frag_verts.mean(axis=1)
+    region_ids = np.empty(frag_verts.shape[0], dtype=np.int32)
+    for i in range(frag_verts.shape[0]):
+        ix, iy, iz = bin_centroid_to_cell(centroids[i], intervals)
+        if ix < 0 or iy < 0 or iz < 0:
+            region_ids[i] = -1
+        else:
+            region_ids[i] = ix + nx * iy + (nx * ny) * iz
+
+    # Apply the unassigned policy before building topology so every array
+    # stays row-aligned.
+    if p.unassigned_policy == "drop":
+        keep = region_ids >= 0
+    else:
+        keep = np.ones(frag_verts.shape[0], dtype=bool)
+    if not keep.any():
+        raise ValueError(
+            "face_cut produced 0 assigned fragments; check the intervals against the mesh extent."
+        )
+
+    frag_verts = frag_verts[keep]
+    frag_normals = frag_normals[keep]
+    parent_per_fragment = parent_per_fragment[keep]
+    region_ids = region_ids[keep]
+    centroids = centroids[keep]
+
+    vertices, triangles = build_geometry_from_fragments(frag_verts)
+    new_topology = Topology.triangles(triangles, vertices)
+    new_elements = ElementMeta(
+        position=centroids,
+        area=_triangle_areas(frag_verts),
+        normal=frag_normals,
+    )
+
+    # Fields: gather each fragment's timeseries from its parent row. This
+    # repeats a parent's row for each of its fragments (piecewise-constant
+    # inheritance). Works for both memory (direct fancy-index) and h5
+    # (per-timestep gather) field stores.
+    gathered: dict[str, np.ndarray] = {}
+    for fname in ds.fields.keys():
+        gathered[fname] = ds.fields.read(fname, elements=parent_per_fragment)
+
+    grouping = Grouping(name=p.name, indices=region_ids)
+
+    return SurfaceDataSource(
+        time=ds.time,
+        topology=new_topology,
+        elements=new_elements,
+        groupings={p.name: grouping},
+        fields=MemoryFieldStore(gathered),
+        field_meta={name: meta for name, meta in ds.field_meta.items() if name in gathered},
+        attrs=dict(ds.attrs),
+    )

--- a/cfdmod/core/pipeline_yaml.py
+++ b/cfdmod/core/pipeline_yaml.py
@@ -150,12 +150,14 @@ def _populate_default_registry() -> None:
         return
 
     from cfdmod.core.ops.data_source_create import (
+        FaceCutParams,
         FieldSeriesForGroupsParams,
         FilterByGroupingParams,
         ProbeExtractionParams,
         ProfileInterpolationParams,
         StatisticsParams,
         compute_statistics,
+        face_cut,
         field_series_for_groups,
         filter_by_grouping,
         probe_extraction,
@@ -223,6 +225,7 @@ def _populate_default_registry() -> None:
         ("force_contribution", force_contribution, ForceContributionParams),
         ("moment_contribution", moment_contribution, MomentContributionParams),
         ("filter_by_grouping", filter_by_grouping, FilterByGroupingParams),
+        ("face_cut", face_cut, FaceCutParams),
         ("field_series_for_groups", field_series_for_groups, FieldSeriesForGroupsParams),
         ("statistics", compute_statistics, StatisticsParams),
         ("modal_projection", modal_projection, ModalProjectionParams),

--- a/cfdmod/geometry/triangle_slicing.py
+++ b/cfdmod/geometry/triangle_slicing.py
@@ -1,0 +1,262 @@
+"""Pure axis-aligned triangle slicing + fragment geometry helpers.
+
+Pure numpy -- no ``lnas``, no ``cfdmod.io`` (and therefore none of the
+heavy scientific stack). This keeps the helpers importable from the v3
+op layer, whose contract is a dependency-light import path, while the
+legacy ``cfdmod.regroup`` pipeline and ``cfdmod.io.geometry.region_meshing``
+re-export them for their own callers.
+
+The cut is the "Ce-style 90-degree" slicing: for each fixed axis-aligned
+plane, a triangle that straddles the plane is split into fragments, each
+fragment tracks the parent triangle it came from (so per-timestep fields
+can be gathered), and triangles parallel to / entirely on one side of a
+plane pass through unchanged.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "triangulate_tri",
+    "slice_triangle",
+    "slice_one_triangle",
+    "slice_triangles_with_parents",
+    "bin_centroid_to_cell",
+    "build_geometry_from_fragments",
+]
+
+import numpy as np
+
+
+def triangulate_tri(sorted_vertices: np.ndarray, insertion_indices: list[int]) -> np.ndarray:
+    """Triangulates a point cloud of a triangle.
+
+    Vertices are ordered according to the original triangle normal.
+    If there is one vertex inserted, the original triangle splits into two.
+    If there are two vertices inserted, it splits into three.
+
+    Args:
+        sorted_vertices (np.ndarray): Triangle vertices ordered.
+        insertion_indices (list[int]): Indices of the vertices inserted in the slice.
+
+    Returns:
+        np.ndarray: Array of triangles.
+    """
+    tri_indexes = []
+    if len(insertion_indices) == 1:
+        i = insertion_indices[0]
+        tri_indexes.append([i - 1, i, (i + 2) % 4])
+        tri_indexes.append([i, (i + 1) % 4, (i + 2) % 4])
+    elif len(insertion_indices) == 2:
+        i, j = insertion_indices[0], insertion_indices[1]
+        tri_indexes.append([4, 0, 1])
+        if j == 3:
+            tri_indexes.append([1, 2, 3])
+            tri_indexes.append([3, 4, 1])
+        else:
+            tri_indexes.append([1, 2, 4])
+            tri_indexes.append([2, 3, 4])
+    else:
+        tri_indexes.append([0, 1, 2])
+
+    return sorted_vertices[np.array(tri_indexes, dtype=np.uint32)].astype(np.float32)
+
+
+def slice_triangle(tri_verts: np.ndarray, axis: int, axis_value: float) -> np.ndarray:
+    """Slice a triangle from a given plane.
+
+    If the plane intersects any edge of the triangle, new vertices are
+    generated and the triangle is re-triangulated into smaller triangles.
+
+    Args:
+        tri_verts (np.ndarray): Vertices of the triangle to slice.
+        axis (int): Axis index (x=0, y=1, z=2).
+        axis_value (float): Value of the interval.
+
+    Returns:
+        np.ndarray: Array of triangle vertices resulting from slicing.
+    """
+    intersected_pts = tri_verts.copy()
+    insertion_indices = []
+
+    for i in range(3):
+        if len(intersected_pts) > 4:
+            # Sliced all possible lines
+            continue
+        else:
+            p1, p2 = tri_verts[i], tri_verts[(i + 1) % 3]
+
+            if (p1[axis] < axis_value and p2[axis] > axis_value) or (
+                p1[axis] > axis_value and p2[axis] < axis_value
+            ):
+                t = (axis_value - p1[axis]) / (p2[axis] - p1[axis])
+                intersect_pt = p1 + t * (p2 - p1)
+
+                insert_idx = i + 1 + intersected_pts.shape[0] // 4
+                insertion_indices.append(insert_idx)
+
+                intersected_pts = np.insert(intersected_pts, insert_idx, intersect_pt, axis=0)
+
+    return triangulate_tri(intersected_pts, sorted(insertion_indices))
+
+
+def slice_one_triangle(
+    tri_verts: np.ndarray,
+    tri_normal: np.ndarray,
+    axis: int,
+    axis_value: float,
+) -> np.ndarray:
+    """Slice a single triangle along an axis-aligned plane.
+
+    Returns ``(N, 3, 3)`` post-slice triangle vertex arrays; ``N >= 1``.
+    Skips slicing when the triangle is parallel to the cut plane (its
+    normal is dominantly along ``axis``) or lies entirely on one side.
+    """
+    if np.abs(tri_normal).max() == np.abs(tri_normal)[axis]:
+        return tri_verts.reshape(1, 3, 3).astype(np.float64)
+    if tri_verts[:, axis].max() < axis_value or tri_verts[:, axis].min() > axis_value:
+        return tri_verts.reshape(1, 3, 3).astype(np.float64)
+    return slice_triangle(tri_verts, axis, axis_value).astype(np.float64)
+
+
+def _apply_axis_cut(
+    cur_verts: np.ndarray,
+    cur_normals: np.ndarray,
+    cur_parents: np.ndarray,
+    axis: int,
+    v: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Slice all current fragments along a single ``(axis, v)`` plane.
+
+    Vectorises the pass-through decision so only the fragments that actually
+    straddle the plane run the per-triangle slicing arithmetic. Output
+    ordering matches the naive per-fragment loop (fragments emitted in the
+    original row order ``i``, and in ``slice_triangle`` order within a row),
+    so the result is identical to slicing each triangle one at a time.
+
+    A fragment is passed through unchanged when its normal is dominantly
+    along ``axis`` (parallel to the cut plane) or it lies entirely on one
+    side of ``v`` -- mirroring :func:`slice_one_triangle`.
+    """
+    n = cur_verts.shape[0]
+    if n == 0:
+        return cur_verts, cur_normals, cur_parents
+
+    abs_normals = np.abs(cur_normals)
+    normal_parallel = abs_normals.max(axis=1) == abs_normals[:, axis]
+    axis_coord = cur_verts[:, :, axis]
+    entirely_below = axis_coord.max(axis=1) < v
+    entirely_above = axis_coord.min(axis=1) > v
+    keep = normal_parallel | entirely_below | entirely_above
+
+    straddle_idx = np.flatnonzero(~keep)
+    if straddle_idx.size == 0:
+        # No fragment crosses this plane; nothing to do (identity).
+        return cur_verts, cur_normals, cur_parents
+
+    # Only the straddling fragments run the (Python) per-triangle cut.
+    counts = np.ones(n, dtype=np.int64)
+    straddle_fragments: dict[int, np.ndarray] = {}
+    for i in straddle_idx.tolist():
+        fragments = slice_triangle(cur_verts[i], axis, v).astype(np.float64)
+        straddle_fragments[i] = fragments
+        counts[i] = fragments.shape[0]
+
+    total = int(counts.sum())
+    offsets = np.empty(n + 1, dtype=np.int64)
+    offsets[0] = 0
+    np.cumsum(counts, out=offsets[1:])
+
+    out_verts = np.empty((total, 3, 3), dtype=np.float64)
+    out_normals = np.empty((total, 3), dtype=np.float64)
+    out_parents = np.empty(total, dtype=np.int64)
+
+    # Kept fragments (exactly one output each) filled in bulk by index.
+    keep_pos = offsets[:-1][keep]
+    out_verts[keep_pos] = cur_verts[keep]
+    out_normals[keep_pos] = cur_normals[keep]
+    out_parents[keep_pos] = cur_parents[keep]
+
+    # Straddling fragments expand into their contiguous slice, inheriting
+    # the parent's normal and parent index.
+    for i, fragments in straddle_fragments.items():
+        start = int(offsets[i])
+        end = int(offsets[i + 1])
+        out_verts[start:end] = fragments
+        out_normals[start:end] = cur_normals[i]
+        out_parents[start:end] = cur_parents[i]
+
+    return out_verts, out_normals, out_parents
+
+
+def slice_triangles_with_parents(
+    tri_verts: np.ndarray,
+    tri_normals: np.ndarray,
+    parent_idxs: np.ndarray,
+    intervals: tuple[list[float], list[float], list[float]],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Slice triangles along axis-aligned planes, tracking parent indices.
+
+    Args:
+        tri_verts: ``(n, 3, 3)`` per-triangle vertex array.
+        tri_normals: ``(n, 3)`` per-triangle outward normal.
+        parent_idxs: ``(n,)`` int64 - the parent (input-mesh) triangle each
+            row of ``tri_verts`` came from.
+        intervals: per-axis interval edges; non-finite values (``inf`` /
+            ``-inf``) are skipped (sentinels for "no binning on this axis").
+
+    Returns:
+        ``(verts, normals, parent_per_fragment)``:
+        - ``verts``: ``(m, 3, 3)`` post-slice triangle vertex arrays.
+        - ``normals``: ``(m, 3)`` per-fragment normals (inherited from parent).
+        - ``parent_per_fragment``: ``(m,)`` int64 - parent triangle index
+          for each fragment (== input ``parent_idxs[i]`` for any fragment
+          derived from input row ``i``).
+    """
+    cur_verts = tri_verts.astype(np.float64).copy()
+    cur_normals = tri_normals.astype(np.float64).copy()
+    cur_parents = np.asarray(parent_idxs, dtype=np.int64).copy()
+
+    for axis in range(3):
+        for v in intervals[axis]:
+            if not np.isfinite(v):
+                continue
+            cur_verts, cur_normals, cur_parents = _apply_axis_cut(
+                cur_verts, cur_normals, cur_parents, axis, float(v)
+            )
+
+    return cur_verts, cur_normals, cur_parents
+
+
+def bin_centroid_to_cell(
+    centroid: np.ndarray,
+    intervals: tuple[list[float], list[float], list[float]],
+) -> tuple[int, int, int]:
+    """Return ``(ix, iy, iz)`` cell index of a centroid; -1 if outside any axis."""
+    out = []
+    for axis in range(3):
+        edges = intervals[axis]
+        idx = -1
+        for j in range(len(edges) - 1):
+            lo = edges[j]
+            hi = edges[j + 1]
+            if lo <= centroid[axis] < hi:
+                idx = j
+                break
+        out.append(idx)
+    return tuple(out)  # type: ignore[return-value]
+
+
+def build_geometry_from_fragments(
+    fragments_verts: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Deduplicate vertices and return ``(vertices, triangles)`` arrays."""
+    if fragments_verts.shape[0] == 0:
+        return (
+            np.zeros((0, 3), dtype=np.float64),
+            np.zeros((0, 3), dtype=np.int32),
+        )
+    n = fragments_verts.shape[0]
+    flat = fragments_verts.reshape(n * 3, 3).astype(np.float64)
+    unique_verts, inverse = np.unique(flat, axis=0, return_inverse=True)
+    triangles = inverse.reshape(n, 3).astype(np.int32)
+    return unique_verts, triangles

--- a/cfdmod/io/geometry/region_meshing.py
+++ b/cfdmod/io/geometry/region_meshing.py
@@ -3,76 +3,20 @@ import warnings
 import numpy as np
 from lnas import LnasGeometry
 
+# The pure-numpy slicing primitives live in the dependency-light
+# ``cfdmod.geometry.triangle_slicing`` so the v3 op layer can import them
+# without dragging in ``cfdmod.io`` (h5py / pandas / ...). Re-exported here
+# for backwards compatibility with existing callers and tests.
+from cfdmod.geometry.triangle_slicing import slice_triangle, triangulate_tri
 
-def triangulate_tri(sorted_vertices: np.ndarray, insertion_indices: list[int]) -> np.ndarray:
-    """Triangulates a point cloud of a triangle
-    Vertices are ordered according to the original triangle normal.
-    If there are only one vertice inserted, then the original triangle will be split into two.
-    If there are two vertices inserted, then the original triangle will be split into three.
-
-    Args:
-        sorted_vertices (np.ndarray): Triangle vertices ordered
-        insertion_indices (list[int]): Indices of the vertices inserted in the slice
-
-    Returns:
-        np.ndarray: Array of triangles
-    """
-    tri_indexes = []
-    if len(insertion_indices) == 1:
-        i = insertion_indices[0]
-        tri_indexes.append([i - 1, i, (i + 2) % 4])
-        tri_indexes.append([i, (i + 1) % 4, (i + 2) % 4])
-    elif len(insertion_indices) == 2:
-        i, j = insertion_indices[0], insertion_indices[1]
-        tri_indexes.append([4, 0, 1])
-        if j == 3:
-            tri_indexes.append([1, 2, 3])
-            tri_indexes.append([3, 4, 1])
-        else:
-            tri_indexes.append([1, 2, 4])
-            tri_indexes.append([2, 3, 4])
-    else:
-        tri_indexes.append([0, 1, 2])
-
-    return sorted_vertices[np.array(tri_indexes, dtype=np.uint32)].astype(np.float32)
-
-
-def slice_triangle(tri_verts: np.ndarray, axis: int, axis_value: float) -> np.ndarray:
-    """Slice a triangle from a given plane
-    If the plane intersects any edge of the triangle, then new vertices are generated.
-    If there are new vertices in the triangle vertices, then it has to be triangulated
-    into smaller triangles
-
-    Args:
-        tri_verts (np.ndarray): Vertices of the triangle to slice
-        axis (int): Axis index (x=0, y=1, z=2)
-        axis_value (float): Value of the interval
-
-    Returns:
-        np.ndarray: Array of triangle vertices resulted from slicing
-    """
-    intersected_pts = tri_verts.copy()
-    insertion_indices = []
-
-    for i in range(3):
-        if len(intersected_pts) > 4:
-            # Sliced all possible lines
-            continue
-        else:
-            p1, p2 = tri_verts[i], tri_verts[(i + 1) % 3]
-
-            if (p1[axis] < axis_value and p2[axis] > axis_value) or (
-                p1[axis] > axis_value and p2[axis] < axis_value
-            ):
-                t = (axis_value - p1[axis]) / (p2[axis] - p1[axis])
-                intersect_pt = p1 + t * (p2 - p1)
-
-                insert_idx = i + 1 + intersected_pts.shape[0] // 4
-                insertion_indices.append(insert_idx)
-
-                intersected_pts = np.insert(intersected_pts, insert_idx, intersect_pt, axis=0)
-
-    return triangulate_tri(intersected_pts, sorted(insertion_indices))
+__all__ = [
+    "triangulate_tri",
+    "slice_triangle",
+    "clean_triangles",
+    "slice_surface",
+    "get_mesh_bounds",
+    "create_regions_mesh",
+]
 
 
 def clean_triangles(geom: LnasGeometry, minimal_area: float = 1e-5) -> LnasGeometry:

--- a/cfdmod/regroup/functions.py
+++ b/cfdmod/regroup/functions.py
@@ -34,7 +34,15 @@ from cfdmod.geometry.grouping import (
     GroupingSpec,
     apply_groupings,
 )
-from cfdmod.io.geometry.region_meshing import slice_triangle
+from cfdmod.geometry.triangle_slicing import (
+    bin_centroid_to_cell as _bin_centroid_to_cell,
+)
+from cfdmod.geometry.triangle_slicing import (
+    build_geometry_from_fragments as _build_geometry_from_fragments,
+)
+from cfdmod.geometry.triangle_slicing import (
+    slice_triangles_with_parents,
+)
 from cfdmod.io.geometry.transformation_config import TransformationConfig
 from cfdmod.io.xdmf import (
     get_pressure_keys,
@@ -222,169 +230,6 @@ def build_regrouped_mesh(
         group_weights=group_weights,
     )
     return new_lnas, index
-
-
-def _slice_one_triangle(
-    tri_verts: np.ndarray,
-    tri_normal: np.ndarray,
-    axis: int,
-    axis_value: float,
-) -> np.ndarray:
-    """Slice a single triangle along an axis-aligned plane.
-
-    Returns ``(N, 3, 3)`` post-slice triangle vertex arrays; ``N >= 1``.
-    Skips slicing when the triangle is parallel to the cut plane (its
-    normal is dominantly along ``axis``) or lies entirely on one side.
-    """
-    if np.abs(tri_normal).max() == np.abs(tri_normal)[axis]:
-        return tri_verts.reshape(1, 3, 3).astype(np.float64)
-    if tri_verts[:, axis].max() < axis_value or tri_verts[:, axis].min() > axis_value:
-        return tri_verts.reshape(1, 3, 3).astype(np.float64)
-    return slice_triangle(tri_verts, axis, axis_value).astype(np.float64)
-
-
-def _apply_axis_cut(
-    cur_verts: np.ndarray,
-    cur_normals: np.ndarray,
-    cur_parents: np.ndarray,
-    axis: int,
-    v: float,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Slice all current fragments along a single ``(axis, v)`` plane.
-
-    Vectorises the pass-through decision so only the fragments that actually
-    straddle the plane run the per-triangle slicing arithmetic. Output
-    ordering matches the naive per-fragment loop (fragments emitted in the
-    original row order ``i``, and in ``slice_triangle`` order within a row),
-    so the result is identical to slicing each triangle one at a time.
-
-    A fragment is passed through unchanged when its normal is dominantly
-    along ``axis`` (parallel to the cut plane) or it lies entirely on one
-    side of ``v`` -- mirroring :func:`_slice_one_triangle`.
-    """
-    n = cur_verts.shape[0]
-    if n == 0:
-        return cur_verts, cur_normals, cur_parents
-
-    abs_normals = np.abs(cur_normals)
-    normal_parallel = abs_normals.max(axis=1) == abs_normals[:, axis]
-    axis_coord = cur_verts[:, :, axis]
-    entirely_below = axis_coord.max(axis=1) < v
-    entirely_above = axis_coord.min(axis=1) > v
-    keep = normal_parallel | entirely_below | entirely_above
-
-    straddle_idx = np.flatnonzero(~keep)
-    if straddle_idx.size == 0:
-        # No fragment crosses this plane; nothing to do (identity).
-        return cur_verts, cur_normals, cur_parents
-
-    # Only the straddling fragments run the (Python) per-triangle cut.
-    counts = np.ones(n, dtype=np.int64)
-    straddle_fragments: dict[int, np.ndarray] = {}
-    for i in straddle_idx.tolist():
-        fragments = slice_triangle(cur_verts[i], axis, v).astype(np.float64)
-        straddle_fragments[i] = fragments
-        counts[i] = fragments.shape[0]
-
-    total = int(counts.sum())
-    offsets = np.empty(n + 1, dtype=np.int64)
-    offsets[0] = 0
-    np.cumsum(counts, out=offsets[1:])
-
-    out_verts = np.empty((total, 3, 3), dtype=np.float64)
-    out_normals = np.empty((total, 3), dtype=np.float64)
-    out_parents = np.empty(total, dtype=np.int64)
-
-    # Kept fragments (exactly one output each) filled in bulk by index.
-    keep_pos = offsets[:-1][keep]
-    out_verts[keep_pos] = cur_verts[keep]
-    out_normals[keep_pos] = cur_normals[keep]
-    out_parents[keep_pos] = cur_parents[keep]
-
-    # Straddling fragments expand into their contiguous slice, inheriting
-    # the parent's normal and parent index.
-    for i, fragments in straddle_fragments.items():
-        start = int(offsets[i])
-        end = int(offsets[i + 1])
-        out_verts[start:end] = fragments
-        out_normals[start:end] = cur_normals[i]
-        out_parents[start:end] = cur_parents[i]
-
-    return out_verts, out_normals, out_parents
-
-
-def slice_triangles_with_parents(
-    tri_verts: np.ndarray,
-    tri_normals: np.ndarray,
-    parent_idxs: np.ndarray,
-    intervals: tuple[list[float], list[float], list[float]],
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Slice triangles along axis-aligned planes, tracking parent indices.
-
-    Args:
-        tri_verts: ``(n, 3, 3)`` per-triangle vertex array.
-        tri_normals: ``(n, 3)`` per-triangle outward normal.
-        parent_idxs: ``(n,)`` int64 - the parent (input-mesh) triangle each
-            row of ``tri_verts`` came from.
-        intervals: per-axis interval edges; non-finite values (``inf`` /
-            ``-inf``) are skipped (sentinels for "no binning on this axis").
-
-    Returns:
-        ``(verts, normals, parent_per_fragment)``:
-        - ``verts``: ``(m, 3, 3)`` post-slice triangle vertex arrays.
-        - ``normals``: ``(m, 3)`` per-fragment normals (inherited from parent).
-        - ``parent_per_fragment``: ``(m,)`` int64 - parent triangle index
-          for each fragment (== input ``parent_idxs[i]`` for any fragment
-          derived from input row ``i``).
-    """
-    cur_verts = tri_verts.astype(np.float64).copy()
-    cur_normals = tri_normals.astype(np.float64).copy()
-    cur_parents = np.asarray(parent_idxs, dtype=np.int64).copy()
-
-    for axis in range(3):
-        for v in intervals[axis]:
-            if not np.isfinite(v):
-                continue
-            cur_verts, cur_normals, cur_parents = _apply_axis_cut(
-                cur_verts, cur_normals, cur_parents, axis, float(v)
-            )
-
-    return cur_verts, cur_normals, cur_parents
-
-
-def _bin_centroid_to_cell(
-    centroid: np.ndarray,
-    intervals: tuple[list[float], list[float], list[float]],
-) -> tuple[int, int, int]:
-    """Return ``(ix, iy, iz)`` cell index of a centroid; -1 if outside any axis."""
-    out = []
-    for axis in range(3):
-        edges = intervals[axis]
-        idx = -1
-        for j in range(len(edges) - 1):
-            lo = edges[j]
-            hi = edges[j + 1]
-            if lo <= centroid[axis] < hi:
-                idx = j
-                break
-        out.append(idx)
-    return tuple(out)  # type: ignore[return-value]
-
-
-def _build_geometry_from_fragments(
-    fragments_verts: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Deduplicate vertices and return ``(vertices, triangles)`` arrays."""
-    if fragments_verts.shape[0] == 0:
-        return (
-            np.zeros((0, 3), dtype=np.float64),
-            np.zeros((0, 3), dtype=np.int32),
-        )
-    n = fragments_verts.shape[0]
-    flat = fragments_verts.reshape(n * 3, 3).astype(np.float64)
-    unique_verts, inverse = np.unique(flat, axis=0, return_inverse=True)
-    triangles = inverse.reshape(n, 3).astype(np.int32)
-    return unique_verts, triangles
 
 
 def build_sliced_regrouped_mesh(

--- a/tests/core/ops/data_source_create/test_face_cut.py
+++ b/tests/core/ops/data_source_create/test_face_cut.py
@@ -1,0 +1,160 @@
+"""Unit tests for the face_cut op.
+
+face_cut geometrically slices a surface's triangles along axis-aligned
+planes so a triangle straddling a boundary contributes its real partial
+area to each side -- the exact counterpart to centroid ``zoning_grouping``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core import (
+    ElementMeta,
+    SurfaceDataSource,
+    TimeAxis,
+    Topology,
+)
+from cfdmod.core.ops.data_source_create import FaceCutParams, face_cut
+from cfdmod.core.ops.field import ForceContributionParams, force_contribution
+from cfdmod.geometry.triangle_slicing import slice_triangles_with_parents
+
+
+def _wall(cp_per_tri: np.ndarray, n_timesteps: int = 3) -> SurfaceDataSource:
+    """A vertical wall (normal -y) spanning x in [0,2], z in [0,2].
+
+    Two triangles, both straddling z = 1 so a z-cut actually slices them.
+    ``cp_per_tri`` is one scalar per triangle, broadcast over time.
+    """
+    verts = np.array(
+        [[0, 0, 0], [2, 0, 0], [2, 0, 2], [0, 0, 2]],
+        dtype=np.float64,
+    )
+    tris = np.array([[0, 1, 2], [0, 2, 3]], dtype=np.int32)
+    # Both triangles lie in the y=0 plane; outward normal is -y.
+    normals = np.array([[0.0, -1.0, 0.0], [0.0, -1.0, 0.0]])
+    cp = np.repeat(cp_per_tri[:, None], n_timesteps, axis=1).astype(np.float64)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=1.0, n_timesteps=n_timesteps),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(
+            area=np.array([2.0, 2.0]),  # each triangle is half of the 2x2 wall
+            normal=normals,
+        ),
+        fields=MemoryFieldStore({"cp": cp}),
+    )
+
+
+def _parent_area(ds: SurfaceDataSource) -> np.ndarray:
+    tv = ds.topology.vertices[ds.topology.connectivity]
+    e1 = tv[:, 1] - tv[:, 0]
+    e2 = tv[:, 2] - tv[:, 0]
+    return 0.5 * np.linalg.norm(np.cross(e1, e2), axis=1)
+
+
+def test_face_cut_partitions_area_exactly():
+    ds = _wall(np.array([1.0, 1.0]))
+    out = face_cut(ds, FaceCutParams(z_intervals=[0.0, 1.0, 2.0], name="floor"))
+
+    # Slicing actually happened (more fragments than parents).
+    assert out.n_elements > ds.n_elements
+    # Fragment areas partition the parent wall exactly (no duplication, no loss).
+    assert out.elements.area.sum() == pytest.approx(_parent_area(ds).sum(), rel=1e-9)
+    # Every fragment sits cleanly in one floor group (no -1 with full coverage).
+    assert set(np.unique(out.groupings["floor"].indices).tolist()) == {0, 1}
+
+
+def test_face_cut_inherits_parent_fields():
+    cp_per_tri = np.array([10.0, 20.0])
+    ds = _wall(cp_per_tri)
+    params = FaceCutParams(z_intervals=[0.0, 1.0, 2.0], name="floor")
+    out = face_cut(ds, params)
+
+    # Independently reconstruct the parent-per-fragment map from the same core.
+    tri_verts = ds.topology.vertices[ds.topology.connectivity]
+    _v, _n, parent_per_fragment = slice_triangles_with_parents(
+        tri_verts,
+        np.asarray(ds.elements.normal, dtype=np.float64),
+        np.arange(ds.n_elements, dtype=np.int64),
+        ([float("-inf"), float("inf")], [float("-inf"), float("inf")], [0.0, 1.0, 2.0]),
+    )
+    expected = ds.fields.read("cp")[parent_per_fragment]
+    np.testing.assert_array_equal(out.fields.read("cp"), expected)
+
+
+def test_face_cut_conserves_total_integrated_force():
+    """Sum of per-fragment force equals the whole-wall force (exactness)."""
+    ds = _wall(np.array([3.0, -2.0]))
+    out = face_cut(ds, FaceCutParams(z_intervals=[0.0, 1.0, 2.0], name="floor"))
+
+    fp = ForceContributionParams(nominal_area=1.0, directions=["y"])
+    parent_cf = force_contribution(ds, fp).fields.read("cf_y")
+    frag_cf = force_contribution(out, fp).fields.read("cf_y")
+
+    # Total integrated force is invariant under slicing (area partitioned,
+    # cp + normal inherited).
+    np.testing.assert_allclose(frag_cf.sum(axis=0), parent_cf.sum(axis=0), rtol=1e-9)
+
+
+def test_face_cut_is_exact_where_centroid_zoning_is_not():
+    """A triangle straddling the boundary splits, unlike centroid zoning.
+
+    The lower-left triangle [(0,0,0),(2,0,0),(2,0,2)] has centroid z = 2/3
+    (floor 0), but ~part of its area lies above z = 1. face_cut assigns
+    that upper part to floor 1; a centroid rule would put the whole
+    triangle in floor 0.
+    """
+    ds = _wall(np.array([1.0, 1.0]))
+    out = face_cut(ds, FaceCutParams(z_intervals=[0.0, 1.0, 2.0], name="floor"))
+
+    idx = out.groupings["floor"].indices
+    area_floor0 = out.elements.area[idx == 0].sum()
+    area_floor1 = out.elements.area[idx == 1].sum()
+    # Both floors receive real area; neither is the whole wall.
+    total = _parent_area(ds).sum()
+    assert 0.0 < area_floor0 < total
+    assert 0.0 < area_floor1 < total
+    assert area_floor0 + area_floor1 == pytest.approx(total, rel=1e-9)
+
+
+def test_face_cut_unassigned_policy():
+    # Cover only z in [0, 1): the top half of the wall falls outside.
+    ds = _wall(np.array([1.0, 1.0]))
+    dropped = face_cut(ds, FaceCutParams(z_intervals=[0.0, 1.0], unassigned_policy="drop"))
+    kept = face_cut(
+        ds, FaceCutParams(z_intervals=[0.0, 1.0], unassigned_policy="keep_as_unassigned")
+    )
+
+    assert (dropped.groupings["floor"].indices >= 0).all()
+    assert (kept.groupings["floor"].indices == -1).any()
+    # Dropping removes area; keeping retains the full wall.
+    assert kept.elements.area.sum() == pytest.approx(_parent_area(ds).sum(), rel=1e-9)
+    assert dropped.elements.area.sum() < kept.elements.area.sum()
+
+
+def test_face_cut_requires_normal():
+    ds = _wall(np.array([1.0, 1.0]))
+    no_normal = ds.model_copy(update={"elements": ElementMeta(area=ds.elements.area)})
+    with pytest.raises(ValueError, match="normal"):
+        face_cut(no_normal, FaceCutParams(z_intervals=[0.0, 1.0, 2.0]))
+
+
+def test_face_cut_requires_triangle_topology():
+    ds = _wall(np.array([1.0, 1.0]))
+    with pytest.raises(ValueError, match="triangle"):
+        face_cut(
+            ds.model_copy(update={"topology": None}),
+            FaceCutParams(z_intervals=[0.0, 1.0, 2.0]),
+        )
+
+
+def test_face_cut_registered_in_catalog():
+    from cfdmod.core.pipeline_yaml import op_info
+
+    info = op_info("face_cut")
+    assert info.produces == "surface"
+    assert info.consumes == ["surface"]
+    assert info.family == "source_create"
+    assert "normal" in info.requires_element_meta

--- a/tests/regroup/test_functions.py
+++ b/tests/regroup/test_functions.py
@@ -217,10 +217,10 @@ def _slice_triangles_naive(
 ):
     """Reference per-fragment slicer (the pre-vectorisation implementation).
 
-    Built directly on ``_slice_one_triangle`` so the vectorised
+    Built directly on ``slice_one_triangle`` so the vectorised
     ``slice_triangles_with_parents`` can be checked for exact parity.
     """
-    from cfdmod.regroup.functions import _slice_one_triangle
+    from cfdmod.geometry.triangle_slicing import slice_one_triangle as _slice_one_triangle
 
     cur_verts = tri_verts.astype(np.float64).copy()
     cur_normals = tri_normals.astype(np.float64).copy()


### PR DESCRIPTION
Closes #152.

## What

Adds the v3 `face_cut` data-source-creation op: it geometrically slices a `SurfaceDataSource`'s triangles along axis-aligned coordinates (`x/y/z_intervals`) and emits a new surface whose fragments each sit cleanly inside one slice, inherit their parent triangle's fields (piecewise-constant) and oriented normal, and recompute their own area/centroid.

This is the exact counterpart to centroid `zoning_grouping`: a triangle straddling a floor/zone boundary contributes its **real partial area** to each side, so `force_contribution` + `field_series_for_groups(agg="sum")` integrate exact force/moment per slice, unchanged.

## Design

- **Adapter, not new math.** Reuses the proven cut core (`slice_triangles_with_parents`), the same path the legacy `regroup` sliced mode uses.
- **Dependency-light extraction.** The pure-numpy primitives (`slice_triangle`, `triangulate_tri`, `slice_triangles_with_parents`, `bin_centroid_to_cell`, `build_geometry_from_fragments`) move to `cfdmod/geometry/triangle_slicing.py`. This keeps the op import path free of the heavy `cfdmod.io` stack (h5py/pandas/...) — verified by `tests/test_import_weight.py`. `regroup/functions.py` and `io/geometry/region_meshing.py` re-export from the new home; **behaviour unchanged** (existing regroup/region-meshing tests stay green, including the #137 bit-parity test).
- **Fields** are gathered per parent row via `FieldStore.read(elements=...)`, which works for both the memory and xdmf_h5 adapters.
- Region ids use the same raster convention (`ix + nx*iy + nx*ny*iz`, `lo <= c < hi`) as `zoning_grouping`, so the two ops are interchangeable in a template.

## Tests (`tests/core/ops/data_source_create/test_face_cut.py`)

- Exact area partition (fragments sum to the parent area, no duplication/loss)
- Field inheritance (each fragment's timeseries == its parent's row, cross-checked against the cut core)
- **Total integrated force is conserved** under slicing (area partitioned, cp + normal inherited)
- **Exactness vs centroid zoning** — both floors receive real area from a straddling triangle
- `unassigned_policy` drop vs keep
- `requires_element_meta` (normal) and triangle-topology guards
- Catalog registration (`produces == "surface"`)

## Scope / follow-ups

- **Notebook swap deferred.** #152 named `notebooks/high_rise/pp/pressure.py` as the swap target; that file does not exist on `main` — it lands in PR #149 (high-rise suite) and currently uses the approximate centroid `zoning_grouping` this op replaces. Swapping it to `face_cut` (keeping centroid as the fast/approx option) is a clean follow-up once #149 merges.
- **Lazy h5 gather** (a `GatherFieldStore` view) is intentionally not built here; the eager per-parent gather matches every sibling op and works on both adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)