### PR TITLE
docs: render API reference autodoc via eval-rst

### DIFF
--- a/docs/source/api_reference.md
+++ b/docs/source/api_reference.md
@@ -18,22 +18,26 @@ per-coefficient functions.
 cfdmod run path/to/template.yaml
 ```
 
-```{autofunction} cfdmod.load_template
+```{eval-rst}
+.. autofunction:: cfdmod.load_template
 ```
 
-```{autofunction} cfdmod.run_template
+```{eval-rst}
+.. autofunction:: cfdmod.run_template
 ```
 
-```{autoclass} cfdmod.PipelineTemplate
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.PipelineTemplate
+   :members:
+   :show-inheritance:
 ```
 
 The op registry backing the template loader is extensible; register a new op
 with {func}`cfdmod.register_op` and inspect the built-ins in
 {data}`cfdmod.OP_REGISTRY`.
 
-```{autofunction} cfdmod.register_op
+```{eval-rst}
+.. autofunction:: cfdmod.register_op
 ```
 
 ## Data sources
@@ -45,47 +49,57 @@ or more named fields sharing that shape, plus element / time / field metadata.
 Ops consume and produce data sources; a {class}`cfdmod.Pipeline` (built with
 {func}`cfdmod.compose`) chains them.
 
-```{autoclass} cfdmod.DataSource
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.DataSource
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.SurfaceDataSource
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.SurfaceDataSource
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.VolumeDataSource
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.VolumeDataSource
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.PointsDataSource
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.PointsDataSource
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.GroupsDataSource
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.GroupsDataSource
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ModesDataSource
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ModesDataSource
+   :show-inheritance:
 ```
 
 ### Axes and topology
 
-```{autoclass} cfdmod.TimeAxis
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.TimeAxis
+   :members:
 ```
 
-```{autoclass} cfdmod.Topology
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.Topology
+   :members:
 ```
 
-```{autoclass} cfdmod.FieldMeta
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.FieldMeta
+   :members:
 ```
 
-```{autoclass} cfdmod.Grouping
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.Grouping
+   :members:
 ```
 
 ### Containers
@@ -94,25 +108,30 @@ A {class}`cfdmod.Container` aggregates many data sources under complex keys
 (case, direction, ...), the way a parametric study fans out over inflow
 angles.
 
-```{autoclass} cfdmod.Container
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.Container
+   :members:
 ```
 
 ### Pipelines and storage
 
-```{autoclass} cfdmod.Pipeline
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.Pipeline
+   :members:
 ```
 
-```{autofunction} cfdmod.compose
+```{eval-rst}
+.. autofunction:: cfdmod.compose
 ```
 
-```{autoclass} cfdmod.MemoryStorage
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.MemoryStorage
+   :members:
 ```
 
-```{autoclass} cfdmod.XdmfH5Storage
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.XdmfH5Storage
+   :members:
 ```
 
 ## Recipe configs
@@ -122,39 +141,46 @@ The pressure and wind recipes ship as small-data Pydantic configs under
 equivalent pipeline. Example templates live under
 `fixtures/tests/pressure/templates/`.
 
-```{autoclass} cfdmod.recipes.CpRecipeConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.CpRecipeConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.recipes.CfRecipeConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.CfRecipeConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.recipes.CmRecipeConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.CmRecipeConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.recipes.CeRecipeConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.CeRecipeConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.recipes.S1RecipeConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.S1RecipeConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.recipes.DynamicAnalysisConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.DynamicAnalysisConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.recipes.PedestrianComfortConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.recipes.PedestrianComfortConfig
+   :members:
+   :show-inheritance:
 ```
 
 ## Triangle-grouping pipeline
@@ -176,11 +202,13 @@ partitions are expressed by composing the built-in grouping kinds below.
 
 ### Driver
 
-```{autofunction} cfdmod.apply_groupings
+```{eval-rst}
+.. autofunction:: cfdmod.apply_groupings
 ```
 
