### PR TITLE
feat(mesh_field): sample field along a line + moving-average window stats

### DIFF
--- a/cfdmod/mesh_field.py
+++ b/cfdmod/mesh_field.py
@@ -149,6 +149,79 @@ def facade_index_per_triangle(groups: dict[str, np.ndarray], n_tri: int) -> np.n
     return out
 
 
+# -- field sampling along a line + time-window stats -----------------------
+
+
+def triangle_centroids(geometry) -> np.ndarray:
+    """Per-triangle centroids ``(n_tri, 3)`` from an ``LnasGeometry``."""
+    tris = np.asarray(geometry.triangle_vertices, dtype=np.float64)  # (n_tri, 3, 3)
+    return tris.mean(axis=1)
+
+
+def sample_field_along_line(
+    geometry,
+    field: np.ndarray,
+    p1,
+    p2,
+    *,
+    n: int = 100,
+):
+    """Sample a per-triangle ``field`` along the segment ``p1 -> p2``.
+
+    Each of ``n`` evenly spaced points takes the value of the nearest triangle
+    (by centroid, via a KD-tree). Returns a DataFrame with the arc length ``s``,
+    the sample coordinates ``x/y/z`` and ``value`` -- e.g. facade pressure vs
+    height by sampling a vertical line down a facade.
+    """
+    import pandas as pd
+    from scipy.spatial import cKDTree
+
+    field = np.asarray(field, dtype=np.float64)
+    p1 = np.asarray(p1, dtype=np.float64)
+    p2 = np.asarray(p2, dtype=np.float64)
+    t = np.linspace(0.0, 1.0, n)
+    pts = p1[None, :] + t[:, None] * (p2 - p1)[None, :]  # (n, 3)
+
+    tree = cKDTree(triangle_centroids(geometry))
+    _, idx = tree.query(pts)
+    s = t * float(np.linalg.norm(p2 - p1))
+    return pd.DataFrame(
+        {"s": s, "x": pts[:, 0], "y": pts[:, 1], "z": pts[:, 2], "value": field[idx]}
+    )
+
+
+def moving_average_stats(series: np.ndarray, dt: float, window_s: float) -> dict:
+    """Rolling-window mean of a signal plus its peak stats.
+
+    ``window_s`` is the averaging window in the series' time units; the window
+    width in samples is ``round(window_s / dt)``. Returns ``mean`` (of the raw
+    series), the smoothed series ``ma``, and ``ma_max`` / ``ma_min`` (the peak
+    and trough of the moving average) -- the "peak of the N-second moving
+    average" used for facade design pressures.
+    """
+    series = np.asarray(series, dtype=np.float64)
+    if series.size == 0:
+        return {
+            "mean": float("nan"),
+            "window": 0,
+            "ma": series,
+            "ma_max": float("nan"),
+            "ma_min": float("nan"),
+        }
+    w = max(1, int(round(window_s / dt)))
+    if series.size < w:
+        ma = np.array([series.mean()])
+    else:
+        ma = np.convolve(series, np.ones(w) / w, mode="valid")
+    return {
+        "mean": float(series.mean()),
+        "window": w,
+        "ma": ma,
+        "ma_max": float(ma.max()),
+        "ma_min": float(ma.min()),
+    }
+
+
 def has_pyvista() -> bool:
     """True when the optional ``[vtk]`` extra (pyvista + vtk) is importable."""
     try:

--- a/tests/test_mesh_field_sampling.py
+++ b/tests/test_mesh_field_sampling.py
@@ -1,0 +1,65 @@
+"""Tests for the mesh_field sampling + time-window stats helpers."""
+
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+
+from cfdmod import mesh_field
+
+pytestmark = pytest.mark.unit
+
+
+def _geometry(triangle_vertices: np.ndarray):
+    """Minimal LnasGeometry stand-in: only .triangle_vertices is used."""
+    return types.SimpleNamespace(triangle_vertices=triangle_vertices)
+
+
+def _three_tris_along_x():
+    # Three tiny triangles with centroids at x = 0, 1, 2 (y=z=0).
+    def tri(cx):
+        return [[cx - 0.1, 0.0, 0.0], [cx + 0.1, 0.0, 0.0], [cx, 0.1, 0.0]]
+
+    return np.array([tri(0.0), tri(1.0), tri(2.0)], dtype=float)
+
+
+def test_triangle_centroids():
+    geom = _geometry(_three_tris_along_x())
+    c = mesh_field.triangle_centroids(geom)
+    assert c.shape == (3, 3)
+    assert np.allclose(c[:, 0], [0.0, 1.0, 2.0], atol=1e-9)
+
+
+def test_sample_field_along_line_picks_nearest_triangle():
+    geom = _geometry(_three_tris_along_x())
+    field = np.array([10.0, 20.0, 30.0])
+    df = mesh_field.sample_field_along_line(geom, field, (0.0, 0.0, 0.0), (2.0, 0.0, 0.0), n=5)
+    assert list(df.columns) == ["s", "x", "y", "z", "value"]
+    assert df.shape[0] == 5
+    # endpoints hit tri0 (10) and tri2 (30); midpoint hits tri1 (20)
+    assert df["value"].iloc[0] == 10.0
+    assert df["value"].iloc[-1] == 30.0
+    assert df["value"].iloc[2] == 20.0
+    assert df["s"].iloc[-1] == pytest.approx(2.0)
+
+
+def test_moving_average_stats_smooths_and_peaks():
+    # A spike smoothed over a 3-sample window has a lower peak than the raw max.
+    series = np.array([0.0, 0.0, 9.0, 0.0, 0.0])
+    out = mesh_field.moving_average_stats(series, dt=1.0, window_s=3.0)
+    assert out["window"] == 3
+    assert out["mean"] == pytest.approx(1.8)
+    assert out["ma_max"] == pytest.approx(3.0)  # (0+9+0)/3
+    assert out["ma_max"] < series.max()
+
+
+def test_moving_average_stats_short_series():
+    out = mesh_field.moving_average_stats(np.array([2.0, 4.0]), dt=1.0, window_s=10.0)
+    assert out["ma_max"] == pytest.approx(3.0)  # falls back to the plain mean
+
+
+def test_moving_average_stats_empty():
+    out = mesh_field.moving_average_stats(np.array([]), dt=1.0, window_s=5.0)
+    assert np.isnan(out["mean"]) and np.isnan(out["ma_max"])


### PR DESCRIPTION
Part of the post-processing port (#169), priority 3. Adds `sample_field_along_line` (nearest-triangle KD-tree sampling -> DataFrame of s/x/y/z/value), `triangle_centroids`, and `moving_average_stats` (peak-of-N-second-MA). Pure numpy/scipy, no PyVista. The PyVista plane-slice render is deferred. Tests in `tests/test_mesh_field_sampling.py` (5). ruff clean. Stacked on #168.