### PR TITLE
feat(inflow_report): NBR/EU code-standard profile comparison + directional U_H

### DIFF
--- a/cfdmod/inflow_report.py
+++ b/cfdmod/inflow_report.py
@@ -12,11 +12,18 @@ Figures produced per profile:
 and a scalar integral length scale estimate. The high-rise sequence also uses
 :func:`reference_velocity` to read U_H off the mean profile at the interest
 height.
+
+For code validation, :func:`plot_profile_vs_code` overlays the simulated mean
+velocity / turbulence intensity on the NBR 6123 and EN 1991-1-4 analytical
+profiles, :func:`directional_reference_speed` returns the design U_H per wind
+direction from an analytical wind profile, and :func:`eu_integral_length_scale`
+gives the EN 1991-1-4 length-scale theory to compare against.
 """
 
 from __future__ import annotations
 
 import dataclasses
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -30,6 +37,11 @@ from cfdmod.inflow import (
     calculate_turbulence_intensity,
 )
 from cfdmod.plot_config import new_axes
+
+if TYPE_CHECKING:
+    from cfdmod.analytical.wind_profile import WindProfile_EU, WindProfile_NBR
+    from cfdmod.s1.plotting import Languages
+    from cfdmod.s1.profile import EUCat, NBRCat
 
 
 @dataclasses.dataclass(frozen=True)
@@ -185,3 +197,126 @@ def plot_spectrum(
     )
     ax.loglog(spec[f"f ({component})"], spec[f"S ({component})"], lw=1.2)
     return fig
+
+
+# -- code-standard comparison (NBR 6123 / EN 1991-1-4) ---------------------
+
+
+def directional_reference_speed(
+    wind_profile: "WindProfile_NBR | WindProfile_EU",
+    *,
+    height: float,
+    recurrence_period: float = 50,
+    directions: list[float] | None = None,
+    use_kd: bool = False,
+) -> pd.Series:
+    """Design reference speed U_H per wind direction from an analytical profile.
+
+    Thin loop over :meth:`WindProfile_NBR.get_U_H` / :meth:`WindProfile_EU.get_U_H`
+    (built from a ``wind_analysis_{NBR,EU}.csv`` via their ``build`` classmethods).
+    Returns a Series indexed by direction (degrees), sorted ascending; take
+    ``.max()`` for the governing speed.
+    """
+    if directions is None:
+        directions = wind_profile.directional_data["wind_direction"].tolist()
+    speeds = {
+        float(d): float(
+            wind_profile.get_U_H(
+                height=height,
+                direction=float(d),
+                recurrence_period=recurrence_period,
+                use_kd=use_kd,
+            )
+        )
+        for d in directions
+    }
+    return pd.Series(speeds, name="U_H").sort_index()
+
+
+def plot_profile_vs_code(
+    profile: ProfileLine,
+    inflow: InflowData,
+    reference_height: float,
+    *,
+    cat_eu: "EUCat | None" = None,
+    cat_nbr: "NBRCat | None" = None,
+    component: str = "ux",
+    Fr: float = 0.65,
+    language: "Languages" = "pt-br",
+):
+    """Mean velocity + turbulence intensity vs the NBR 6123 / EN 1991-1-4 curves.
+
+    Delegates to :func:`cfdmod.s1.plotting.plot_numerical_and_analytical_vel_profile`,
+    feeding it the simulated profile (mean ``u(z)``, ``Iu(z)`` and ``u_ref`` at
+    ``reference_height``). Returns ``(fig, ax)`` where ``ax`` is the 2-panel array.
+    """
+    from cfdmod.s1.plotting import plot_numerical_and_analytical_vel_profile
+
+    means = calculate_mean_velocity(inflow, for_components=[component])
+    ti = calculate_turbulence_intensity(inflow, for_components=[component])
+    u_num = _profile_series(profile, means, f"{component}_mean")
+    iu_num = _profile_series(profile, ti, f"I_{component}")
+    u_ref = float(np.interp(reference_height, profile.z, u_num))
+    return plot_numerical_and_analytical_vel_profile(
+        z=profile.z,
+        H=reference_height,
+        u_num=u_num,
+        Iu_num=iu_num,
+        u_num_ref=u_ref,
+        cat_eu=cat_eu,
+        cat_nbr=cat_nbr,
+        Fr=Fr,
+        language=language,
+    )
+
+
+def integral_length_scale_profile(
+    inflow: InflowData,
+    profile: ProfileLine,
+    *,
+    component: str = "ux",
+) -> np.ndarray:
+    """Integral length scale at each height of ``profile`` (NaN where unresolved)."""
+    means = calculate_mean_velocity(inflow, for_components=[component])
+    u = _profile_series(profile, means, f"{component}_mean")
+    return np.array(
+        [
+            integral_length_scale(inflow, int(pi), float(um), component=component)
+            for pi, um in zip(profile.point_idx, u)
+        ]
+    )
+
+
+def eu_integral_length_scale(
+    z: np.ndarray,
+    z0: float,
+    *,
+    z_min: float = 1.0,
+) -> np.ndarray:
+    """EN 1991-1-4 (B.1) turbulence length scale L(z) = L_t (z/z_t)^alpha.
+
+    L_t = 300 m, z_t = 200 m, alpha = 0.67 + 0.05 ln(z0); z is floored at
+    ``z_min`` (below which L is held constant, per the code).
+    """
+    z_arr = np.asarray(z, dtype=float)
+    alpha = 0.67 + 0.05 * np.log(z0)
+    return 300.0 * (np.maximum(z_arr, z_min) / 200.0) ** alpha
+
+
+def plot_integral_length_scale(
+    z: np.ndarray,
+    L_num: np.ndarray,
+    H: float,
+    *,
+    L_theory: np.ndarray | None = None,
+    language: "Languages" = "pt-br",
+):
+    """Numerical integral length scale (and optional theory) as L/H vs z/H."""
+    title = {"pt-br": "Escala integral de comprimento", "en": "Integral length scale"}[language]
+    fig, ax = new_axes(xlabel=r"$l_{int} / H$", ylabel="$z / H$", title=title)
+    z_arr = np.asarray(z, dtype=float)
+    ax.plot(np.asarray(L_num, dtype=float) / H, z_arr / H, "-o", ms=3, label="AeroSim")
+    if L_theory is not None:
+        ax.plot(np.asarray(L_theory, dtype=float) / H, z_arr / H, "--k", label="EN 1991-1-4")
+    ax.legend(loc="best", frameon=False)
+    return fig, ax

--- a/tests/test_inflow_report.py
+++ b/tests/test_inflow_report.py
@@ -1,0 +1,85 @@
+"""Tests for the code-standard comparison helpers in cfdmod.inflow_report."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import pathlib  # noqa: E402
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+from cfdmod import inflow_report as ir  # noqa: E402
+from cfdmod.analytical import WindProfile_NBR  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+INFLOW_FIX = REPO / "fixtures" / "tests" / "inflow" / "pitot_inlet"
+
+
+def _nbr_profile() -> WindProfile_NBR:
+    df = pd.DataFrame(
+        {
+            "wind_direction": [0.0, 90.0, 180.0, 270.0],
+            "I": [0.0] * 4,
+            "II": [1.0] * 4,
+            "III": [0.0] * 4,
+            "IV": [0.0] * 4,
+            "V": [0.0] * 4,
+            "Kd": [1.0, 1.2, 1.0, 1.0],
+        }
+    )
+    return WindProfile_NBR(directional_data=df, V0=35.0)
+
+
+def test_directional_reference_speed_all_directions():
+    s = ir.directional_reference_speed(_nbr_profile(), height=100.0, recurrence_period=50)
+    assert list(s.index) == [0.0, 90.0, 180.0, 270.0]
+    assert (s.to_numpy() > 0).all()
+    assert s.max() == pytest.approx(float(s.to_numpy().max()))
+
+
+def test_directional_reference_speed_subset_and_kd():
+    wp = _nbr_profile()
+    base = ir.directional_reference_speed(wp, height=50.0, directions=[90.0], use_kd=False)
+    with_kd = ir.directional_reference_speed(wp, height=50.0, directions=[90.0], use_kd=True)
+    # direction 90 has Kd=1.2, so enabling Kd scales U_H up by 1.2
+    assert with_kd.loc[90.0] == pytest.approx(1.2 * base.loc[90.0], rel=1e-6)
+
+
+def test_eu_integral_length_scale_monotone_and_positive():
+    z = np.array([10.0, 50.0, 100.0, 200.0, 300.0])
+    L = ir.eu_integral_length_scale(z, z0=0.3)
+    assert np.all(L > 0)
+    assert np.all(np.diff(L) > 0)
+    assert L[np.argmin(np.abs(z - 200.0))] == pytest.approx(300.0, rel=1e-6)  # L(z_t)=L_t
+
+
+def test_plot_integral_length_scale_returns_fig_ax():
+    z = np.linspace(1.0, 200.0, 20)
+    L = ir.eu_integral_length_scale(z, z0=0.3)
+    fig, ax = ir.plot_integral_length_scale(z, L, H=200.0, L_theory=L)
+    assert fig is not None and ax is not None
+
+
+@pytest.mark.integration
+def test_profile_vs_code_on_pitot_fixture():
+    if not (INFLOW_FIX / "hist_series.csv").exists():
+        pytest.skip("pitot_inlet fixture not present")
+    from cfdmod.inflow import InflowData
+
+    inflow = InflowData.from_files(INFLOW_FIX / "hist_series.csv", INFLOW_FIX / "points.csv")
+    profiles = ir.detect_profiles(inflow, min_points=3)
+    assert profiles
+    prof = profiles[0]
+    ref_h = float(np.median(prof.z))
+
+    fig, ax = ir.plot_profile_vs_code(prof, inflow, ref_h, cat_eu="III")
+    assert fig is not None and len(ax) == 2
+
+    scales = ir.integral_length_scale_profile(inflow, prof)
+    assert scales.shape == prof.z.shape


### PR DESCRIPTION
First slice of the post-processing port (#169), priority 1 (inflow).

Wires the already-ported analytical wind profiles + s1 profile plots into the
`inflow_report` helpers so notebooks get code validation directly:

- `directional_reference_speed()` - design U_H per wind direction from a
  `WindProfile_NBR`/`WindProfile_EU` (built from `wind_analysis_{NBR,EU}.csv`).
- `plot_profile_vs_code()` - simulated mean velocity + turbulence intensity vs
  the NBR 6123 / EN 1991-1-4 curves.
- `integral_length_scale_profile()` - per-height integral length scale.
- `eu_integral_length_scale()` - EN 1991-1-4 (B.1) length-scale theory.
- `plot_integral_length_scale()` - L/H vs z/H, numerical + optional theory.

Tests: `tests/test_inflow_report.py` (5, incl. a pitot_inlet integration check). ruff clean.

Stacked on `chore/reorg-notebooks` (#168) since the modules land there; retarget to main once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)