-```{autoclass} cfdmod.GroupingResult
-:members:
+```{eval-rst}
+.. autoclass:: cfdmod.GroupingResult
+   :members:
 ```
 
 ### Built-in grouping kinds
@@ -191,54 +219,64 @@ Pydantic model under `cfdmod/geometry/grouping/kinds/` with a unique `kind`
 literal, registering it in the union, and adding a dispatch branch in
 `cfdmod.geometry.grouping.base._dispatch`.
 
-```{autoclass} cfdmod.BySurfaceGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.BySurfaceGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByZoningGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByZoningGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByDivisionsGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByDivisionsGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.BySizeGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.BySizeGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByConnectivityGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByConnectivityGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByNormalGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByNormalGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByPlaneGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByPlaneGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByPercentileGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByPercentileGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.ByCylindricalGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.ByCylindricalGrouping
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.CustomGrouping
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.CustomGrouping
+   :members:
+   :show-inheritance:
 ```
 
 ### Persistence
@@ -248,20 +286,24 @@ A grouping chain can be recorded alongside a coefficient's
 `{"groupings": cfdmod.dump_groupings(chain)}` (sibling to `"filters"`);
 {func}`cfdmod.load_groupings` rehydrates the typed spec instances on read.
 
-```{autofunction} cfdmod.dump_groupings
+```{eval-rst}
+.. autofunction:: cfdmod.dump_groupings
 ```
 
-```{autofunction} cfdmod.load_groupings
+```{eval-rst}
+.. autofunction:: cfdmod.load_groupings
 ```
 
 ## I/O helpers
 
 ### Mesh resolver
 
-```{autofunction} cfdmod.load_mesh
+```{eval-rst}
+.. autofunction:: cfdmod.load_mesh
 ```
 
-```{autofunction} cfdmod.mesh_from_h5
+```{eval-rst}
+.. autofunction:: cfdmod.mesh_from_h5
 ```
 
 ### Embedded post-processing metadata
@@ -270,10 +312,12 @@ Every pipeline output H5 carries a `processing_metadata` group with the config
 used to produce it. The two helpers below let external pipelines write or read
 that block without depending on the layout details.
 
-```{autofunction} cfdmod.write_processing_metadata
+```{eval-rst}
+.. autofunction:: cfdmod.write_processing_metadata
 ```
 
-```{autofunction} cfdmod.read_processing_metadata
+```{eval-rst}
+.. autofunction:: cfdmod.read_processing_metadata
 ```
 
 ### Timeseries access
@@ -282,21 +326,26 @@ Pull a coefficient timeseries out of any output H5 into a wide-form
 `pandas.DataFrame`, save it as CSV for spreadsheet ingest, or plot it with one
 matplotlib call.
 
-```{autofunction} cfdmod.read_timeseries_df
+```{eval-rst}
+.. autofunction:: cfdmod.read_timeseries_df
 ```
 
-```{autofunction} cfdmod.to_csv
+```{eval-rst}
+.. autofunction:: cfdmod.to_csv
 ```
 
-```{autofunction} cfdmod.plot_timeseries
+```{eval-rst}
+.. autofunction:: cfdmod.plot_timeseries
 ```
 
 ### Geometry I/O (STL)
 
-```{autofunction} cfdmod.read_stl
+```{eval-rst}
+.. autofunction:: cfdmod.read_stl
 ```
 
-```{autofunction} cfdmod.export_stl
+```{eval-rst}
+.. autofunction:: cfdmod.export_stl
 ```
 
 ## Remesh (geometry coarsening)
@@ -311,10 +360,12 @@ triangles, a curved patch unchanged.
 The module follows a small convention split. The two array-level functions
 take raw `(vertices, triangles)` and operate on a single sub-mesh:
 
-```{autofunction} cfdmod.merge_coplanar
+```{eval-rst}
+.. autofunction:: cfdmod.merge_coplanar
 ```
 
-```{autofunction} cfdmod.decimate_qem
+```{eval-rst}
+.. autofunction:: cfdmod.decimate_qem
 ```
 
 `decimate_qem` requires the optional `fast-simplification` dep
@@ -326,7 +377,8 @@ named surface in an `LnasFormat` and restitches the per-surface outputs back
 into a fresh `LnasFormat` (same surface names, `vertex` order recompacted,
 optional tolerance-based seam dedup):
 
