### PR TITLE
feat(mesh_field): PyVista plane-slice field render

### DIFF
--- a/cfdmod/mesh_field.py
+++ b/cfdmod/mesh_field.py
@@ -10,7 +10,12 @@ publication-quality images where the optional renderer is installed:
 - **PyVista (optional, ``[vtk]`` extra).** :func:`write_field_vtp` dumps the
   per-triangle field to a ``.vtp`` and :func:`render_vtp_snapshot` drives
   :func:`cfdmod.snapshot.take_snapshot` for a contoured, colour-barred render.
-  Both no-op with a clear message when PyVista/VTK is absent.
+  :func:`slice_field_on_plane` cuts the field mesh with a plane and returns the
+  cross-section points / values / outline segments as a :class:`PlaneSlice`
+  (rendered to a 2-D PNG by the pure-matplotlib :func:`render_plane_slice`).
+  The VTK-backed paths (``write_field_vtp``, ``render_vtp_snapshot`` and
+  ``slice_field_on_plane``) all no-op with a clear message when PyVista/VTK is
+  absent.
 
 Facade selection reuses the library's normal-based grouping
 (:func:`cfdmod.geometry.grouping.kinds.by_normal.apply_by_normal`): a
@@ -21,6 +26,7 @@ and ``+z`` roof by the cardinal direction of their outward normal.
 from __future__ import annotations
 
 import pathlib
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -299,6 +305,204 @@ def render_vtp_snapshot(
         camera=CameraConfig(zoom=zoom, view_up=view_up, window_size=window_size),
     )
     take_snapshot(pathlib.Path(image_path), cfg, off_screen=True)
