### PR TITLE
docs: fix broken coefficient cross-links + unify v3 API vocabulary

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -107,35 +107,35 @@ Recipe configs
 ==============
 
 The pressure and wind recipes ship as small-data Pydantic configs under
-:mod:`cfdmod.core.recipes`; each mirrors one legacy ``*CaseConfig`` and
+:mod:`cfdmod.recipes`; each mirrors one legacy ``*CaseConfig`` and
 builds the equivalent pipeline. Example templates live under
 ``fixtures/tests/pressure/templates/``.
 
-.. autoclass:: cfdmod.core.recipes.CpRecipeConfig
+.. autoclass:: cfdmod.recipes.CpRecipeConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: cfdmod.core.recipes.CfRecipeConfig
+.. autoclass:: cfdmod.recipes.CfRecipeConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: cfdmod.core.recipes.CmRecipeConfig
+.. autoclass:: cfdmod.recipes.CmRecipeConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: cfdmod.core.recipes.CeRecipeConfig
+.. autoclass:: cfdmod.recipes.CeRecipeConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: cfdmod.core.recipes.S1RecipeConfig
+.. autoclass:: cfdmod.recipes.S1RecipeConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: cfdmod.core.recipes.DynamicAnalysisConfig
+.. autoclass:: cfdmod.recipes.DynamicAnalysisConfig
    :members:
    :show-inheritance:
 
-.. autoclass:: cfdmod.core.recipes.PedestrianComfortConfig
+.. autoclass:: cfdmod.recipes.PedestrianComfortConfig
    :members:
    :show-inheritance:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,6 +40,14 @@ or in Python, over any storage backend:
    template = load_template("path/to/cp.yaml")
    bindings = run_template(template, storage=XdmfH5Storage(root="."))
 
+.. note::
+   ``cfdmod run <template>`` is the Python snippet above wrapped for
+   convenience: it loads the template and runs it over an ``XdmfH5Storage``
+   rooted at the template's directory (exposed in the library as
+   ``cfdmod.recipes.run_yaml``). Call ``load_template`` + ``run_template``
+   directly when you need a different storage backend -- for example
+   ``MemoryStorage`` in tests.
+
 Example Cp / Cf / Cm / Ce templates ship under
 ``fixtures/tests/pressure/templates/``. The full worked example lives at
 ``notebooks/process_container_pack.ipynb`` in the repository; the

--- a/docs/source/use_cases/pressure/coefficients/force_coefficient.rst
+++ b/docs/source/use_cases/pressure/coefficients/force_coefficient.rst
@@ -54,7 +54,7 @@ If its center lies inside the sub-body volume, then it belongs to it.
 The result is a sectionated body in different **sub-bodies for each interval**.
 When sectioning the body, the respective nominal area should be the same as the sub-body nominal area.
 
-.. note:: Check out the `definitions <./definitions.rst>`_ section for more information about **surface, body and sub-body** definitions.
+.. note:: Check out the `concepts <../concepts.rst>`_ section for more information about **surface, body and sub-body** definitions.
 
 Like the other coefficients, we can apply statistical analysis to the net force coefficient.
 
@@ -113,7 +113,7 @@ Data format
         This also guarantee that even if different bodies lie on the same region, the interpreted region for each of them will be different
 
 .. note::
-    For more information about the normalized time scale (:math:`t^*`), check the `Normalization section <./normalization.rst>`_ 
+    For more information about the normalized time scale (:math:`t^*`), check the `Time Normalization section <./time_normalization.rst>`_
 
 .. list-table:: :math:`C_{fx}(t)`
    :widths: 15 15 15 15 15

--- a/docs/source/use_cases/pressure/coefficients/index.rst
+++ b/docs/source/use_cases/pressure/coefficients/index.rst
@@ -16,7 +16,7 @@ There are several different coefficients, that are commonly used in the wind ind
 * `Pressure Coefficient <./pressure_coefficient.rst>`_: It is a fundamental adimensionalization of the pressure data. It is obtained by dividing a pressure difference by the **dynamic pressure**.
 * `Shape Coefficient <./shape_coefficient.rst>`_: It is equivalent to a resulting pressure coefficient over an **area of interest**. It is used to combine the pressure effects over the area, in a way to **sum the exerted force in each triangle** inside this area. Some peaks in each triangle **may cancel each other** in when calculating the shape coefficient.
 * `Force Coefficient <./force_coefficient.rst>`_: It is a general adimensionalization of the resulting **wind induced force** over a body. It is calculated by summing the resulting force of each triangle, and dividing it by a **representative area**.