-```{autofunction} cfdmod.remesh_per_group
+```{eval-rst}
+.. autofunction:: cfdmod.remesh_per_group
 ```
 
 ## Regroup (disk regroup pipeline)
@@ -339,29 +391,36 @@ aggregates per group). It reuses the grouping kinds above and adds one
 regroup-local spec that fans out per-component target-size subdivisions.
 Runnable as `python -m cfdmod.regroup`.
 
-```{autoclass} cfdmod.RegroupConfig
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.RegroupConfig
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.BySizeRoundedPerComponent
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.BySizeRoundedPerComponent
+   :members:
+   :show-inheritance:
 ```
 
-```{autofunction} cfdmod.build_regroup_mapping
+```{eval-rst}
+.. autofunction:: cfdmod.build_regroup_mapping
 ```
 
-```{autofunction} cfdmod.build_regrouped_mesh
+```{eval-rst}
+.. autofunction:: cfdmod.build_regrouped_mesh
 ```
 
-```{autofunction} cfdmod.apply_regroup_to_timeseries
+```{eval-rst}
+.. autofunction:: cfdmod.apply_regroup_to_timeseries
 ```
 
-```{autofunction} cfdmod.expand_regroup_chain
+```{eval-rst}
+.. autofunction:: cfdmod.expand_regroup_chain
 ```
 
-```{autofunction} cfdmod.run_regroup
+```{eval-rst}
+.. autofunction:: cfdmod.run_regroup
 ```
 
 ## Building wind-load post-processing
@@ -379,20 +438,24 @@ from cfdmod.building import BuildingCase, cf_per_floor, solve_building_response
 
 ### Case aggregation
 
-```{autoclass} cfdmod.building.BuildingCase
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.building.BuildingCase
+   :members:
+   :show-inheritance:
 ```
 
-```{autofunction} cfdmod.building.cp_from_pressure
+```{eval-rst}
+.. autofunction:: cfdmod.building.cp_from_pressure
 ```
 
 ### Per-floor coefficients
 
-```{autofunction} cfdmod.building.cf_per_floor
+```{eval-rst}
+.. autofunction:: cfdmod.building.cf_per_floor
 ```
 
-```{autofunction} cfdmod.building.cm_per_floor
+```{eval-rst}
+.. autofunction:: cfdmod.building.cm_per_floor
 ```
 
 ### Peak statistics
@@ -400,21 +463,26 @@ from cfdmod.building import BuildingCase, cf_per_floor, solve_building_response
 The peak of a fluctuating series is taken by one of three selectable methods
 (raw maximum, gust peak-factor, or a Gumbel fit).
 
-```{autofunction} cfdmod.building.gust_peak_factor
+```{eval-rst}
+.. autofunction:: cfdmod.building.gust_peak_factor
 ```
 
-```{autofunction} cfdmod.building.peak_value
+```{eval-rst}
+.. autofunction:: cfdmod.building.peak_value
 ```
 
 ### Dynamic response
 
-```{autofunction} cfdmod.building.solve_building_response
+```{eval-rst}
+.. autofunction:: cfdmod.building.solve_building_response
 ```
 
-```{autofunction} cfdmod.building.floor_accelerations
+```{eval-rst}
+.. autofunction:: cfdmod.building.floor_accelerations
 ```
 
-```{autofunction} cfdmod.building.peak_response_table
+```{eval-rst}
+.. autofunction:: cfdmod.building.peak_response_table
 ```
 
 ### Occupant comfort
@@ -424,24 +492,30 @@ standards -- NBR 6123, Melbourne (1992) and the NBCC. `comfort_limit`
 dispatches on the selected standard and occupancy; the per-standard helpers are
 also exposed directly.
 
-```{autofunction} cfdmod.building.comfort_limit
+```{eval-rst}
+.. autofunction:: cfdmod.building.comfort_limit
 ```
 
-```{autofunction} cfdmod.building.nbr6123_acceleration_limit
+```{eval-rst}
+.. autofunction:: cfdmod.building.nbr6123_acceleration_limit
 ```
 
-```{autofunction} cfdmod.building.melbourne1992_acceleration_limit
+```{eval-rst}
+.. autofunction:: cfdmod.building.melbourne1992_acceleration_limit
 ```
 
-```{autofunction} cfdmod.building.nbcc_acceleration_limit
+```{eval-rst}
+.. autofunction:: cfdmod.building.nbcc_acceleration_limit
 ```
 
 ### Design load cases
 
