### PR TITLE
feat(building): structural mode-shape / mass / frequency figures

### DIFF
--- a/cfdmod/building/__init__.py
+++ b/cfdmod/building/__init__.py
@@ -18,6 +18,11 @@ from cfdmod.building.dynamic import (
     solve_building_response,
     structure_from_csvs,
 )
+from cfdmod.building.modes_report import (
+    plot_floor_mass,
+    plot_mode_shape,
+    plot_natural_frequencies,
+)
 from cfdmod.building.pressure import cf_per_floor, cm_per_floor, cp_from_pressure
 
 __all__ = [
@@ -32,4 +37,7 @@ __all__ = [
     "solve_building_response",
     "floor_accelerations",
     "peak_response_table",
+    "plot_mode_shape",
+    "plot_floor_mass",
+    "plot_natural_frequencies",
 ]

--- a/cfdmod/building/modes_report.py
+++ b/cfdmod/building/modes_report.py
@@ -1,0 +1,73 @@
+"""Figures for the structural model that feeds the dynamic-response stage.
+
+Visualises a :class:`cfdmod.dynamics.structural.BuildingStructuralData`: mode
+shapes (DX / DY / RZ per floor), the per-floor mass distribution, and the
+natural-frequency spectrum. Presentation only -- the numbers come straight off
+the structural object.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cfdmod.plot_config import new_axes
+
+# mode_shapes[:, mode, k] component order.
+_COMPONENTS = ("DX", "DY", "RZ")
+
+
+def _floor_axis(structure, use_height: bool):
+    if use_height:
+        return np.asarray(structure.floor_points, dtype=np.float64)[:, 2], "z [m]"
+    return np.arange(structure.n_floors, dtype=np.float64), "floor"
+
+
+def plot_mode_shape(
+    structure,
+    mode: int,
+    *,
+    use_height: bool = True,
+    rotation_scale: float | np.ndarray | None = None,
+):
+    """Plot the DX / DY / RZ components of one mode vs floor (or height).
+
+    ``rotation_scale`` multiplies the RZ (rotation) component so it plots on the
+    same scale as the translations -- pass the floors' radius of gyration
+    (``structure.floors_radius``) for a physically comparable amplitude.
+    """
+    shapes = np.asarray(structure.mode_shapes, dtype=np.float64)  # (n_floors, n_modes, 3)
+    if not 0 <= mode < shapes.shape[1]:
+        raise IndexError(f"mode {mode} out of range (n_modes={shapes.shape[1]})")
+    y, ylabel = _floor_axis(structure, use_height)
+    dx, dy, rz = shapes[:, mode, 0], shapes[:, mode, 1], shapes[:, mode, 2]
+    if rotation_scale is not None:
+        rz = rz * np.asarray(rotation_scale, dtype=np.float64)
+
+    fig, ax = new_axes(xlabel="modal amplitude [-]", ylabel=ylabel, title=f"Mode {mode}")
+    ax.plot(dx, y, "-o", ms=3, label="DX")
+    ax.plot(dy, y, "--s", ms=3, label="DY")
+    ax.plot(rz, y, ":^", ms=3, label="RZ" + ("*R" if rotation_scale is not None else ""))
+    ax.legend(loc="best", frameon=False)
+    return fig, ax
+
+
+def plot_floor_mass(structure, *, use_height: bool = True):
+    """Per-floor mass vs floor (or height)."""
+    y, ylabel = _floor_axis(structure, use_height)
+    mass = np.asarray(structure.floors_mass, dtype=np.float64)
+    fig, ax = new_axes(xlabel="floor mass [kg]", ylabel=ylabel, title="Floor mass distribution")
+    ax.plot(mass, y, "-o", ms=3)
+    return fig, ax
+
+
+def plot_natural_frequencies(structure):
+    """Natural frequency (Hz) per mode number.
+
+    ``natural_frequencies`` is stored as angular ``wp = 2*pi*f``; converted to Hz.
+    """
+    wp = np.asarray(structure.natural_frequencies, dtype=np.float64)
+    f_hz = wp / (2.0 * np.pi)
+    modes = np.arange(1, f_hz.size + 1)
+    fig, ax = new_axes(xlabel="mode", ylabel="f [Hz]", title="Natural frequencies")
+    ax.plot(modes, f_hz, "o", ms=5)
+    return fig, ax

--- a/tests/building/test_modes_report.py
+++ b/tests/building/test_modes_report.py
@@ -1,0 +1,55 @@
+"""Tests for cfdmod.building.modes_report structural figures."""
+
+from __future__ import annotations
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless
+
+import numpy as np  # noqa: E402
+import pytest  # noqa: E402
+
+from cfdmod.building import modes_report  # noqa: E402
+from cfdmod.dynamics.structural import BuildingStructuralData  # noqa: E402
+
+pytestmark = pytest.mark.unit
+
+
+def _structure(n_floors: int = 4, n_modes: int = 3) -> BuildingStructuralData:
+    z = np.linspace(0.0, 100.0, n_floors)
+    return BuildingStructuralData(
+        mode_shapes=np.random.default_rng(0).normal(size=(n_floors, n_modes, 3)),
+        natural_frequencies=2 * np.pi * np.array([0.2, 0.5, 0.9])[:n_modes],
+        floor_points=np.column_stack([np.zeros(n_floors), np.zeros(n_floors), z]),
+        cm_positions=np.zeros((n_floors, 2)),
+        floors_mass=np.linspace(5000.0, 3000.0, n_floors),
+        floors_radius=np.full(n_floors, 8.0),
+    )
+
+
+def test_plot_mode_shape_returns_fig_ax():
+    st = _structure()
+    fig, ax = modes_report.plot_mode_shape(st, mode=0, rotation_scale=st.floors_radius)
+    assert fig is not None and ax is not None
+    # three lines: DX, DY, RZ
+    assert len(ax.get_lines()) == 3
+
+
+def test_plot_mode_shape_out_of_range():
+    with pytest.raises(IndexError):
+        modes_report.plot_mode_shape(_structure(n_modes=2), mode=5)
+
+
+def test_plot_floor_mass():
+    fig, ax = modes_report.plot_floor_mass(_structure(), use_height=True)
+    assert fig is not None
+    line = ax.get_lines()[0]
+    assert len(line.get_xdata()) == 4
+
+
+def test_plot_natural_frequencies_converts_to_hz():
+    st = _structure(n_modes=3)
+    fig, ax = modes_report.plot_natural_frequencies(st)
+    ydata = ax.get_lines()[0].get_ydata()
+    # wp = 2*pi*f stored -> Hz recovered
+    assert np.allclose(np.sort(ydata), [0.2, 0.5, 0.9], atol=1e-9)


### PR DESCRIPTION
Part of the post-processing port (#169), priority 5. Adds `cfdmod.building.modes_report` - `plot_mode_shape`, `plot_floor_mass`, `plot_natural_frequencies` for a `BuildingStructuralData` (which today loads but is never visualised). Tests in `tests/building/test_modes_report.py` (4). ruff clean. Stacked on #168.