+    return True
+
+
+# -- plane-slice field render (optional PyVista) ---------------------------
+
+_AXIS_INDEX: dict[str, int] = {"x": 0, "y": 1, "z": 2}
+
+
+@dataclass
+class PlaneSlice:
+    """A field mesh cut by a plane: cross-section points, values and outline.
+
+    Attributes:
+        points: ``(n_pts, 3)`` slice-point coordinates.
+        values: ``(n_pts,)`` scalar sampled onto ``points`` (aligned 1:1).
+        segments: ``(n_seg, 2)`` index pairs into ``points`` -> outline lines
+            tracing the building cross-section.
+        origin: ``(3,)`` plane origin echoed back.
+        normal: ``(3,)`` plane normal echoed back.
+    """
+
+    points: np.ndarray
+    values: np.ndarray
+    segments: np.ndarray
+    origin: np.ndarray
+    normal: np.ndarray
+
+
+def slice_field_on_plane(
+    geometry,
+    field: np.ndarray,
+    *,
+    origin,
+    normal=(0.0, 1.0, 0.0),
+    association: str = "cell",
+    field_name: str = "value",
+) -> PlaneSlice | None:
+    """Cut a per-triangle ``field`` on a mesh with a plane (requires ``[vtk]``).
+
+    Builds a PyVista surface from the ``LnasGeometry`` vertices + triangles,
+    attaches ``field`` as cell (default) or point data, and slices it with the
+    plane ``(origin, normal)``. Returns a :class:`PlaneSlice` with the
+    cross-section ``points``, per-point ``values`` and outline ``segments``.
+
+    No-ops with a clear message and returns ``None`` when PyVista/VTK is absent,
+    mirroring :func:`write_field_vtp` / :func:`render_vtp_snapshot`. When the
+    plane misses the mesh, returns a :class:`PlaneSlice` with empty arrays.
+
+    Args:
+        geometry: An ``LnasGeometry`` (uses ``vertices`` + ``triangles``).
+        field: Per-triangle (``association="cell"``) or per-vertex
+            (``association="point"``) scalar array.
+        origin: ``(3,)`` point on the slicing plane.
+        normal: ``(3,)`` plane normal (default ``+y``).
+        association: ``"cell"`` (per-triangle, primary) or ``"point"``.
+        field_name: Name to store the scalar under on the PyVista mesh.
+    """
+    if not has_pyvista():
+        print("[mesh_field] PyVista not installed ([vtk] extra); slice_field_on_plane is a no-op.")
+        return None
+    try:
+        import pyvista as pv
+    except Exception:
+        return None
+
+    origin = np.asarray(origin, dtype=np.float64)
+    normal = np.asarray(normal, dtype=np.float64)
+
+    vertices = np.asarray(geometry.vertices, dtype=np.float64)
+    triangles = np.asarray(geometry.triangles, dtype=np.int64)  # (n_tri, 3)
+    n_tri = triangles.shape[0]
+    faces = np.hstack(
+        [np.full((n_tri, 1), 3, dtype=np.int64), triangles]
+    ).ravel()  # [3, i0, i1, i2, 3, ...]
+    mesh = pv.PolyData(vertices, faces)
+
+    values_in = np.asarray(field, dtype=np.float64)
+    if association == "point":
+        mesh.point_data[field_name] = values_in
+    else:
+        mesh.cell_data[field_name] = values_in
+
+    sliced = mesh.slice(normal=normal, origin=origin)
+
+    empty = np.empty((0, 3), dtype=np.float64)
+    if sliced.n_points == 0:
+        return PlaneSlice(
+            points=empty,
+            values=np.empty((0,), dtype=np.float64),
+            segments=np.empty((0, 2), dtype=np.int64),
+            origin=origin,
+            normal=normal,
+        )
+
+    points = np.asarray(sliced.points, dtype=np.float64)  # (n_pts, 3)
+
+    if association == "point":
+        values = np.asarray(sliced[field_name], dtype=np.float64)
+    else:
+        per_point = sliced.cell_data_to_point_data()
+        values = np.asarray(per_point[field_name], dtype=np.float64)
+
+    lines = np.asarray(sliced.lines, dtype=np.int64)
+    if lines.size:
+        segments = lines.reshape(-1, 3)[:, 1:]  # [2, a, b, ...] -> (n_seg, 2)
+    else:
+        segments = np.empty((0, 2), dtype=np.int64)
+
+    return PlaneSlice(
+        points=points,
+        values=values,
+        segments=segments,
+        origin=origin,
+        normal=normal,
+    )
+
+
+def render_plane_slice(
+    slc: PlaneSlice | None,
+    image_path: str | pathlib.Path,
+    *,
+    plane_axes: tuple[str, str] = ("x", "z"),
+    mode: str = "tricontourf",
+    cmap: str = "turbo",
+    clim: tuple[float, float] | None = None,
+    clim_percentile: tuple[float, float] = (2.0, 98.0),
+    levels: int = 24,
+    label: str = "p",
+    title: str = "",
+    draw_outline: bool = True,
+    outline_kwargs: dict | None = None,
+) -> bool:
+    """Render a :class:`PlaneSlice` cross-section to a 2-D PNG (matplotlib only).
+
+    Maps the two in-plane coordinates (``plane_axes``, default ``x`` / ``z`` for
+    the ``p(x, z)`` view on a ``y=const`` plane), draws the field as filled
+    contours (``mode="tricontourf"``, falling back to a scatter when the
+    triangulation degenerates) or a ``"scatter"``, adds a colourbar and overlays
+    the slice's own line cells as the building cross-section outline.
+
+    Colour limits default to the ``clim_percentile`` percentiles of the values
+    (robust to outliers). No-ops (returns ``False``) on a ``None`` or empty
+    slice, so it degrades cleanly when the plane misses the mesh.
+
+    Returns ``True`` on success, ``False`` when nothing was rendered.
+    """
+    if slc is None or slc.points.size == 0:
+        print("[mesh_field] empty slice; nothing to render.")
+        return False
+
+    from matplotlib.collections import LineCollection
+
+    from cfdmod import plot_config
+
+    h = slc.points[:, _AXIS_INDEX[plane_axes[0]]]
+    v = slc.points[:, _AXIS_INDEX[plane_axes[1]]]
+    values = slc.values
+
+    if clim is None:
+        finite = values[np.isfinite(values)]
+        if finite.size:
+            clim = tuple(np.nanpercentile(finite, clim_percentile))
+        else:
+            clim = (0.0, 1.0)
+    vmin, vmax = float(clim[0]), float(clim[1])
+
+    plot_config.apply_style()
+    fig, ax = plot_config.new_axes(
+        xlabel=f"{plane_axes[0]} [m]",
+        ylabel=f"{plane_axes[1]} [m]",
+        title=title,
+    )
+
+    mappable = None
+    if mode == "tricontourf":
+        try:
+            mappable = ax.tricontourf(h, v, values, levels=levels, cmap=cmap, vmin=vmin, vmax=vmax)
+        except Exception:
+            mappable = None
+    if mappable is None:
+        mappable = ax.scatter(h, v, c=values, cmap=cmap, vmin=vmin, vmax=vmax, s=6)
+
+    fig.colorbar(mappable, ax=ax, label=label)
+
+    if draw_outline and slc.segments.size:
+        opts = {"colors": "black", "linewidths": 0.8, "zorder": 3}
+        if outline_kwargs:
+            opts.update(outline_kwargs)
+        coords = np.column_stack([h, v])  # (n_pts, 2)
+        lines = coords[slc.segments]  # (n_seg, 2, 2)
+        ax.add_collection(LineCollection(lines, **opts))
+
+    ax.set_aspect("equal")
+
+    image_path = pathlib.Path(image_path)
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(image_path, dpi=150, bbox_inches="tight")
+    plot_config.close(fig)
     return True
 
 

