### PR TITLE
feat(building): gust peak factor + selectable peak methods

### DIFF
--- a/cfdmod/building/__init__.py
+++ b/cfdmod/building/__init__.py
@@ -18,6 +18,7 @@ from cfdmod.building.dynamic import (
     solve_building_response,
     structure_from_csvs,
 )
+from cfdmod.building.peaks import PeakMethod, gust_peak_factor, peak_value
 from cfdmod.building.pressure import cf_per_floor, cm_per_floor, cp_from_pressure
 
 __all__ = [
@@ -32,4 +33,7 @@ __all__ = [
     "solve_building_response",
     "floor_accelerations",
     "peak_response_table",
+    "PeakMethod",
+    "gust_peak_factor",
+    "peak_value",
 ]

--- a/cfdmod/building/peaks.py
+++ b/cfdmod/building/peaks.py
@@ -1,0 +1,94 @@
+"""Peak-estimation methods for building response time series.
+
+The engineer-facing deliverables reduce a fluctuating response (acceleration,
+floor force, displacement) to a single design peak. Three methods are used in
+the field, selectable per deliverable:
+
+- ``"max"`` -- the observed extreme (optionally of the absolute value).
+- ``"peak-factor"`` -- Davenport: ``mean + g * std`` with the gust peak factor
+  ``g`` from the response frequency and averaging duration.
+- ``"gumbel"`` -- fit a Gumbel to block maxima and read the design fractile off
+  it (more stable than the raw max for short records).
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+
+PeakMethod = Literal["max", "peak-factor", "gumbel"]
+
+
+def gust_peak_factor(f0: float, duration: float = 600.0, *, full: bool = True) -> float:
+    """Davenport gust peak factor ``g`` for a narrow-band process.
+
+    ``g = sqrt(2 ln(nu T)) + 0.5772 / sqrt(2 ln(nu T))`` with ``nu = f0`` the
+    mean up-crossing rate (Hz) and ``T = duration`` (s). With ``full=False``
+    only the leading ``sqrt(2 ln(nu T))`` term is returned (the form used in the
+    quick-look notebooks).
+    """
+    nu_t = f0 * duration
+    if nu_t <= 1.0:
+        raise ValueError(f"f0 * duration must exceed 1 (got {nu_t})")
+    base = np.sqrt(2.0 * np.log(nu_t))
+    return float(base + 0.5772 / base if full else base)
+
+
+def _gumbel_fit(block_maxima: np.ndarray) -> tuple[float, float]:
+    """Method-of-moments Gumbel (loc, scale) from block maxima."""
+    m = float(np.mean(block_maxima))
+    s = float(np.std(block_maxima, ddof=1)) if block_maxima.size > 1 else 0.0
+    scale = s * np.sqrt(6.0) / np.pi
+    loc = m - 0.5772 * scale
+    return loc, scale
+
+
+def peak_value(
+    series: np.ndarray,
+    method: PeakMethod = "peak-factor",
+    *,
+    f0: float | None = None,
+    duration: float = 600.0,
+    absolute: bool = True,
+    n_blocks: int = 10,
+    non_exceedance: float = 0.78,
+) -> float:
+    """Reduce a response time series to a single design peak.
+
+    Args:
+        method: ``"max"``, ``"peak-factor"`` (needs ``f0``), or ``"gumbel"``.
+        f0: response frequency (Hz), required for ``"peak-factor"``.
+        duration: full-scale averaging window (s) for the gust factor.
+        absolute: if True, ``"max"`` uses ``max(|series|)`` and ``"peak-factor"``
+            builds the peak off ``|mean| + g*std``.
+        n_blocks: number of blocks for ``"gumbel"`` block maxima.
+        non_exceedance: design fractile ``p`` for ``"gumbel"``
+            (``x_p = loc - scale ln(-ln p)``).
+    """
+    x = np.asarray(series, dtype=np.float64)
+    x = x[np.isfinite(x)]
+    if x.size == 0:
+        return float("nan")
+
+    if method == "max":
+        return float(np.max(np.abs(x)) if absolute else np.max(x))
+
+    if method == "peak-factor":
+        if f0 is None:
+            raise ValueError("peak-factor method requires f0")
+        g = gust_peak_factor(f0, duration)
+        mean = abs(float(np.mean(x))) if absolute else float(np.mean(x))
+        return float(mean + g * float(np.std(x)))
+
+    if method == "gumbel":
+        vals = np.abs(x) if absolute else x
+        n_blocks = max(1, min(n_blocks, vals.size))
+        blocks = np.array_split(vals, n_blocks)
+        block_maxima = np.array([float(np.max(b)) for b in blocks if b.size])
+        loc, scale = _gumbel_fit(block_maxima)
+        if scale == 0.0:
+            return float(loc)
+        return float(loc - scale * np.log(-np.log(non_exceedance)))
+
+    raise ValueError(f"unknown peak method {method!r}")

--- a/tests/building/test_peaks.py
+++ b/tests/building/test_peaks.py
@@ -1,0 +1,60 @@
+"""Tests for cfdmod.building.peaks (gust factor + peak methods)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.building import gust_peak_factor, peak_value
+
+pytestmark = pytest.mark.unit
+
+
+def test_gust_peak_factor_known_value():
+    # nu*T = 0.2 * 600 = 120; base = sqrt(2 ln 120) = 3.0936; +0.5772/base
+    g = gust_peak_factor(0.2, 600.0)
+    assert g == pytest.approx(3.0936 + 0.5772 / 3.0936, rel=1e-3)
+    base_only = gust_peak_factor(0.2, 600.0, full=False)
+    assert base_only < g
+    assert base_only == pytest.approx(3.0936, rel=1e-3)
+
+
+def test_gust_peak_factor_rejects_small_nu_t():
+    with pytest.raises(ValueError):
+        gust_peak_factor(0.001, 100.0)  # nu*T = 0.1 < 1
+
+
+def test_peak_value_max_absolute():
+    x = np.array([-5.0, 1.0, 3.0])
+    assert peak_value(x, "max") == 5.0
+    assert peak_value(x, "max", absolute=False) == 3.0
+
+
+def test_peak_value_peak_factor():
+    rng = np.random.default_rng(0)
+    x = rng.normal(0.0, 2.0, size=20000)
+    g = gust_peak_factor(0.2, 600.0)
+    expected = abs(x.mean()) + g * x.std()
+    assert peak_value(x, "peak-factor", f0=0.2) == pytest.approx(expected, rel=1e-9)
+
+
+def test_peak_value_peak_factor_requires_f0():
+    with pytest.raises(ValueError):
+        peak_value(np.arange(10.0), "peak-factor")
+
+
+def test_peak_value_gumbel_monotone_in_fractile():
+    rng = np.random.default_rng(1)
+    x = rng.gumbel(0.0, 1.0, size=5000)
+    low = peak_value(x, "gumbel", non_exceedance=0.5)
+    high = peak_value(x, "gumbel", non_exceedance=0.95)
+    assert high > low
+
+
+def test_peak_value_empty_is_nan():
+    assert np.isnan(peak_value(np.array([]), "max"))
+
+
+def test_peak_value_unknown_method():
+    with pytest.raises(ValueError):
+        peak_value(np.arange(5.0), "nope")  # type: ignore[arg-type]


### PR DESCRIPTION
Part of the post-processing port (#169), priority 2. Adds `cfdmod.building.peaks`: `gust_peak_factor` (Davenport) and `peak_value` with `max` / `peak-factor` / `gumbel` methods, exported from `cfdmod.building`. Tests in `tests/building/test_peaks.py` (8). ruff clean.

Deferred (need exact code constants / legacy review, better with a human): comfort-criteria limits (NBR residential/commercial, Melbourne), load-case Fx/Fy/Mz tables, and the multi-direction result-filter object. Stacked on #168.