-* `Momentum Coefficient <./momentum_coefficient.rst>`_: It is a general adimensionalization of the resulting **wind induced momentum** over a body. It is calculated by summing the resulting momentum of each triangle, and dividing it by a **representative volume**. The anchor point to define the momentum lever is an **arbitrary point for the whole body**.
+* `Moment Coefficient <./moment_coefficient.rst>`_: It is a general adimensionalization of the resulting **wind induced momentum** over a body. It is calculated by summing the resulting momentum of each triangle, and dividing it by a **representative volume**. The anchor point to define the momentum lever is an **arbitrary point for the whole body**.
 
 Geometry Artifact
 =================

--- a/docs/source/use_cases/pressure/coefficients/moment_coefficient.rst
+++ b/docs/source/use_cases/pressure/coefficients/moment_coefficient.rst
@@ -58,7 +58,7 @@ If its center lies inside the sub-body volume, then it belongs to it.
 The result is a sectionated body in different **sub-bodies for each interval**.
 When sectioning the body, the respective nominal volume should be the same as the sub-body nominal volume.
 
-.. note:: Check out the `definitions <./definitions.rst>`_ section for more information about **surface, body and sub-body** definitions.
+.. note:: Check out the `concepts <../concepts.rst>`_ section for more information about **surface, body and sub-body** definitions.
 
 Like the other coefficients, we can apply statistical analysis to the moment coefficient.
 
@@ -134,7 +134,7 @@ Data format
         This also guarantee that even if different bodies lie on the same region, the interpreted region for each of them will be different
 
 .. note::
-    For more information about the normalized time scale (:math:`t^*`), check the `Normalization section <./normalization.rst>`_ 
+    For more information about the normalized time scale (:math:`t^*`), check the `Time Normalization section <./time_normalization.rst>`_
 
 .. list-table:: :math:`C_{mx}(t)`
    :widths: 15 15 15 15 15

--- a/docs/source/use_cases/pressure/coefficients/pressure_coefficient.rst
+++ b/docs/source/use_cases/pressure/coefficients/pressure_coefficient.rst
@@ -68,7 +68,7 @@ Data format
 ===========
 
 .. note::
-    For more information about the normalized time scale (:math:`t^*`), check the `Normalization section <./normalization.rst>`_ 
+    For more information about the normalized time scale (:math:`t^*`), check the `Time Normalization section <./time_normalization.rst>`_
 
 .. list-table:: :math:`c_p(t)`
    :widths: 20 20 20 20 20

--- a/docs/source/use_cases/pressure/coefficients/shape_coefficient.rst
+++ b/docs/source/use_cases/pressure/coefficients/shape_coefficient.rst
@@ -113,7 +113,7 @@ Data format
         This also guarantee that even if different surfaces lie on the same region, the interpreted region for each of them will be different
 
 .. note::
-    For more information about the normalized time scale (:math:`t^*`), check the `Normalization section <./normalization.rst>`_ 
+    For more information about the normalized time scale (:math:`t^*`), check the `Time Normalization section <./time_normalization.rst>`_
 
 .. list-table:: :math:`C_e(t)`
    :widths: 15 15 15 15


### PR DESCRIPTION
## What

Concrete doc-accuracy pass toward #124. An audit of `docs/source/` found the tree is **already substantively migrated to v3** (no doc imports a removed v2 symbol as live code), so the issue's original "full rewrite" framing is stale. This PR lands only the concrete, verifiable fixes:

1. **7 broken intra-doc cross-links** repointed at files that exist:
   - `./momentum_coefficient.rst` -> `./moment_coefficient.rst` (coefficients index)
   - `./normalization.rst` -> `./time_normalization.rst` (cp / ce / cf / cm pages)
   - `./definitions.rst` -> `../concepts.rst` (cf / cm "definitions" note)
2. **Import-path style unified** on the public `cfdmod.recipes` path in `api_reference.rst` (was `cfdmod.core.recipes`), matching the migration guide.
3. **API vocabulary reconciled**: a quickstart note ties the `cfdmod run` CLI to the `load_template` + `run_template` Python API and to `cfdmod.recipes.run_yaml`, so CLI and library read as one surface.

## Verification

- `sphinx-build` succeeds; no new warnings (the 67 remaining are pre-existing `ipython3` notebook-lexer noise + the unrelated `html_baseurl` sitemap note).
- `cfdmod.recipes.*` autoclass targets confirmed to resolve (no autodoc import warnings).
- All edited files are ASCII-only.

## Out of scope (deferred)

Per an explicit scope decision, the larger external-user items from #124 are **not** in this PR: new onboarding pages (install / first-run / reading-outputs-into-pandas+ParaView) and wiring `sphinx.ext.doctest` so snippets are tested. Tracked as remaining work on #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)