### PR TITLE
chore: remove client identifiers from high-rise validator/docs

### DIFF
--- a/notebooks/high_rise/README.md
+++ b/notebooks/high_rise/README.md
@@ -77,10 +77,11 @@ of the suite itself. Regenerate the notebooks after editing them with
 
 - Cf/Cm use **explicit reference-area** normalisation (`nominal_area` /
   `nominal_volume`), per the 3.2 decision -- not the legacy per-region
-  bounding-box area, so values differ from the 067 deliverables.
+  bounding-box area, so values differ from the earlier per-region deliverables.
 - Numerical validation currently runs on the in-repo `galpao` / `caarc` /
-  `pitot_inlet` fixtures. Case 067 has config but no raw pressure data on disk;
-  case 063 (Codeme) has real high-rise raw data for a real-case run.
+  `pitot_inlet` fixtures. One real consulting case has config but no raw
+  pressure data on disk; another has real high-rise raw data for an
+  end-to-end run.
 - A YAML-template batch path (`cfdmod run`) exists for Cp/Cf/Cm/Ce, but the
   per-floor Cf template with dynamic dynamic-pressure is a follow-up (templates
   currently bake a fixed scale factor).

--- a/notebooks/high_rise/_validate_pp.py
+++ b/notebooks/high_rise/_validate_pp.py
@@ -1,10 +1,11 @@
 """Validate the pp/ helper package end-to-end on real in-repo fixtures.
 
 Run: uv run python notebooks/high_rise/_validate_pp.py
-Exercises HighRiseCase (against the real 067 case_data), inflow profile
-detection + figures (pitot_inlet fixture), the Cp -> per-floor Cf/Cm pressure
-wiring, the dynamic-response recipe wiring, and the facade / structure mesh-field
-snapshots (galpao fixture + its lnas mesh).
+Exercises HighRiseCase (against a real case_data dir if CFDMOD_HR_VALIDATE_CASE_DATA
+points at one, else a synthetic case), inflow profile detection + figures
+(pitot_inlet fixture), the Cp -> per-floor Cf/Cm pressure wiring, the
+dynamic-response recipe wiring, and the facade / structure mesh-field snapshots
+(galpao fixture + its lnas mesh).
 """
 
 from __future__ import annotations
@@ -35,18 +36,22 @@ def check(label: str, cond: bool, detail: str = "") -> None:
 
 
 def section_case() -> pp.HighRiseCase:
-    print("A. HighRiseCase (real 067 case_data)")
-    case_data = pathlib.Path(
-        "/data/eng/consulting/067_CampoGrande_ClementePereira/post_processing/pp_config/case_data"
-    )
-    if not case_data.exists():
-        print("  (067 case_data not mounted; skipping real-config parse)")
+    print("A. HighRiseCase")
+    # Point CFDMOD_HR_VALIDATE_CASE_DATA at a real case_data dir to parse it;
+    # otherwise fall back to a synthetic case (no client data is committed).
+    import os
+
+    env = os.environ.get("CFDMOD_HR_VALIDATE_CASE_DATA")
+    case_data = pathlib.Path(env) if env else None
+    if case_data is None or not case_data.exists():
+        print("  (no CFDMOD_HR_VALIDATE_CASE_DATA case_data; using synthetic case)")
         return _synthetic_case()
-    case = pp.HighRiseCase.from_case_data(case_data, "params_cat3.yaml")
-    check("reference_height == 70", case.reference_height == 70.0, f"H={case.reference_height}")
-    check("nominal_area == 486.5", case.nominal_area == 486.5)
-    check("n_floors == 26", case.n_floors == 26, f"n_floors={case.n_floors}")
-    check("simul U_H ~ 29.91", abs(case.simul_reference_velocity - 29.914) < 1e-2)
+    params = os.environ.get("CFDMOD_HR_VALIDATE_PARAMS", "params_cat3.yaml")
+    case = pp.HighRiseCase.from_case_data(case_data, params)
+    check("reference_height positive", case.reference_height > 0, f"H={case.reference_height}")
+    check("nominal_area positive", case.nominal_area > 0)
+    check("n_floors > 1", case.n_floors > 1, f"n_floors={case.n_floors}")
+    check("simul U_H finite", np.isfinite(case.simul_reference_velocity))
     q0 = case.dynamic_pressure
     case2 = case.with_reference_velocity(32.0)
     check(
@@ -61,13 +66,13 @@ def section_case() -> pp.HighRiseCase:
 def _synthetic_case() -> pp.HighRiseCase:
     return pp.HighRiseCase(
         name="synthetic",
-        reference_height=70.0,
-        characteristic_length=6.95,
-        basic_wind_speed=38.0,
-        simul_reference_velocity=29.914,
-        nominal_area=486.5,
-        nominal_volume=3381.175,
-        floor_heights=[0.0, 10.0, 20.0, 30.0],
+        reference_height=100.0,
+        characteristic_length=20.0,
+        basic_wind_speed=40.0,
+        simul_reference_velocity=30.0,
+        nominal_area=500.0,
+        nominal_volume=10000.0,
+        floor_heights=[0.0, 25.0, 50.0, 75.0, 100.0],
     )
 
 

--- a/notebooks/high_rise/pp/case.py
+++ b/notebooks/high_rise/pp/case.py
@@ -89,7 +89,7 @@ class HighRiseCase(BaseModel):
     ) -> "HighRiseCase":
         """Build from a ``case_data/`` dir containing global_data.json + a params yaml.
 
-        Parses the 067-style params layout (top-level ``anchors`` plus
+        Parses the consulting params layout (top-level ``anchors`` plus
         ``pressure_coefficient`` / ``force_coefficient`` / ``moment_coefficient``
         blocks). Missing optional fields fall back to sensible defaults.
         """


### PR DESCRIPTION
## Why

A data-hygiene audit found a real consulting **client identifier committed on `main`**: `notebooks/high_rise/_validate_pp.py` hardcoded the path `/data/eng/consulting/067_CampoGrande_ClementePereira/...` and asserted that specific building's exact dimensions (H, nominal area, floor count, U_H). The README and a docstring also named a client ("Codeme") and case numbers. These predate the recent high-rise work but should not be in the repo.

## What

- `_validate_pp.py`: the real-case check now reads the `case_data` dir from `CFDMOD_HR_VALIDATE_CASE_DATA` (falls back to a synthetic case), and asserts generic sanity (positive/finite) instead of one building's numbers. No client path or dimensions committed.
- `_synthetic_case()`: round, obviously-synthetic values (H=100, area=500, ...), not a real building's.
- `README.md` / `pp/case.py`: client name ("Codeme") and case-number references genericized.

`caarc` is left as-is -- it's the public CAARC academic tall-building benchmark, not a client.

Verified: `uv run python notebooks/high_rise/_validate_pp.py` passes on the synthetic path; a repo grep for the client tokens returns nothing.

Generated with Claude Code.

Closes #167.