--- a/tests/test_mesh_field_slice.py
+++ b/tests/test_mesh_field_slice.py
@@ -1,0 +1,86 @@
+import numpy as np
+import pytest
+from lnas import LnasGeometry
+
+from cfdmod import mesh_field
+
+pytestmark = pytest.mark.unit
+
+
+def _box_geometry() -> LnasGeometry:
+    """A small closed unit box as an LnasGeometry (8 vertices, 12 triangles)."""
+    vertices = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [1.0, 1.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+            [1.0, 0.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [0.0, 1.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    triangles = np.array(
+        [
+            [0, 2, 1],
+            [0, 3, 2],
+            [4, 5, 6],
+            [4, 6, 7],
+            [0, 1, 5],
+            [0, 5, 4],
+            [1, 2, 6],
+            [1, 6, 5],
+            [2, 3, 7],
+            [2, 7, 6],
+            [3, 0, 4],
+            [3, 4, 7],
+        ],
+        dtype=np.int64,
+    )
+    return LnasGeometry(vertices, triangles)
+
+
+def test_slice_and_render_smoke(tmp_path):
+    pytest.importorskip("pyvista")
+
+    geom = _box_geometry()
+    centroids = mesh_field.triangle_centroids(geom)
+    field = centroids[:, 2]  # z-graded per-triangle field
+
+    y0 = 0.5
+    slc = mesh_field.slice_field_on_plane(
+        geom, field, origin=(0.5, y0, 0.5), normal=(0.0, 1.0, 0.0)
+    )
+
+    assert slc is not None
+    assert slc.points.shape[1] == 3
+    assert slc.points.size > 0
+    assert slc.values.shape[0] == slc.points.shape[0]
+    assert np.allclose(slc.points[:, 1], y0, atol=1e-6)
+
+    image_path = tmp_path / "slice.png"
+    ok = mesh_field.render_plane_slice(slc, image_path, plane_axes=("x", "z"))
+    assert ok is True
+    assert image_path.exists()
+
+
+def test_slice_field_on_plane_noop_without_pyvista(monkeypatch, capsys):
+    monkeypatch.setattr(mesh_field, "has_pyvista", lambda: False)
+
+    geom = _box_geometry()
+    field = np.zeros(geom.triangles.shape[0], dtype=np.float64)
+
+    result = mesh_field.slice_field_on_plane(
+        geom, field, origin=(0.5, 0.5, 0.5), normal=(0.0, 1.0, 0.0)
+    )
+    assert result is None
+    out = capsys.readouterr().out
+    assert "PyVista not installed" in out
+
+
+def test_render_plane_slice_noop_on_none(capsys):
+    assert mesh_field.render_plane_slice(None, "unused.png") is False
+    out = capsys.readouterr().out
+    assert "empty slice" in out


### PR DESCRIPTION
Implements the mesh_field PyVista plane-slice field render (issue #179).

## What changed

- **`slice_field_on_plane(geometry, field, *, origin, normal, association, field_name) -> PlaneSlice | None`**
  Builds a PyVista `PolyData` from the `LnasGeometry` vertices + triangles,
  attaches the per-triangle field as cell data (or per-vertex as point data),
  and slices it with the plane `(origin, normal)`. Returns a new `PlaneSlice`
  dataclass carrying the cross-section `points` (n_pts, 3), per-point `values`
  (cell data converted 1:1 via `cell_data_to_point_data()`), and outline
  `segments` (n_seg, 2) from the slice line cells, plus the echoed origin/normal.
  Empty-slice safe (returns a `PlaneSlice` with empty arrays when the plane
  misses the mesh).

- **`render_plane_slice(slc, image_path, ...) -> bool`**
  Pure-matplotlib 2-D render of the cross-section: maps two in-plane coords,
  `tricontourf` (scatter fallback on degenerate triangulation) or `scatter`,
  percentile CLIM, colourbar, and the slice's own line cells overlaid as the
  building cross-section outline via a `LineCollection`. Equal aspect.

Both VTK-backed entry points no-op with a clear message when PyVista/VTK is
absent, mirroring the existing `write_field_vtp` / `render_vtp_snapshot`
pattern. All additive, ASCII-only; module docstring updated.

## Tests (`tests/test_mesh_field_slice.py`, `pytest.mark.unit`)

- PyVista-guarded (`importorskip`) smoke test: slices a small closed box on
  a `y=const` plane, asserts shapes and sliced-y, and renders a PNG.
- Always-on no-op tests: `slice_field_on_plane` returns `None` with a printed
  message when `has_pyvista` is monkeypatched off; `render_plane_slice(None, ...)`
  returns `False`.

`uv run pytest tests/test_mesh_field_slice.py`: 2 passed, 1 skipped (pyvista
not installed in CI-less env). `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)