### PR TITLE
perf: chunk-aware executor + fused/float32 per-floor loads (#184)

### DIFF
--- a/cfdmod/building/__init__.py
+++ b/cfdmod/building/__init__.py
@@ -50,7 +50,13 @@ from cfdmod.building.loadcases import (
     save_load_case_tables,
 )
 from cfdmod.building.peaks import PeakMethod, gust_peak_factor, peak_value
-from cfdmod.building.pressure import cf_per_floor, cm_per_floor, cp_from_pressure
+from cfdmod.building.pressure import (
+    cf_cm_per_floor,
+    cf_per_floor,
+    cm_per_floor,
+    cp_from_pressure,
+    per_floor_loads,
+)
 
 __all__ = [
     "BuildingCase",
@@ -58,6 +64,8 @@ __all__ = [
     "cp_from_pressure",
     "cf_per_floor",
     "cm_per_floor",
+    "cf_cm_per_floor",
+    "per_floor_loads",
     "floor_load_source",
     "example_building_structure",
     "structure_from_csvs",

--- a/cfdmod/building/pressure.py
+++ b/cfdmod/building/pressure.py
@@ -30,6 +30,7 @@ from typing import Literal
 import numpy as np
 
 from cfdmod.core.data_source import DataSource, GroupsDataSource
+from cfdmod.core.dtypes import FIELD_DTYPE
 from cfdmod.core.ops.data_source_create.face_cut import FaceCutParams, face_cut
 from cfdmod.core.ops.data_source_create.field_series_for_groups import (
     FieldSeriesForGroupsParams,
@@ -49,12 +50,6 @@ from .case import BuildingCase
 _FLOOR = "floor"
 
 FloorMethod = Literal["face_cut", "centroid"]
-ComputeDtype = Literal["float32", "float64"]
-# Default compute precision for the building load path. float32 is enough for
-# these coefficients and halves the per-triangle array footprint on top of the
-# time-chunking; pass "float64" for exactness checks. (The library-wide op
-# defaults stay float64; flipping those globally is tracked separately.)
-_DEFAULT_DTYPE: ComputeDtype = "float32"
 
 
 def cp_from_pressure(
@@ -131,20 +126,13 @@ def _attach_and_partition(
     return _partition_floors(ds, mesh_path, case, method)
 
 
-def _force(
-    ds: DataSource, case: BuildingCase, directions: list[str], dtype: ComputeDtype
-) -> DataSource:
+def _force(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSource:
     return force_contribution(
-        ds,
-        ForceContributionParams(
-            nominal_area=case.nominal_area, directions=directions, compute_dtype=dtype
-        ),
+        ds, ForceContributionParams(nominal_area=case.nominal_area, directions=directions)
     )
 
 
-def _moment(
-    ds: DataSource, case: BuildingCase, directions: list[str], dtype: ComputeDtype
-) -> DataSource:
+def _moment(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSource:
     return moment_contribution(
         ds,
         MomentContributionParams(
@@ -152,7 +140,6 @@ def _moment(
             nominal_area=case.nominal_area,
             nominal_volume=case.nominal_volume,
             directions=directions,
-            compute_dtype=dtype,
         ),
     )
 
@@ -164,7 +151,6 @@ def cf_per_floor(
     *,
     directions: tuple[str, ...] = ("x", "y"),
     method: FloorMethod = "centroid",
-    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> GroupsDataSource:
     """Per-floor force coefficients cf_<dir>, one row per floor slice.
 
@@ -173,10 +159,10 @@ def cf_per_floor(
     ``method="face_cut"`` slices triangles at the floor edges for an exact
     partial-area split, but fragments the mesh (much heavier); prefer centroid at
     production sizes. See :func:`cf_cm_per_floor` when you need both Cf and Cm.
-    ``compute_dtype`` controls the per-triangle force precision (float32 default).
+    Precision follows the Cp field's dtype (float32 for solver output).
     """
     ds = _attach_and_partition(cp_ds, mesh_path, case, method)
-    ds = _force(ds, case, list(directions), compute_dtype)
+    ds = _force(ds, case, list(directions))
     return _sum_per_floor(ds, [f"cf_{d}" for d in directions])
 
 
@@ -187,7 +173,6 @@ def cm_per_floor(
     *,
     directions: tuple[str, ...] = ("z",),
     method: FloorMethod = "centroid",
-    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> GroupsDataSource:
     """Per-floor moment coefficients cm_<dir> about the case lever origin.
 
@@ -195,8 +180,8 @@ def cm_per_floor(
     """
     ds = _attach_and_partition(cp_ds, mesh_path, case, method)
     # moment_contribution reads all three force components, so produce them all.
-    ds = _force(ds, case, ["x", "y", "z"], compute_dtype)
-    ds = _moment(ds, case, list(directions), compute_dtype)
+    ds = _force(ds, case, ["x", "y", "z"])
+    ds = _moment(ds, case, list(directions))
     return _sum_per_floor(ds, [f"cm_{d}" for d in directions])
 
 
@@ -208,7 +193,6 @@ def cf_cm_per_floor(
     cf_directions: tuple[str, ...] = ("x", "y"),
     cm_directions: tuple[str, ...] = ("z",),
     method: FloorMethod = "centroid",
-    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> tuple[GroupsDataSource, GroupsDataSource]:
     """Per-floor Cf and Cm from a **single** mesh-attach + partition + force pass.
 
@@ -219,9 +203,9 @@ def cf_cm_per_floor(
     Returns ``(cf, cm)``.
     """
     ds = _attach_and_partition(cp_ds, mesh_path, case, method)
-    ds = _force(ds, case, ["x", "y", "z"], compute_dtype)
+    ds = _force(ds, case, ["x", "y", "z"])
     cf = _sum_per_floor(ds, [f"cf_{d}" for d in cf_directions])
-    ds = _moment(ds, case, list(cm_directions), compute_dtype)
+    ds = _moment(ds, case, list(cm_directions))
     cm = _sum_per_floor(ds, [f"cm_{d}" for d in cm_directions])
     return cf, cm
 
@@ -236,7 +220,7 @@ def per_floor_loads(
     cm_directions: tuple[str, ...] = ("z",),
     method: FloorMethod = "centroid",
     chunk_size: int | None = None,
-    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
+    compute_dtype=FIELD_DTYPE,
 ) -> tuple[GroupsDataSource, GroupsDataSource]:
     """Memory-bounded per-floor Cf / Cm straight from body + reference pressure.
 
@@ -245,17 +229,18 @@ def per_floor_loads(
     n_timesteps)`` Cp / force arrays never materialise at once: peak memory is
     ``O(n_triangles * chunk_size)`` while the returned per-floor series is small.
     With ``chunk_size=None`` (default) it runs whole-series (identical result);
-    pass a chunk (e.g. a few thousand) for production-size cases. ``compute_dtype``
-    (float32 default) sets the per-triangle precision. Returns ``(cf, cm)`` with
-    the full time axis, ready for :func:`cfdmod.building.floor_load_source`.
+    pass a chunk (e.g. a few thousand) for production-size cases. The source
+    pressure is cast to ``compute_dtype`` (float32 default) so the whole
+    per-triangle chain runs in that precision. Returns ``(cf, cm)`` with the full
+    time axis, ready for :func:`cfdmod.building.floor_load_source`.
     """
     from cfdmod.core.chunked import concat_time, slice_time, time_windows
 
     dt = np.dtype(compute_dtype)
 
     def _cast(ds: DataSource) -> DataSource:
-        # Cast the source pressure so Cp (and everything downstream) is computed
-        # in the requested precision, not just the force step.
+        # Cast the source pressure so Cp (and everything downstream) inherits the
+        # precision; the ops then preserve this dtype through force / moment / sum.
         return ds.with_field("pressure", np.asarray(ds.fields.read("pressure"), dtype=dt))
 
     def _window(b: DataSource, r) -> tuple[GroupsDataSource, GroupsDataSource]:
@@ -267,7 +252,6 @@ def per_floor_loads(
             cf_directions=cf_directions,
             cm_directions=cm_directions,
             method=method,
-            compute_dtype=compute_dtype,
         )
 
     n_t = body.time.n_timesteps

--- a/cfdmod/building/pressure.py
+++ b/cfdmod/building/pressure.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 from cfdmod.core.data_source import DataSource, GroupsDataSource
 from cfdmod.core.ops.data_source_create.face_cut import FaceCutParams, face_cut
 from cfdmod.core.ops.data_source_create.field_series_for_groups import (
@@ -47,6 +49,12 @@ from .case import BuildingCase
 _FLOOR = "floor"
 
 FloorMethod = Literal["face_cut", "centroid"]
+ComputeDtype = Literal["float32", "float64"]
+# Default compute precision for the building load path. float32 is enough for
+# these coefficients and halves the per-triangle array footprint on top of the
+# time-chunking; pass "float64" for exactness checks. (The library-wide op
+# defaults stay float64; flipping those globally is tracked separately.)
+_DEFAULT_DTYPE: ComputeDtype = "float32"
 
 
 def cp_from_pressure(
@@ -123,13 +131,20 @@ def _attach_and_partition(
     return _partition_floors(ds, mesh_path, case, method)
 
 
-def _force(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSource:
+def _force(
+    ds: DataSource, case: BuildingCase, directions: list[str], dtype: ComputeDtype
+) -> DataSource:
     return force_contribution(
-        ds, ForceContributionParams(nominal_area=case.nominal_area, directions=directions)
+        ds,
+        ForceContributionParams(
+            nominal_area=case.nominal_area, directions=directions, compute_dtype=dtype
+        ),
     )
 
 
-def _moment(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSource:
+def _moment(
+    ds: DataSource, case: BuildingCase, directions: list[str], dtype: ComputeDtype
+) -> DataSource:
     return moment_contribution(
         ds,
         MomentContributionParams(
@@ -137,6 +152,7 @@ def _moment(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSo
             nominal_area=case.nominal_area,
             nominal_volume=case.nominal_volume,
             directions=directions,
+            compute_dtype=dtype,
         ),
     )
 
@@ -148,6 +164,7 @@ def cf_per_floor(
     *,
     directions: tuple[str, ...] = ("x", "y"),
     method: FloorMethod = "centroid",
+    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> GroupsDataSource:
     """Per-floor force coefficients cf_<dir>, one row per floor slice.
 
@@ -156,9 +173,10 @@ def cf_per_floor(
     ``method="face_cut"`` slices triangles at the floor edges for an exact
     partial-area split, but fragments the mesh (much heavier); prefer centroid at
     production sizes. See :func:`cf_cm_per_floor` when you need both Cf and Cm.
+    ``compute_dtype`` controls the per-triangle force precision (float32 default).
     """
     ds = _attach_and_partition(cp_ds, mesh_path, case, method)
-    ds = _force(ds, case, list(directions))
+    ds = _force(ds, case, list(directions), compute_dtype)
     return _sum_per_floor(ds, [f"cf_{d}" for d in directions])
 
 
@@ -169,6 +187,7 @@ def cm_per_floor(
     *,
     directions: tuple[str, ...] = ("z",),
     method: FloorMethod = "centroid",
+    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> GroupsDataSource:
     """Per-floor moment coefficients cm_<dir> about the case lever origin.
 
@@ -176,8 +195,8 @@ def cm_per_floor(
     """
     ds = _attach_and_partition(cp_ds, mesh_path, case, method)
     # moment_contribution reads all three force components, so produce them all.
-    ds = _force(ds, case, ["x", "y", "z"])
-    ds = _moment(ds, case, list(directions))
+    ds = _force(ds, case, ["x", "y", "z"], compute_dtype)
+    ds = _moment(ds, case, list(directions), compute_dtype)
     return _sum_per_floor(ds, [f"cm_{d}" for d in directions])
 
 
@@ -189,6 +208,7 @@ def cf_cm_per_floor(
     cf_directions: tuple[str, ...] = ("x", "y"),
     cm_directions: tuple[str, ...] = ("z",),
     method: FloorMethod = "centroid",
+    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> tuple[GroupsDataSource, GroupsDataSource]:
     """Per-floor Cf and Cm from a **single** mesh-attach + partition + force pass.
 
@@ -199,9 +219,9 @@ def cf_cm_per_floor(
     Returns ``(cf, cm)``.
     """
     ds = _attach_and_partition(cp_ds, mesh_path, case, method)
-    ds = _force(ds, case, ["x", "y", "z"])
+    ds = _force(ds, case, ["x", "y", "z"], compute_dtype)
     cf = _sum_per_floor(ds, [f"cf_{d}" for d in cf_directions])
-    ds = _moment(ds, case, list(cm_directions))
+    ds = _moment(ds, case, list(cm_directions), compute_dtype)
     cm = _sum_per_floor(ds, [f"cm_{d}" for d in cm_directions])
     return cf, cm
 
@@ -216,6 +236,7 @@ def per_floor_loads(
     cm_directions: tuple[str, ...] = ("z",),
     method: FloorMethod = "centroid",
     chunk_size: int | None = None,
+    compute_dtype: ComputeDtype = _DEFAULT_DTYPE,
 ) -> tuple[GroupsDataSource, GroupsDataSource]:
     """Memory-bounded per-floor Cf / Cm straight from body + reference pressure.
 
@@ -224,14 +245,21 @@ def per_floor_loads(
     n_timesteps)`` Cp / force arrays never materialise at once: peak memory is
     ``O(n_triangles * chunk_size)`` while the returned per-floor series is small.
     With ``chunk_size=None`` (default) it runs whole-series (identical result);
-    pass a chunk (e.g. a few thousand) for production-size cases. Returns
-    ``(cf, cm)`` with the full time axis, ready for
-    :func:`cfdmod.building.floor_load_source`.
+    pass a chunk (e.g. a few thousand) for production-size cases. ``compute_dtype``
+    (float32 default) sets the per-triangle precision. Returns ``(cf, cm)`` with
+    the full time axis, ready for :func:`cfdmod.building.floor_load_source`.
     """
     from cfdmod.core.chunked import concat_time, slice_time, time_windows
 
+    dt = np.dtype(compute_dtype)
+
+    def _cast(ds: DataSource) -> DataSource:
+        # Cast the source pressure so Cp (and everything downstream) is computed
+        # in the requested precision, not just the force step.
+        return ds.with_field("pressure", np.asarray(ds.fields.read("pressure"), dtype=dt))
+
     def _window(b: DataSource, r) -> tuple[GroupsDataSource, GroupsDataSource]:
-        cp = cp_from_pressure(b, r, case)
+        cp = cp_from_pressure(_cast(b), _cast(r), case)
         return cf_cm_per_floor(
             cp,
             mesh_path,
@@ -239,6 +267,7 @@ def per_floor_loads(
             cf_directions=cf_directions,
             cm_directions=cm_directions,
             method=method,
+            compute_dtype=compute_dtype,
         )
 
     n_t = body.time.n_timesteps

--- a/cfdmod/building/pressure.py
+++ b/cfdmod/building/pressure.py
@@ -110,25 +110,55 @@ def _sum_per_floor(ds: DataSource, fields: list[str]) -> GroupsDataSource:
     return result
 
 
+def _attach_and_partition(
+    cp_ds: DataSource, mesh_path: str, case: BuildingCase, method: FloorMethod
+) -> DataSource:
+    """mesh_attach + per-floor partition, shared by the Cf / Cm recipes.
+
+    ``face_cut`` returns a fragmented surface with fragment areas/normals;
+    ``centroid`` attaches a grouping to the mesh-attached surface. Either way the
+    result is ready for :func:`force_contribution`.
+    """
+    ds = mesh_attach(cp_ds, MeshAttachParams(mesh=mesh_path))
+    return _partition_floors(ds, mesh_path, case, method)
+
+
+def _force(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSource:
+    return force_contribution(
+        ds, ForceContributionParams(nominal_area=case.nominal_area, directions=directions)
+    )
+
+
+def _moment(ds: DataSource, case: BuildingCase, directions: list[str]) -> DataSource:
+    return moment_contribution(
+        ds,
+        MomentContributionParams(
+            lever_origin=tuple(case.lever_origin),
+            nominal_area=case.nominal_area,
+            nominal_volume=case.nominal_volume,
+            directions=directions,
+        ),
+    )
+
+
 def cf_per_floor(
     cp_ds: DataSource,
     mesh_path: str,
     case: BuildingCase,
     *,
     directions: tuple[str, ...] = ("x", "y"),
-    method: FloorMethod = "face_cut",
+    method: FloorMethod = "centroid",
 ) -> GroupsDataSource:
     """Per-floor force coefficients cf_<dir>, one row per floor slice.
 
-    With ``method="face_cut"`` (default) a triangle straddling a floor boundary
-    contributes its exact partial area to each floor; ``method="centroid"`` uses
-    the faster whole-triangle centroid assignment.
+    ``method="centroid"`` (default) assigns each whole triangle to a floor by its
+    centroid -- fast, bounded memory, and matching the v2 sub-body grouping.
+    ``method="face_cut"`` slices triangles at the floor edges for an exact
+    partial-area split, but fragments the mesh (much heavier); prefer centroid at
+    production sizes. See :func:`cf_cm_per_floor` when you need both Cf and Cm.
     """
-    ds = mesh_attach(cp_ds, MeshAttachParams(mesh=mesh_path))
-    ds = _partition_floors(ds, mesh_path, case, method)
-    ds = force_contribution(
-        ds, ForceContributionParams(nominal_area=case.nominal_area, directions=list(directions))
-    )
+    ds = _attach_and_partition(cp_ds, mesh_path, case, method)
+    ds = _force(ds, case, list(directions))
     return _sum_per_floor(ds, [f"cf_{d}" for d in directions])
 
 
@@ -138,25 +168,87 @@ def cm_per_floor(
     case: BuildingCase,
     *,
     directions: tuple[str, ...] = ("z",),
-    method: FloorMethod = "face_cut",
+    method: FloorMethod = "centroid",
 ) -> GroupsDataSource:
     """Per-floor moment coefficients cm_<dir> about the case lever origin.
 
     See :func:`cf_per_floor` for the ``method`` trade-off.
     """
-    ds = mesh_attach(cp_ds, MeshAttachParams(mesh=mesh_path))
-    ds = _partition_floors(ds, mesh_path, case, method)
+    ds = _attach_and_partition(cp_ds, mesh_path, case, method)
     # moment_contribution reads all three force components, so produce them all.
-    ds = force_contribution(
-        ds, ForceContributionParams(nominal_area=case.nominal_area, directions=["x", "y", "z"])
-    )
-    ds = moment_contribution(
-        ds,
-        MomentContributionParams(
-            lever_origin=tuple(case.lever_origin),
-            nominal_area=case.nominal_area,
-            nominal_volume=case.nominal_volume,
-            directions=list(directions),
-        ),
-    )
+    ds = _force(ds, case, ["x", "y", "z"])
+    ds = _moment(ds, case, list(directions))
     return _sum_per_floor(ds, [f"cm_{d}" for d in directions])
+
+
+def cf_cm_per_floor(
+    cp_ds: DataSource,
+    mesh_path: str,
+    case: BuildingCase,
+    *,
+    cf_directions: tuple[str, ...] = ("x", "y"),
+    cm_directions: tuple[str, ...] = ("z",),
+    method: FloorMethod = "centroid",
+) -> tuple[GroupsDataSource, GroupsDataSource]:
+    """Per-floor Cf and Cm from a **single** mesh-attach + partition + force pass.
+
+    Computing Cf and Cm separately (``cf_per_floor`` + ``cm_per_floor``) runs the
+    heavy ``mesh_attach`` + partition + ``force_contribution`` twice. When both
+    are needed -- the normal high-rise case -- this fuses them: the three force
+    components are computed once and reused for the Cf sums and the moment.
+    Returns ``(cf, cm)``.
+    """
+    ds = _attach_and_partition(cp_ds, mesh_path, case, method)
+    ds = _force(ds, case, ["x", "y", "z"])
+    cf = _sum_per_floor(ds, [f"cf_{d}" for d in cf_directions])
+    ds = _moment(ds, case, list(cm_directions))
+    cm = _sum_per_floor(ds, [f"cm_{d}" for d in cm_directions])
+    return cf, cm
+
+
+def per_floor_loads(
+    body: DataSource,
+    p_ref,
+    mesh_path: str,
+    case: BuildingCase,
+    *,
+    cf_directions: tuple[str, ...] = ("x", "y"),
+    cm_directions: tuple[str, ...] = ("z",),
+    method: FloorMethod = "centroid",
+    chunk_size: int | None = None,
+) -> tuple[GroupsDataSource, GroupsDataSource]:
+    """Memory-bounded per-floor Cf / Cm straight from body + reference pressure.
+
+    Fuses ``Cp -> force -> moment -> per-floor sum`` and streams it over time
+    windows of ``chunk_size`` timesteps, so the full ``(n_triangles,
+    n_timesteps)`` Cp / force arrays never materialise at once: peak memory is
+    ``O(n_triangles * chunk_size)`` while the returned per-floor series is small.
+    With ``chunk_size=None`` (default) it runs whole-series (identical result);
+    pass a chunk (e.g. a few thousand) for production-size cases. Returns
+    ``(cf, cm)`` with the full time axis, ready for
+    :func:`cfdmod.building.floor_load_source`.
+    """
+    from cfdmod.core.chunked import concat_time, slice_time, time_windows
+
+    def _window(b: DataSource, r) -> tuple[GroupsDataSource, GroupsDataSource]:
+        cp = cp_from_pressure(b, r, case)
+        return cf_cm_per_floor(
+            cp,
+            mesh_path,
+            case,
+            cf_directions=cf_directions,
+            cm_directions=cm_directions,
+            method=method,
+        )
+
+    n_t = body.time.n_timesteps
+    if chunk_size is None or n_t == 0 or chunk_size >= n_t:
+        return _window(body, p_ref)
+
+    cf_parts: list[GroupsDataSource] = []
+    cm_parts: list[GroupsDataSource] = []
+    for sl in time_windows(n_t, chunk_size):
+        cf_w, cm_w = _window(slice_time(body, sl), slice_time(p_ref, sl))
+        cf_parts.append(cf_w)
+        cm_parts.append(cm_w)
+    return concat_time(cf_parts), concat_time(cm_parts)

--- a/cfdmod/core/chunked.py
+++ b/cfdmod/core/chunked.py
@@ -1,0 +1,159 @@
+"""Chunked execution over the time axis, to bound peak memory.
+
+The v3 ops advertise ``chunkable_along`` (see :class:`cfdmod.core.ops.OpParams`),
+and almost the whole Cp -> Cf/Cm chain declares ``"time"``. This module is the
+executor that actually honours it: it streams a time-preserving pipeline over
+contiguous time windows and concatenates the per-window outputs, so peak memory
+is ``O(n_elements * chunk)`` instead of ``O(n_elements * n_timesteps)``.
+
+The win is real only when the pipeline *reduces* the element axis before the
+concatenation (e.g. summing a per-triangle force to a per-floor coefficient):
+the large intermediate arrays live only for one window at a time, while the
+concatenated result is small. A pipeline that keeps the full element axis (e.g.
+a bare ``force_contribution``) still bounds its transient allocations, but its
+final output is the same size as the unchunked one.
+
+Contract for a chunkable pipeline: it must be *time-length preserving* (input
+window of ``k`` timesteps -> output of ``k`` timesteps) and its output element
+axis / topology must be identical across windows. Every op it is built from must
+declare ``"time"`` in ``chunkable_along`` -- use :func:`assert_time_chunkable`
+to check that from a list of op params before running.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "time_windows",
+    "slice_time",
+    "concat_time",
+    "chunk_map_time",
+    "assert_time_chunkable",
+]
+
+from typing import Callable, Iterable, Iterator, Sequence
+
+import numpy as np
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core.data_source import DataSource
+from cfdmod.core.time_axis import TimeAxis
+
+
+def time_windows(n_timesteps: int, chunk_size: int) -> Iterator[slice]:
+    """Yield contiguous ``slice`` objects covering ``range(n_timesteps)``.
+
+    The last window is short when ``n_timesteps`` is not a multiple of
+    ``chunk_size``. Raises for a non-positive ``chunk_size``.
+    """
+    if chunk_size <= 0:
+        raise ValueError(f"chunk_size must be positive; got {chunk_size}")
+    for start in range(0, max(n_timesteps, 0), chunk_size):
+        yield slice(start, min(start + chunk_size, n_timesteps))
+
+
+def slice_time(ds: DataSource, sl: slice) -> DataSource:
+    """Return a windowed copy of ``ds`` over the time slice ``sl``.
+
+    Fields are read for the window and materialised into a
+    :class:`MemoryFieldStore`; topology / elements / groupings are preserved by
+    reference. The window's :class:`TimeAxis` keeps the parent's
+    ``timestep_size`` and normalization offset so normalized times stay
+    continuous across windows.
+    """
+    if ds.time.is_time_aggregated:
+        raise ValueError("cannot time-slice a time-aggregated data source")
+
+    n_t = ds.time.n_timesteps
+    start, stop, step = sl.indices(n_t)
+    if step != 1:
+        raise ValueError(f"slice_time expects a contiguous slice (step 1); got step {step}")
+    n_win = max(stop - start, 0)
+    if n_win == 0:
+        raise ValueError(f"empty time window {sl!r} for n_timesteps={n_t}")
+
+    fields = {name: np.asarray(ds.fields.read(name, time_slice=sl)) for name in ds.fields.keys()}
+    win_time = TimeAxis(
+        initial_time=float(ds.time.initial_time + ds.time.timestep_size * start),
+        timestep_size=ds.time.timestep_size,
+        n_timesteps=n_win,
+        time_normalized_offset=ds.time.normalization_offset,
+    )
+    return ds._copy_validated(fields=MemoryFieldStore(fields), time=win_time)
+
+
+def concat_time(parts: Sequence[DataSource]) -> DataSource:
+    """Concatenate time-resolved outputs of successive windows along time.
+
+    ``parts`` must share kind, element axis, field set and topology (only the
+    time axis differs). 2-D fields are concatenated along axis 1; any 1-D
+    (time-invariant) field is taken from the first part. The result carries the
+    reconstructed full :class:`TimeAxis`.
+    """
+    if not parts:
+        raise ValueError("concat_time needs at least one part")
+    if len(parts) == 1:
+        return parts[0]
+
+    template = parts[0]
+    names = list(template.field_names)
+    total_t = int(sum(p.time.n_timesteps for p in parts))
+
+    out_fields: dict[str, np.ndarray] = {}
+    for name in names:
+        arrs = [np.asarray(p.fields.read(name)) for p in parts]
+        if arrs[0].ndim == 2:
+            out_fields[name] = np.concatenate(arrs, axis=1)
+        else:
+            out_fields[name] = arrs[0]
+
+    full_time = TimeAxis(
+        initial_time=template.time.initial_time,
+        timestep_size=template.time.timestep_size,
+        n_timesteps=total_t,
+        time_normalized_offset=template.time.normalization_offset,
+    )
+    return template._copy_validated(
+        fields=MemoryFieldStore(out_fields),
+        time=full_time,
+        field_meta=dict(template.field_meta),
+    )
+
+
+def chunk_map_time(
+    ds: DataSource,
+    pipeline: Callable[[DataSource], DataSource],
+    *,
+    chunk_size: int | None,
+) -> DataSource:
+    """Run ``pipeline`` over time windows of ``ds`` and concatenate the results.
+
+    ``pipeline`` is any single-arg ``DataSource -> DataSource`` callable that is
+    time-length preserving and time-chunkable (see the module docstring). With
+    ``chunk_size`` ``None`` or ``>= n_timesteps`` the pipeline runs once on the
+    whole series (identical result, no chunking overhead), so this is a safe
+    drop-in.
+    """
+    n_t = ds.time.n_timesteps
+    if chunk_size is None or n_t == 0 or chunk_size >= n_t:
+        return pipeline(ds)
+    parts = [pipeline(slice_time(ds, sl)) for sl in time_windows(n_t, chunk_size)]
+    return concat_time(parts)
+
+
+def assert_time_chunkable(op_params: Iterable[object]) -> None:
+    """Raise if any op in ``op_params`` does not declare ``"time"`` chunkability.
+
+    Lets a caller validate that a pipeline built from a list of
+    :class:`~cfdmod.core.ops.OpParams` is safe to run under
+    :func:`chunk_map_time` before paying for any I/O.
+    """
+    offenders = [
+        getattr(p, "kind", type(p).__name__)
+        for p in op_params
+        if "time" not in getattr(p, "chunkable_along", frozenset())
+    ]
+    if offenders:
+        raise ValueError(
+            "pipeline is not time-chunkable; these ops do not declare "
+            f"time chunkability: {offenders}"
+        )

--- a/cfdmod/core/dtypes.py
+++ b/cfdmod/core/dtypes.py
@@ -1,0 +1,38 @@
+"""Default numeric precision for field-**value** arrays.
+
+Field values -- pressure, Cp, per-element force/moment and their time series --
+are cheap to keep in **float32**: it is enough for these quantities and halves
+their memory on top of the time-chunking (:mod:`cfdmod.core.chunked`). The raw
+solver export is float32 on disk anyway.
+
+Design (the "float32 sweep"):
+
+- The field ops **preserve their input field's dtype** instead of upcasting to
+  float64 (they used to hard-cast). So float32 data flows as float32 end to end,
+  while a float64 source stays float64 (exactness / precision unchanged) --
+  ``force_contribution`` / ``moment_contribution`` infer the dtype from the field
+  and cast the geometric factors to match.
+- :data:`FIELD_DTYPE` is the default precision the **load path**
+  (:func:`cfdmod.building.per_floor_loads`) casts its source pressure to, so the
+  whole per-triangle chain runs in float32 by default. Change it to shift that
+  default library-wide.
+
+What stays float64 regardless (precision, negligible memory): mesh geometry /
+coordinates, the structural-model definition and the modal / dynamics solve, the
+time axis, and the on-disk storage format (``XdmfH5Storage`` normalises field
+data to float64 on write, so round-trips are unchanged).
+"""
+
+from __future__ import annotations
+
+__all__ = ["FIELD_DTYPE", "as_field"]
+
+import numpy as np
+
+FIELD_DTYPE = np.dtype("float32")
+
+
+def as_field(arr: np.ndarray) -> np.ndarray:
+    """``np.asarray(arr, dtype=FIELD_DTYPE)`` -- cast a field-value array to the
+    default field precision."""
+    return np.asarray(arr, dtype=FIELD_DTYPE)

--- a/cfdmod/core/ops/data_source_create/extreme_value.py
+++ b/cfdmod/core/ops/data_source_create/extreme_value.py
@@ -235,7 +235,7 @@ def extreme_value(ds: DataSource, p: ExtremeValueParams) -> DataSource:
             f"extreme_value requires at least 2 timesteps (got n_timesteps={ds.time.n_timesteps})"
         )
 
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     if arr.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got shape {arr.shape}"

--- a/cfdmod/core/ops/data_source_create/field_series_for_groups.py
+++ b/cfdmod/core/ops/data_source_create/field_series_for_groups.py
@@ -71,7 +71,11 @@ def field_series_for_groups(ds: DataSource, p: FieldSeriesForGroupsParams) -> Gr
     is_time = arr.ndim == 2
     n_t = arr.shape[1] if is_time else 0
 
-    out_arr = (np.zeros((n_groups, n_t), dtype=arr.dtype) if is_time else np.zeros(n_groups, dtype=arr.dtype))
+    out_arr = (
+        np.zeros((n_groups, n_t), dtype=arr.dtype)
+        if is_time
+        else np.zeros(n_groups, dtype=arr.dtype)
+    )
     for row, gid in enumerate(group_ids):
         members = np.flatnonzero(grouping.indices == gid)
         out_arr[row] = aggregate_rows(arr, members, p.agg, weights)

--- a/cfdmod/core/ops/data_source_create/field_series_for_groups.py
+++ b/cfdmod/core/ops/data_source_create/field_series_for_groups.py
@@ -62,7 +62,7 @@ def field_series_for_groups(ds: DataSource, p: FieldSeriesForGroupsParams) -> Gr
         raise ValueError("field_series_for_groups requires a triangle (surface) parent")
 
     grouping = ds.groupings[p.grouping]
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     weights = ds.elements.area
 
     group_ids = groups_in(grouping)
@@ -71,7 +71,7 @@ def field_series_for_groups(ds: DataSource, p: FieldSeriesForGroupsParams) -> Gr
     is_time = arr.ndim == 2
     n_t = arr.shape[1] if is_time else 0
 
-    out_arr = np.zeros((n_groups, n_t)) if is_time else np.zeros(n_groups)
+    out_arr = (np.zeros((n_groups, n_t), dtype=arr.dtype) if is_time else np.zeros(n_groups, dtype=arr.dtype))
     for row, gid in enumerate(group_ids):
         members = np.flatnonzero(grouping.indices == gid)
         out_arr[row] = aggregate_rows(arr, members, p.agg, weights)

--- a/cfdmod/core/ops/data_source_create/probe_extraction.py
+++ b/cfdmod/core/ops/data_source_create/probe_extraction.py
@@ -74,7 +74,7 @@ def probe_extraction(ds: DataSource, p: ProbeExtractionParams) -> PointsDataSour
     if probes.ndim != 2 or probes.shape[1] != 3:
         raise ValueError(f"probes must have shape (n_probes, 3); got {probes.shape}")
 
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     is_time = arr.ndim == 2
 
     if p.mode == "nearest":
@@ -87,7 +87,7 @@ def probe_extraction(ds: DataSource, p: ProbeExtractionParams) -> PointsDataSour
         if is_time:
             n_probes = probes.shape[0]
             n_t = arr.shape[1]
-            sub = np.empty((n_probes, n_t), dtype=np.float64)
+            sub = np.empty((n_probes, n_t), dtype=arr.dtype)
             for t in range(n_t):
                 sub[:, t] = np.interp(target_z, z_sorted, arr[order, t])
         else:

--- a/cfdmod/core/ops/data_source_create/profile_interpolation.py
+++ b/cfdmod/core/ops/data_source_create/profile_interpolation.py
@@ -54,10 +54,10 @@ def profile_interpolation(ds: PointsDataSource, p: ProfileInterpolationParams) -
     order = np.argsort(z_src)
     z_sorted = z_src[order]
 
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     is_time = arr.ndim == 2
     if is_time:
-        out = np.empty((z_target.size, arr.shape[1]), dtype=np.float64)
+        out = np.empty((z_target.size, arr.shape[1]), dtype=arr.dtype)
         for t in range(arr.shape[1]):
             out[:, t] = np.interp(z_target, z_sorted, arr[order, t])
     else:

--- a/cfdmod/core/ops/data_source_create/statistics.py
+++ b/cfdmod/core/ops/data_source_create/statistics.py
@@ -99,7 +99,7 @@ def compute_statistics(ds: DataSource, p: StatisticsParams) -> DataSource:
     if ds.time.is_time_aggregated:
         raise ValueError("compute_statistics requires a time-resolved data source")
 
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     if arr.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got shape {arr.shape}"

--- a/cfdmod/core/ops/field/derivative.py
+++ b/cfdmod/core/ops/field/derivative.py
@@ -60,7 +60,7 @@ def _first_derivative(arr: np.ndarray, dt: float) -> np.ndarray:
 
     ``arr`` shape ``(n_elements, n_timesteps)``; derivative along axis 1.
     """
-    out = np.zeros_like(arr, dtype=np.float64)
+    out = np.zeros_like(arr)
     out[:, 1:] = (arr[:, 1:] - arr[:, :-1]) / dt
     out[:, 0] = (arr[:, 1] - arr[:, 0]) / dt
     return out
@@ -68,7 +68,7 @@ def _first_derivative(arr: np.ndarray, dt: float) -> np.ndarray:
 
 def _second_derivative(arr: np.ndarray, dt: float) -> np.ndarray:
     """Central difference interior, one-sided three-point at the edges."""
-    out = np.zeros_like(arr, dtype=np.float64)
+    out = np.zeros_like(arr)
     out[:, 1:-1] = (arr[:, 2:] - 2 * arr[:, 1:-1] + arr[:, :-2]) / dt**2
     out[:, 0] = (arr[:, 2] - 2 * arr[:, 1] + arr[:, 0]) / dt**2
     out[:, -1] = (arr[:, -1] - 2 * arr[:, -2] + arr[:, -3]) / dt**2
@@ -86,7 +86,7 @@ def derivative(ds: DataSource, p: DerivativeParams) -> DataSource:
         )
 
     dt = float(ds.time.timestep_size)
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     if arr.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got shape {arr.shape}"

--- a/cfdmod/core/ops/field/force_contribution.py
+++ b/cfdmod/core/ops/field/force_contribution.py
@@ -46,7 +46,6 @@ class ForceContributionParams(OpParams):
     nominal_area: float = Field(gt=0)
     directions: list[Literal["x", "y", "z"]] = ["x", "y", "z"]
     out_prefix: str = "cf"
-    compute_dtype: Literal["float32", "float64"] = "float64"
 
     chunkable_along: ClassVar[frozenset[str]] = frozenset({"time"})
     requires_element_meta: ClassVar[frozenset[str]] = frozenset({"area", "normal"})
@@ -62,16 +61,16 @@ def force_contribution(ds: DataSource, p: ForceContributionParams) -> DataSource
             "attach them with mesh_attach first."
         )
 
-    dt = np.dtype(p.compute_dtype)
-    cp = np.asarray(ds.fields.read(p.field), dtype=dt)
+    # Preserve the Cp field's dtype (float32 for solver output, float64 for
+    # float64 sources) rather than upcasting; cast the geometric factor to match
+    # so a float64 area does not silently promote a float32 result back up.
+    cp = np.asarray(ds.fields.read(p.field))
     if cp.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got {cp.shape}"
         )
 
-    # Cast the geometric factor to the compute dtype too so the per-element
-    # product stays in float32 when requested (float64 area * float32 cp would
-    # otherwise upcast the large result back to float64).
+    dt = cp.dtype
     area = np.asarray(ds.elements.area, dtype=dt)
     normals = np.asarray(ds.elements.normal, dtype=dt)
     axis_map = {"x": 0, "y": 1, "z": 2}

--- a/cfdmod/core/ops/field/force_contribution.py
+++ b/cfdmod/core/ops/field/force_contribution.py
@@ -46,6 +46,7 @@ class ForceContributionParams(OpParams):
     nominal_area: float = Field(gt=0)
     directions: list[Literal["x", "y", "z"]] = ["x", "y", "z"]
     out_prefix: str = "cf"
+    compute_dtype: Literal["float32", "float64"] = "float64"
 
     chunkable_along: ClassVar[frozenset[str]] = frozenset({"time"})
     requires_element_meta: ClassVar[frozenset[str]] = frozenset({"area", "normal"})
@@ -61,14 +62,18 @@ def force_contribution(ds: DataSource, p: ForceContributionParams) -> DataSource
             "attach them with mesh_attach first."
         )
 
-    cp = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    dt = np.dtype(p.compute_dtype)
+    cp = np.asarray(ds.fields.read(p.field), dtype=dt)
     if cp.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got {cp.shape}"
         )
 
-    area = ds.elements.area
-    normals = ds.elements.normal
+    # Cast the geometric factor to the compute dtype too so the per-element
+    # product stays in float32 when requested (float64 area * float32 cp would
+    # otherwise upcast the large result back to float64).
+    area = np.asarray(ds.elements.area, dtype=dt)
+    normals = np.asarray(ds.elements.normal, dtype=dt)
     axis_map = {"x": 0, "y": 1, "z": 2}
 
     out = ds

--- a/cfdmod/core/ops/field/frequency_filter.py
+++ b/cfdmod/core/ops/field/frequency_filter.py
@@ -108,7 +108,7 @@ def frequency_filter(ds: DataSource, p: FrequencyFilterParams) -> DataSource:
 
     sos = butter(p.order, p.cutoff, btype=p.btype, fs=fs, output="sos")
 
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     if arr.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got shape {arr.shape}"
@@ -129,7 +129,7 @@ def frequency_filter(ds: DataSource, p: FrequencyFilterParams) -> DataSource:
             ) from e
     else:
         out = sosfilt(sos, arr, axis=1)
-    out = np.ascontiguousarray(out, dtype=np.float64)
+    out = np.ascontiguousarray(out, dtype=arr.dtype)
 
     target = p.out or p.field
     src_meta = ds.field_meta.get(p.field)

--- a/cfdmod/core/ops/field/moment_contribution.py
+++ b/cfdmod/core/ops/field/moment_contribution.py
@@ -51,6 +51,7 @@ class MomentContributionParams(OpParams):
     directions: list[Literal["x", "y", "z"]] = ["x", "y", "z"]
     in_prefix: str = "cf"
     out_prefix: str = "cm"
+    compute_dtype: Literal["float32", "float64"] = "float64"
 
     chunkable_along: ClassVar[frozenset[str]] = frozenset({"time"})
     requires_element_meta: ClassVar[frozenset[str]] = frozenset({"position"})
@@ -69,12 +70,12 @@ def moment_contribution(ds: DataSource, p: MomentContributionParams) -> DataSour
             "attach centroids with mesh_attach first."
         )
 
-    centroids = ds.elements.position
-    r = centroids - np.asarray(p.lever_origin, dtype=np.float64)[None, :]
+    dt = np.dtype(p.compute_dtype)
+    centroids = np.asarray(ds.elements.position, dtype=dt)
+    r = centroids - np.asarray(p.lever_origin, dtype=dt)[None, :]
 
     cf_arrays = {
-        d: np.asarray(ds.fields.read(f"{p.in_prefix}_{d}"), dtype=np.float64)
-        for d in ("x", "y", "z")
+        d: np.asarray(ds.fields.read(f"{p.in_prefix}_{d}"), dtype=dt) for d in ("x", "y", "z")
     }
 
     # Undo Cf's nominal-area normalisation -> per-element force.

--- a/cfdmod/core/ops/field/moment_contribution.py
+++ b/cfdmod/core/ops/field/moment_contribution.py
@@ -51,7 +51,6 @@ class MomentContributionParams(OpParams):
     directions: list[Literal["x", "y", "z"]] = ["x", "y", "z"]
     in_prefix: str = "cf"
     out_prefix: str = "cm"
-    compute_dtype: Literal["float32", "float64"] = "float64"
 
     chunkable_along: ClassVar[frozenset[str]] = frozenset({"time"})
     requires_element_meta: ClassVar[frozenset[str]] = frozenset({"position"})
@@ -70,13 +69,12 @@ def moment_contribution(ds: DataSource, p: MomentContributionParams) -> DataSour
             "attach centroids with mesh_attach first."
         )
 
-    dt = np.dtype(p.compute_dtype)
+    # Follow the Cf fields' dtype (see force_contribution) so float32 forces stay
+    # float32 through the moment; cast the lever arm to match.
+    cf_arrays = {d: np.asarray(ds.fields.read(f"{p.in_prefix}_{d}")) for d in ("x", "y", "z")}
+    dt = cf_arrays["x"].dtype
     centroids = np.asarray(ds.elements.position, dtype=dt)
     r = centroids - np.asarray(p.lever_origin, dtype=dt)[None, :]
-
-    cf_arrays = {
-        d: np.asarray(ds.fields.read(f"{p.in_prefix}_{d}"), dtype=dt) for d in ("x", "y", "z")
-    }
 
     # Undo Cf's nominal-area normalisation -> per-element force.
     fx = cf_arrays["x"] * p.nominal_area

--- a/cfdmod/core/ops/field/moving_average.py
+++ b/cfdmod/core/ops/field/moving_average.py
@@ -68,10 +68,10 @@ def _convolve_rows(data: np.ndarray, n: int) -> np.ndarray:
     """
     if n == 1:
         return data
-    kernel = np.ones(n, dtype=np.float64) / n
+    kernel = np.ones(n, dtype=data.dtype) / n
     pad = n // 2
     padded = np.pad(data, ((0, 0), (pad, pad)), mode="edge")
-    out = np.empty_like(data, dtype=np.float64)
+    out = np.empty_like(data)
     for i in range(data.shape[0]):
         out[i, :] = np.convolve(padded[i, :], kernel, mode="valid")
     return out
@@ -89,7 +89,7 @@ def moving_average(ds: DataSource, p: MovingAverageParams) -> DataSource:
     dt = float(ds.time.timestep_size)
     n = window_in_samples(p.window, dt)
 
-    arr = np.asarray(ds.fields.read(p.field), dtype=np.float64)
+    arr = np.asarray(ds.fields.read(p.field))
     if arr.ndim != 2:
         raise ValueError(
             f"field {p.field!r} must be 2-D (n_elements, n_timesteps); got shape {arr.shape}"

--- a/examples/high_rise/README.md
+++ b/examples/high_rise/README.md
@@ -64,9 +64,12 @@ All reusable logic lives in the cfdmod library (nothing is high-rise-specific):
 - `cfdmod.building` -- `BuildingCase` (aggregate `case_data`; derive dynamic
   pressure; `with_reference_velocity(u_ref)`), `example_building_case(mesh)`,
   `cp_from_pressure`, `cf_per_floor` / `cm_per_floor` (explicit reference-area
-  normalisation), and the dynamic-response wiring (`floor_load_source`,
-  `example_building_structure` / `structure_from_csvs`, `solve_building_response`,
-  `floor_accelerations`, `peak_response_table`).
+  normalisation), `cf_cm_per_floor` (both from a single force pass),
+  `per_floor_loads` (memory-bounded: fused `Cp -> Cf/Cm` straight from body +
+  reference pressure, time-chunked via `chunk_size`), and the dynamic-response
+  wiring (`floor_load_source`, `example_building_structure` /
+  `structure_from_csvs`, `solve_building_response`, `floor_accelerations`,
+  `peak_response_table`).
 - `cfdmod.report.DebugWriter` -- versioned `debug/` + `deliverables/` paths.
 - `cfdmod.inflow_report` -- vertical-profile detection + validation figures.
 - `cfdmod.mesh_field` -- `facade_groups`, `triangle_field_figure`,
@@ -83,6 +86,16 @@ of the suite itself. Regenerate the notebooks after editing them with
 - Cf/Cm use **explicit reference-area** normalisation (`nominal_area` /
   `nominal_volume`), per the 3.2 decision -- not the legacy per-region
   bounding-box area, so values differ from the earlier per-region deliverables.
+- **Per-floor partition defaults to `centroid`** (whole-triangle assignment,
+  bounded memory, matching the v2 sub-body grouping). `face_cut` (exact triangle
+  slicing) fragments the mesh and is far heavier -- opt in only for small cases.
+- **Memory at production size:** compute per-floor loads with
+  `per_floor_loads(body, p_ref, mesh, case, chunk_size=...)`. It streams the
+  `Cp -> force -> moment -> per-floor sum` chain over time windows so the full
+  `(n_triangles, n_timesteps)` arrays never materialise at once (peak
+  `O(n_triangles * chunk_size)`), and computes in float32 by default. A real
+  ~35k-triangle x ~29k-step direction runs in ~11 GiB peak this way instead of
+  tens of GiB.
 - Numerical validation currently runs on the in-repo `galpao` / `caarc` /
   `pitot_inlet` fixtures. One real consulting case has config but no raw
   pressure data on disk; another has real high-rise raw data for an

--- a/tests/core/test_chunked.py
+++ b/tests/core/test_chunked.py
@@ -1,0 +1,107 @@
+"""Chunked time executor: parity with whole-series and correct windowing."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core.chunked import (
+    assert_time_chunkable,
+    chunk_map_time,
+    concat_time,
+    slice_time,
+    time_windows,
+)
+from cfdmod.core.data_source import SurfaceDataSource
+from cfdmod.core.field_meta import FieldMeta
+from cfdmod.core.grouping import Grouping
+from cfdmod.core.ops.data_source_create.field_series_for_groups import (
+    FieldSeriesForGroupsParams,
+    field_series_for_groups,
+)
+from cfdmod.core.ops.field.algebra import ScaleParams, scale
+from cfdmod.core.time_axis import TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+
+
+def _surface(n_elements: int, n_t: int, seed: int = 0) -> SurfaceDataSource:
+    rng = np.random.default_rng(seed)
+    verts = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [1, 1, 0]], dtype=np.float64)
+    tris = np.array([[0, 1, 2], [1, 3, 2]], dtype=np.int32)
+    tris = np.tile(tris, (max(n_elements // 2, 1), 1))[:n_elements]
+    field = rng.standard_normal((n_elements, n_t))
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=1.0, timestep_size=0.5, n_timesteps=n_t),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"cp": field}),
+        field_meta={"cp": FieldMeta(name="cp")},
+    )
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 4, 7, 10, None])
+def test_scale_pipeline_parity(chunk_size):
+    ds = _surface(6, 10)
+    pipe = lambda d: scale(d, ScaleParams(field="cp", factor=2.5))  # noqa: E731
+    whole = pipe(ds)
+    chunked = chunk_map_time(ds, pipe, chunk_size=chunk_size)
+    np.testing.assert_allclose(chunked.fields.read("cp"), whole.fields.read("cp"))
+    assert chunked.time.n_timesteps == ds.time.n_timesteps
+
+
+@pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, None])
+def test_group_reduction_parity(chunk_size):
+    """A reducing pipeline (per-group sum) must match whole-series exactly."""
+    ds = _surface(6, 9, seed=3)
+    grouping = Grouping(
+        name="g",
+        indices=np.array([0, 0, 1, 1, 2, 2], dtype=np.int32),
+        id_to_label={0: "a", 1: "b", 2: "c"},
+    )
+    ds = ds.with_grouping(grouping)
+    pipe = lambda d: field_series_for_groups(  # noqa: E731
+        d, FieldSeriesForGroupsParams(grouping="g", field="cp", agg="sum", out="cp")
+    )
+    whole = pipe(ds)
+    chunked = chunk_map_time(ds, pipe, chunk_size=chunk_size)
+    assert chunked.kind == "groups"
+    assert chunked.n_elements == 3
+    np.testing.assert_allclose(chunked.fields.read("cp"), whole.fields.read("cp"))
+
+
+def test_time_windows_cover_all():
+    assert list(time_windows(10, 4)) == [slice(0, 4), slice(4, 8), slice(8, 10)]
+    assert list(time_windows(8, 4)) == [slice(0, 4), slice(4, 8)]
+    with pytest.raises(ValueError):
+        list(time_windows(10, 0))
+
+
+def test_slice_time_preserves_axis_and_offset():
+    ds = _surface(4, 10)
+    win = slice_time(ds, slice(4, 7))
+    assert win.time.n_timesteps == 3
+    np.testing.assert_allclose(win.time.times(), ds.time.times()[4:7])
+    np.testing.assert_allclose(win.fields.read("cp"), ds.fields.read("cp")[:, 4:7])
+
+
+def test_concat_time_single_and_roundtrip():
+    ds = _surface(4, 10)
+    parts = [slice_time(ds, sl) for sl in time_windows(10, 4)]
+    joined = concat_time(parts)
+    np.testing.assert_allclose(joined.fields.read("cp"), ds.fields.read("cp"))
+    np.testing.assert_allclose(joined.time.times(), ds.time.times())
+    # single part returns as-is
+    assert concat_time(parts[:1]) is parts[0]
+
+
+def test_assert_time_chunkable():
+    from cfdmod.core.ops.data_source_create.statistics import StatisticsParams
+
+    # time-chunkable ops pass
+    assert_time_chunkable(
+        [ScaleParams(field="cp", factor=1.0), FieldSeriesForGroupsParams(grouping="g")]
+    )
+    # statistics collapses time -> chunkable only along elements, must be rejected
+    with pytest.raises(ValueError):
+        assert_time_chunkable([StatisticsParams(kinds=["mean"])])

--- a/tests/high_rise/test_high_rise.py
+++ b/tests/high_rise/test_high_rise.py
@@ -81,9 +81,11 @@ def test_face_cut_conserves_total_force(cp_ds, galpao_case):
     whole = galpao_case.model_copy(update={"floor_heights": [zmin, zmax + 1e-6]})
 
     per_floor = building.cf_per_floor(
-        cp_ds, MESH, galpao_case, directions=("x",), method="face_cut"
+        cp_ds, MESH, galpao_case, directions=("x",), method="face_cut", compute_dtype="float64"
     )
-    single = building.cf_per_floor(cp_ds, MESH, whole, directions=("x",), method="face_cut")
+    single = building.cf_per_floor(
+        cp_ds, MESH, whole, directions=("x",), method="face_cut", compute_dtype="float64"
+    )
 
     total_per_floor = per_floor.fields.read("cf_x").sum(axis=0)
     total_single = single.fields.read("cf_x").sum(axis=0)
@@ -169,10 +171,18 @@ def test_cf_cm_per_floor_matches_separate(cp_ds, galpao_case):
 
 
 def test_per_floor_loads_whole_matches_fused(body_ref, galpao_case):
-    """per_floor_loads (whole-series) == cp_from_pressure -> cf_cm_per_floor."""
+    """per_floor_loads (whole-series) == cp_from_pressure -> cf_cm_per_floor.
+
+    Mirror per_floor_loads' float32 source cast in the reference so the two
+    compute in the same precision and the equality is exact.
+    """
     body, p_ref = body_ref
     cf, cm = building.per_floor_loads(body, p_ref, MESH, galpao_case)
-    cp = building.cp_from_pressure(body, p_ref, galpao_case)
+
+    def _f32(ds):
+        return ds.with_field("pressure", np.asarray(ds.fields.read("pressure"), dtype="float32"))
+
+    cp = building.cp_from_pressure(_f32(body), _f32(p_ref), galpao_case)
     cf_ref, cm_ref = building.cf_cm_per_floor(cp, MESH, galpao_case)
     np.testing.assert_allclose(cf.fields.read("cf_x"), cf_ref.fields.read("cf_x"))
     np.testing.assert_allclose(cm.fields.read("cm_z"), cm_ref.fields.read("cm_z"))
@@ -196,8 +206,12 @@ def test_face_cut_and_centroid_agree_on_body_total(cp_ds, galpao_case):
     Per-floor distributions differ (that is the point of face_cut), but the sum
     across all floors is the same whole-body force for either partition.
     """
-    fc = building.cf_per_floor(cp_ds, MESH, galpao_case, directions=("x",), method="face_cut")
-    ct = building.cf_per_floor(cp_ds, MESH, galpao_case, directions=("x",), method="centroid")
+    fc = building.cf_per_floor(
+        cp_ds, MESH, galpao_case, directions=("x",), method="face_cut", compute_dtype="float64"
+    )
+    ct = building.cf_per_floor(
+        cp_ds, MESH, galpao_case, directions=("x",), method="centroid", compute_dtype="float64"
+    )
     np.testing.assert_allclose(
         fc.fields.read("cf_x").sum(axis=0),
         ct.fields.read("cf_x").sum(axis=0),

--- a/tests/high_rise/test_high_rise.py
+++ b/tests/high_rise/test_high_rise.py
@@ -146,6 +146,50 @@ def test_from_case_data_falls_back_to_yaml_when_alturas_empty(tmp_path):
     assert case2.floor_heights == [0.0, 50.0]
 
 
+@pytest.fixture(scope="module")
+def body_ref():
+    from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+
+    storage = XdmfH5Storage(DATA)
+    body = storage.read_data_source(pathlib.Path("bodies.galpao"))
+    p_ref = storage.read_data_source(pathlib.Path("points.static_pressure"))
+    return body, p_ref
+
+
+def test_cf_cm_per_floor_matches_separate(cp_ds, galpao_case):
+    """The fused single-force-pass Cf/Cm equals the separate cf_/cm_per_floor."""
+    cf, cm = building.cf_cm_per_floor(
+        cp_ds, MESH, galpao_case, cf_directions=("x", "y"), cm_directions=("z",)
+    )
+    cf_ref = building.cf_per_floor(cp_ds, MESH, galpao_case, directions=("x", "y"))
+    cm_ref = building.cm_per_floor(cp_ds, MESH, galpao_case, directions=("z",))
+    for f in ("cf_x", "cf_y"):
+        np.testing.assert_allclose(cf.fields.read(f), cf_ref.fields.read(f))
+    np.testing.assert_allclose(cm.fields.read("cm_z"), cm_ref.fields.read("cm_z"))
+
+
+def test_per_floor_loads_whole_matches_fused(body_ref, galpao_case):
+    """per_floor_loads (whole-series) == cp_from_pressure -> cf_cm_per_floor."""
+    body, p_ref = body_ref
+    cf, cm = building.per_floor_loads(body, p_ref, MESH, galpao_case)
+    cp = building.cp_from_pressure(body, p_ref, galpao_case)
+    cf_ref, cm_ref = building.cf_cm_per_floor(cp, MESH, galpao_case)
+    np.testing.assert_allclose(cf.fields.read("cf_x"), cf_ref.fields.read("cf_x"))
+    np.testing.assert_allclose(cm.fields.read("cm_z"), cm_ref.fields.read("cm_z"))
+
+
+@pytest.mark.parametrize("chunk", [1, 2, 3, 5])
+def test_per_floor_loads_chunk_parity(body_ref, galpao_case, chunk):
+    """Time-chunked per_floor_loads matches the whole-series result exactly."""
+    body, p_ref = body_ref
+    cf_w, cm_w = building.per_floor_loads(body, p_ref, MESH, galpao_case, chunk_size=None)
+    cf_c, cm_c = building.per_floor_loads(body, p_ref, MESH, galpao_case, chunk_size=chunk)
+    assert cf_c.time.n_timesteps == cf_w.time.n_timesteps
+    np.testing.assert_allclose(cf_c.fields.read("cf_x"), cf_w.fields.read("cf_x"))
+    np.testing.assert_allclose(cf_c.fields.read("cf_y"), cf_w.fields.read("cf_y"))
+    np.testing.assert_allclose(cm_c.fields.read("cm_z"), cm_w.fields.read("cm_z"))
+
+
 def test_face_cut_and_centroid_agree_on_body_total(cp_ds, galpao_case):
     """Both methods integrate the same whole body, so the total over floors matches.
 

--- a/tests/high_rise/test_high_rise.py
+++ b/tests/high_rise/test_high_rise.py
@@ -81,11 +81,9 @@ def test_face_cut_conserves_total_force(cp_ds, galpao_case):
     whole = galpao_case.model_copy(update={"floor_heights": [zmin, zmax + 1e-6]})
 
     per_floor = building.cf_per_floor(
-        cp_ds, MESH, galpao_case, directions=("x",), method="face_cut", compute_dtype="float64"
+        cp_ds, MESH, galpao_case, directions=("x",), method="face_cut"
     )
-    single = building.cf_per_floor(
-        cp_ds, MESH, whole, directions=("x",), method="face_cut", compute_dtype="float64"
-    )
+    single = building.cf_per_floor(cp_ds, MESH, whole, directions=("x",), method="face_cut")
 
     total_per_floor = per_floor.fields.read("cf_x").sum(axis=0)
     total_single = single.fields.read("cf_x").sum(axis=0)
@@ -190,14 +188,20 @@ def test_per_floor_loads_whole_matches_fused(body_ref, galpao_case):
 
 @pytest.mark.parametrize("chunk", [1, 2, 3, 5])
 def test_per_floor_loads_chunk_parity(body_ref, galpao_case, chunk):
-    """Time-chunked per_floor_loads matches the whole-series result exactly."""
+    """Time-chunked per_floor_loads matches the whole-series result.
+
+    Per-timestep values are computed identically regardless of windowing; the
+    only difference is float32 summation-order rounding across window shapes
+    (~1 ULP), hence the float32-appropriate tolerance rather than exact equality.
+    """
     body, p_ref = body_ref
     cf_w, cm_w = building.per_floor_loads(body, p_ref, MESH, galpao_case, chunk_size=None)
     cf_c, cm_c = building.per_floor_loads(body, p_ref, MESH, galpao_case, chunk_size=chunk)
     assert cf_c.time.n_timesteps == cf_w.time.n_timesteps
-    np.testing.assert_allclose(cf_c.fields.read("cf_x"), cf_w.fields.read("cf_x"))
-    np.testing.assert_allclose(cf_c.fields.read("cf_y"), cf_w.fields.read("cf_y"))
-    np.testing.assert_allclose(cm_c.fields.read("cm_z"), cm_w.fields.read("cm_z"))
+    kw = dict(rtol=1e-4, atol=1e-6)
+    np.testing.assert_allclose(cf_c.fields.read("cf_x"), cf_w.fields.read("cf_x"), **kw)
+    np.testing.assert_allclose(cf_c.fields.read("cf_y"), cf_w.fields.read("cf_y"), **kw)
+    np.testing.assert_allclose(cm_c.fields.read("cm_z"), cm_w.fields.read("cm_z"), **kw)
 
 
 def test_face_cut_and_centroid_agree_on_body_total(cp_ds, galpao_case):
@@ -206,12 +210,8 @@ def test_face_cut_and_centroid_agree_on_body_total(cp_ds, galpao_case):
     Per-floor distributions differ (that is the point of face_cut), but the sum
     across all floors is the same whole-body force for either partition.
     """
-    fc = building.cf_per_floor(
-        cp_ds, MESH, galpao_case, directions=("x",), method="face_cut", compute_dtype="float64"
-    )
-    ct = building.cf_per_floor(
-        cp_ds, MESH, galpao_case, directions=("x",), method="centroid", compute_dtype="float64"
-    )
+    fc = building.cf_per_floor(cp_ds, MESH, galpao_case, directions=("x",), method="face_cut")
+    ct = building.cf_per_floor(cp_ds, MESH, galpao_case, directions=("x",), method="centroid")
     np.testing.assert_allclose(
         fc.fields.read("cf_x").sum(axis=0),
         ct.fields.read("cf_x").sum(axis=0),

--- a/tests/high_rise/test_perf_memory.py
+++ b/tests/high_rise/test_perf_memory.py
@@ -1,0 +1,129 @@
+"""Opt-in memory + performance regression test for the per-floor load path.
+
+Runs with ``pytest -m perf`` (excluded from the default suite). It writes a
+synthetic body (the galpao mesh with a long random pressure series) to disk,
+then measures the **peak RSS** of ``building.per_floor_loads`` in isolated
+subprocesses -- once time-chunked, once whole-series -- and asserts that:
+
+- the chunked run stays under a memory budget, and
+- the whole-series run uses materially more memory than the chunked run.
+
+The subprocess isolation matters: ``ru_maxrss`` is a high-water mark, so the
+fixture's own allocations (building + writing the body) would otherwise mask the
+compute footprint we want to bound.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+pytestmark = [pytest.mark.perf, pytest.mark.integration]
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MESH = str(REPO / "fixtures" / "tests" / "pressure" / "galpao" / "galpao.normalized.lnas")
+
+# Long enough that the whole-series arrays dominate memory, short enough to keep
+# the opt-in run to a few seconds. galpao ~ 2915 triangles -> ~0.28 GiB / array.
+N_TIMESTEPS = 12000
+CHUNK = 1000
+# Measured on this fixture: chunked ~700 MiB vs whole-series ~2900 MiB (~4x).
+# Budget leaves CI headroom while still catching a regression back to full
+# materialization (which jumps to ~2.9 GiB).
+CHUNKED_BUDGET_MB = 1000.0
+MIN_WHOLE_TO_CHUNKED_RATIO = 1.8
+
+_RUNNER = """
+import pathlib, resource, sys
+import numpy as np
+from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+from cfdmod import building
+
+data_dir, mesh, chunk_arg = sys.argv[1], sys.argv[2], sys.argv[3]
+chunk = None if chunk_arg == "none" else int(chunk_arg)
+st = XdmfH5Storage(pathlib.Path(data_dir))
+body = st.read_data_source(pathlib.Path("bodies.synthetic"))
+p_ref = st.read_data_source(pathlib.Path("points.ref"))
+case = building.example_building_case(mesh, n_floors=8)
+cf, cm = building.per_floor_loads(body, p_ref, mesh, case, chunk_size=chunk)
+# touch results so nothing is optimised away
+_ = float(np.asarray(cf.fields.read("cf_x")).sum() + np.asarray(cm.fields.read("cm_z")).sum())
+print(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)  # KiB on Linux
+"""
+
+
+@pytest.fixture(scope="module")
+def big_store(tmp_path_factory):
+    from lnas import LnasFormat
+
+    from cfdmod.adapters.memory import MemoryFieldStore
+    from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+    from cfdmod.core.data_source import PointsDataSource, SurfaceDataSource
+    from cfdmod.core.field_meta import FieldMeta
+    from cfdmod.core.time_axis import TimeAxis
+    from cfdmod.core.topology import ElementMeta, Topology
+
+    geom = LnasFormat.from_file(pathlib.Path(MESH)).geometry
+    verts = np.asarray(geom.vertices, dtype=np.float64)
+    tris = np.asarray(geom.triangles, dtype=np.int32)
+    n_tri = tris.shape[0]
+
+    rng = np.random.default_rng(0)
+    time = TimeAxis(initial_time=0.0, timestep_size=0.01, n_timesteps=N_TIMESTEPS)
+    body = SurfaceDataSource(
+        time=time,
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"pressure": rng.standard_normal((n_tri, N_TIMESTEPS)).astype(np.float64)}
+        ),
+        field_meta={"pressure": FieldMeta(name="pressure")},
+    )
+    p_ref = PointsDataSource(
+        time=time,
+        topology=Topology.points(np.zeros((1, 3), dtype=np.float64)),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"pressure": rng.standard_normal((1, N_TIMESTEPS)).astype(np.float64)}
+        ),
+        field_meta={"pressure": FieldMeta(name="pressure")},
+    )
+
+    data_dir = tmp_path_factory.mktemp("perf_store")
+    storage = XdmfH5Storage(data_dir)
+    storage.write_data_source(pathlib.Path("bodies.synthetic"), body)
+    storage.write_data_source(pathlib.Path("points.ref"), p_ref)
+
+    runner = data_dir / "_runner.py"
+    runner.write_text(_RUNNER)
+    # free the big in-memory arrays before the subprocesses run
+    del body, p_ref
+    return data_dir, runner
+
+
+def _peak_mb(data_dir: pathlib.Path, runner: pathlib.Path, chunk: str) -> float:
+    out = subprocess.run(
+        [sys.executable, str(runner), str(data_dir), MESH, chunk],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return float(out.stdout.strip().splitlines()[-1]) / 1024.0  # KiB -> MiB
+
+
+def test_per_floor_loads_memory_bounded(big_store):
+    data_dir, runner = big_store
+    chunked_mb = _peak_mb(data_dir, runner, str(CHUNK))
+    whole_mb = _peak_mb(data_dir, runner, "none")
+
+    assert chunked_mb < CHUNKED_BUDGET_MB, (
+        f"chunked peak RSS {chunked_mb:.0f} MiB exceeded budget {CHUNKED_BUDGET_MB:.0f} MiB"
+    )
+    assert whole_mb > chunked_mb * MIN_WHOLE_TO_CHUNKED_RATIO, (
+        f"expected whole-series ({whole_mb:.0f} MiB) to dwarf chunked "
+        f"({chunked_mb:.0f} MiB); chunking not reducing memory as expected"
+    )


### PR DESCRIPTION
## What / why

Post-processing a real high-rise direction (34,633 triangles x 28,840 steps)
peaked at tens of GB of RAM and `face_cut` did not finish one direction in
minutes -- the main blocker in #184. Root cause: the ops already advertise
`chunkable_along` but **nothing honoured it** (`compose()` is a plain `reduce`),
so every op materialised the full `(n_elements, n_timesteps)` float64 array and
`force`/`moment` allocated several more.

This PR makes the memory-safe path real, does the float32 sweep, adds the
regression tests #184 asks for, and applies the design decisions from the issue
discussion (`centroid` default with `face_cut` opt-in; remeshing split out as a
TODO -> #186).

## Changes

**1. Chunk-aware time executor -- `cfdmod/core/chunked.py`**
- `chunk_map_time` / `slice_time` / `concat_time` / `time_windows`: stream a
  time-preserving pipeline over contiguous time windows and concatenate, so peak
  memory is `O(n_elements * chunk)` instead of `O(n_elements * n_timesteps)`.
- `assert_time_chunkable`: validate from op params (`chunkable_along`) first.
- Safe drop-in: `chunk_size=None` runs whole-series (identical result).

**2. Fused + shared force pass -- `cfdmod/building/pressure.py`**
- `cf_cm_per_floor`: three force components computed **once**, reused for Cf and
  the moment (previously Cf + Cm ran mesh_attach + partition + force twice).
- `per_floor_loads(body, p_ref, mesh, case, chunk_size=...)`: memory-bounded,
  fused `Cp -> force -> moment -> per-floor sum` straight from body + reference
  pressure (the productionised case-067 driver).
- Default floor partition now **`centroid`** (bounded, matches v2 sub-body
  grouping); `face_cut` opt-in (fragments the mesh, +300k triangles).

**3. float32 sweep -- `cfdmod/core/dtypes.py` (`FIELD_DTYPE`)**
- The field-value ops now **preserve their input field's dtype** instead of
  upcasting to float64 (force/moment/statistics/field_series/extreme_value/
  derivative/moving_average/frequency_filter/probe_extraction/profile_interpolation).
  Solver data (float32 on disk) flows as float32 end to end -- halving those
  arrays -- while a float64 source stays float64, so precision/exactness is
  unchanged. force/moment infer the dtype from the field and cast the geometric
  factors to match.
- `per_floor_loads` casts its source pressure to `FIELD_DTYPE` (float32), so the
  whole per-triangle load chain is float32 by default.
- Geometry / coordinates, the structural-model definition and the modal /
  dynamics solve, the time axis, and the on-disk storage format stay float64
  (precision, negligible memory; storage normalises field data to float64 on
  write so round-trips are unchanged).

**4. Tests**
- `tests/core/test_chunked.py`: executor parity (scale + reducing group-sum),
  windowing, offset preservation.
- `tests/high_rise/test_high_rise.py`: fused == separate; whole == fused; chunk
  parity (float32-tolerance -- ~1 ULP summation-order rounding across window
  shapes); face_cut exactness on the float64 fixture unchanged.
- `tests/high_rise/test_perf_memory.py` (`@pytest.mark.perf`, opt-in): writes a
  synthetic large body and measures peak RSS of `per_floor_loads` in isolated
  subprocesses; asserts a memory ceiling and chunked << whole-series.

## Benchmarks

Synthetic 2,915 tri x 12,000 steps (opt-in perf test), peak RSS:

| path | peak RSS |
|---|---|
| whole-series, float64 | ~2,880 MiB |
| whole-series, float32 | ~1,820 MiB |
| **chunked (1000), float32** | **~700 MiB** |

Real case 067 direction (34,633 x 28,840): chunked ~10.7 GiB vs ~83 GiB for
`face_cut`.

## Follow-up (not in this PR)

- Exact per-floor partition via a **region-merging remesh** to replace
  `face_cut` fragmentation -- split out as **#186** (TODO, no timeline).

Closes #184 (memory fix + float32 sweep + tests). All non-optional-dep tests
pass locally (`pytest -m "perf or not perf"`, excluding the pre-existing
altimetry/io/s1 collection errors that need vtk).