-```{autofunction} cfdmod.building.generate_load_cases
+```{eval-rst}
+.. autofunction:: cfdmod.building.generate_load_cases
 ```
 
-```{autofunction} cfdmod.building.save_load_case_tables
+```{eval-rst}
+.. autofunction:: cfdmod.building.save_load_case_tables
 ```
 
 ### Multi-direction fan-out
@@ -449,12 +523,14 @@ also exposed directly.
 A single driver runs the whole per-floor / dynamic / comfort chain over every
 (direction, body, config) combination of a parametric study.
 
-```{autoclass} cfdmod.building.FanoutPlan
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.building.FanoutPlan
+   :members:
+   :show-inheritance:
 ```
 
-```{autofunction} cfdmod.building.run_fanout
+```{eval-rst}
+.. autofunction:: cfdmod.building.run_fanout
 ```
 
 ## Structural model import (dynamics)
@@ -473,30 +549,36 @@ from cfdmod.dynamics import read_tqs_portels, read_tqs_portico, read_eberick
 
 ### Structural model
 
-```{autoclass} cfdmod.dynamics.structural.BuildingStructuralData
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.dynamics.structural.BuildingStructuralData
+   :members:
+   :show-inheritance:
 ```
 
 ### Importers
 
-```{autofunction} cfdmod.dynamics.read_tqs_portels
+```{eval-rst}
+.. autofunction:: cfdmod.dynamics.read_tqs_portels
 ```
 
-```{autofunction} cfdmod.dynamics.read_tqs_portico
+```{eval-rst}
+.. autofunction:: cfdmod.dynamics.read_tqs_portico
 ```
 
-```{autofunction} cfdmod.dynamics.read_eberick
+```{eval-rst}
+.. autofunction:: cfdmod.dynamics.read_eberick
 ```
 
 ### Conversion
 
-```{autofunction} cfdmod.dynamics.imports.aggregate_to_building
+```{eval-rst}
+.. autofunction:: cfdmod.dynamics.imports.aggregate_to_building
 ```
 
-```{autoclass} cfdmod.dynamics.imports.EberickUnits
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.dynamics.imports.EberickUnits
+   :members:
+   :show-inheritance:
 ```
 
 ## Analytical wind profiles
@@ -504,23 +586,28 @@ from cfdmod.dynamics import read_tqs_portels, read_tqs_portico, read_eberick
 Code-based mean-velocity profiles $U(z)$ for reference and inflow target
 curves.
 
-```{autoclass} cfdmod.WindProfile_NBR
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.WindProfile_NBR
+   :members:
+   :show-inheritance:
 ```
 
-```{autoclass} cfdmod.WindProfile_EU
-:members:
-:show-inheritance:
+```{eval-rst}
+.. autoclass:: cfdmod.WindProfile_EU
+   :members:
+   :show-inheritance:
 ```
 
 ## Notebook utilities
 
-```{autofunction} cfdmod.mesh_summary
+```{eval-rst}
+.. autofunction:: cfdmod.mesh_summary
 ```
 
-```{autofunction} cfdmod.show_config
+```{eval-rst}
+.. autofunction:: cfdmod.show_config
 ```
 
-```{autofunction} cfdmod.load_lnas
+```{eval-rst}
+.. autofunction:: cfdmod.load_lnas
 ```


### PR DESCRIPTION
## Problem

The API reference page (`docs/source/api_reference.md`) is MyST Markdown, but its autodoc directives used the MyST fence form (```` ```{autofunction} ````/```` ```{autoclass} ````). `sphinx.ext.autodoc` emits reStructuredText, which MyST does not re-parse inside a `.md` page - so every entry rendered as literal `.. py:function:: ...` text followed by a stray `module:` field list, instead of a real signature + docstring.

This surfaced when building the docs with `cfdmod` importable (the AeroSim docs-site now installs it so autodoc can run): imports succeed, but nothing renders.

## Fix

Wrap each autodoc directive in an ```` ```{eval-rst} ```` block so the generated RST is parsed by the RST parser, per the MyST guidance for RST-producing extensions. Purely a docs-rendering change; no Python touched.

## Verification

`sphinx-build` of `docs/source`:
- All **87** entries now render proper signatures, members and docstrings.
- **195** py-domain objects on the API reference page (was **0**).
- **0** literal `.. py:function` / `.. autoclass` leakage (was the entire page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)