### PR TITLE
feat(report): DebugWriter.save_csv + idempotency guard; plot_config.set_style_tech

### DIFF
--- a/cfdmod/plot_config.py
+++ b/cfdmod/plot_config.py
@@ -62,3 +62,30 @@ def new_axes(xlabel: str = "", ylabel: str = "", title: str = ""):
 
 def close(fig) -> None:
     plt.close(fig)
+
+
+def set_style_tech() -> None:
+    """Tech-report figure style: whitegrid, markers-only lines, thin spines.
+
+    Meant for the code-comparison / deliverable figures (numerical points over
+    analytical code curves), where a marker-only numerical series reads better
+    than a connected line. Robust to matplotlib's seaborn-style rename.
+    """
+    for style in ("seaborn-v0_8-whitegrid", "seaborn-whitegrid"):
+        if style in plt.style.available:
+            plt.style.use(style)
+            break
+    plt.rcParams.update(
+        {
+            "font.family": "sans-serif",
+            "font.size": 10,
+            "mathtext.fontset": "custom",
+            "legend.facecolor": "white",
+            "legend.edgecolor": "none",
+            "lines.linestyle": "",
+            "lines.linewidth": 2,
+            "lines.markersize": 6,
+            "lines.markeredgecolor": "none",
+            "axes.edgecolor": "black",
+        }
+    )

--- a/cfdmod/report.py
+++ b/cfdmod/report.py
@@ -54,13 +54,45 @@ class DebugWriter:
         return self._resolve(self.deliverables_dir, name)
 
     def savefig(
-        self, fig, name: str, *, deliverable: bool = False, **savefig_kwargs
+        self,
+        fig,
+        name: str,
+        *,
+        deliverable: bool = False,
+        skip_if_exists: bool = False,
+        **savefig_kwargs,
     ) -> pathlib.Path:
-        """Save a matplotlib figure to debug (default) or deliverables, return the path."""
+        """Save a matplotlib figure to debug (default) or deliverables, return the path.
+
+        With ``skip_if_exists`` the write is skipped when the target already
+        exists (idempotent re-runs over an expensive fan-out).
+        """
         path = self.deliverable_path(name) if deliverable else self.debug_path(name)
+        if skip_if_exists and path.exists():
+            return path
         savefig_kwargs.setdefault("bbox_inches", "tight")
         savefig_kwargs.setdefault("dpi", 150)
         fig.savefig(path, **savefig_kwargs)
+        return path
+
+    def save_csv(
+        self,
+        df,
+        name: str,
+        *,
+        deliverable: bool = False,
+        skip_if_exists: bool = False,
+        index: bool = False,
+        **to_csv_kwargs,
+    ) -> pathlib.Path:
+        """Save a DataFrame to debug (default) or deliverables as CSV, return the path.
+
+        ``skip_if_exists`` mirrors :meth:`savefig` for idempotent re-runs.
+        """
+        path = self.deliverable_path(name) if deliverable else self.debug_path(name)
+        if skip_if_exists and path.exists():
+            return path
+        df.to_csv(path, index=index, **to_csv_kwargs)
         return path
 
     @staticmethod

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,58 @@
+"""Tests for cfdmod.report.DebugWriter and the plot_config tech style."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import matplotlib.pyplot as plt  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+from cfdmod import plot_config  # noqa: E402
+from cfdmod.report import DebugWriter  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def test_save_csv_writes_and_roundtrips(tmp_path):
+    dbg = DebugWriter(tmp_path, stage="cf", version="v1")
+    df = pd.DataFrame({"floor": [1, 2], "cf_x": [0.5, 0.7]})
+    path = dbg.save_csv(df, "tables/loads.csv")
+    assert path.exists()
+    assert path == tmp_path / "debug" / "v1" / "cf" / "tables" / "loads.csv"
+    back = pd.read_csv(path)
+    assert list(back.columns) == ["floor", "cf_x"]
+    assert back.shape == (2, 2)
+
+
+def test_save_csv_deliverable_root(tmp_path):
+    dbg = DebugWriter(tmp_path, stage="cf", version="v1")
+    path = dbg.save_csv(pd.DataFrame({"a": [1]}), "x.csv", deliverable=True)
+    assert path == tmp_path / "deliverables" / "v1" / "cf" / "x.csv"
+
+
+def test_skip_if_exists_does_not_overwrite(tmp_path):
+    dbg = DebugWriter(tmp_path, stage="cf", version="v1")
+    path = dbg.save_csv(pd.DataFrame({"a": [1]}), "x.csv")
+    original = path.read_text()
+    # Second call with different content but skip_if_exists must NOT overwrite.
+    dbg.save_csv(pd.DataFrame({"a": [999]}), "x.csv", skip_if_exists=True)
+    assert path.read_text() == original
+
+
+def test_savefig_skip_if_exists(tmp_path):
+    dbg = DebugWriter(tmp_path, stage="inflow", version="v1")
+    fig = plt.figure()
+    p1 = dbg.savefig(fig, "f.png")
+    mtime = p1.stat().st_mtime_ns
+    dbg.savefig(fig, "f.png", skip_if_exists=True)
+    assert p1.stat().st_mtime_ns == mtime  # unchanged
+    plt.close(fig)
+
+
+def test_set_style_tech_applies_marker_style():
+    plot_config.set_style_tech()
+    assert plt.rcParams["lines.linestyle"] == ""
+    assert plt.rcParams["lines.markersize"] == 6


### PR DESCRIPTION
Part of the post-processing port (#169). Adds `DebugWriter.save_csv`, a `skip_if_exists` idempotency guard on `savefig`/`save_csv` (the notebooks' `_guard` pattern), and `plot_config.set_style_tech()`. Tests in `tests/test_report.py` (5). ruff clean. Stacked on #168.