### PR TITLE
feat(core): output freshness / staleness detection for pipeline templates

### DIFF
--- a/cfdmod/__init__.py
+++ b/cfdmod/__init__.py
@@ -110,6 +110,10 @@ __all__ = [
     "OpInfo",
     "list_ops",
     "op_info",
+    # Freshness / output staleness
+    "output_status",
+    "OutputStatus",
+    "FreshnessConfig",
     # Errors (issue #147)
     "CfdmodError",
     "TemplateError",
@@ -242,6 +246,9 @@ _SYMBOL_MODULE: dict[str, str] = {
     "OpInfo": "cfdmod.core",
     "list_ops": "cfdmod.core",
     "op_info": "cfdmod.core",
+    "output_status": "cfdmod.core",
+    "OutputStatus": "cfdmod.core",
+    "FreshnessConfig": "cfdmod.core",
     # Errors
     "CfdmodError": "cfdmod.core",
     "TemplateError": "cfdmod.core",

--- a/cfdmod/__main__.py
+++ b/cfdmod/__main__.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 from cfdmod.altimetry.cli import app as altimetry_app
 from cfdmod.dynamics.cli import app as dynamics_app
 from cfdmod.loft.cli import app as loft_app
-from cfdmod.recipes import run_yaml
+from cfdmod.recipes import run_yaml, status_yaml
 from cfdmod.regroup.cli import app as regroup_app
 from cfdmod.roughness.cli import app as roughness_app
 
@@ -30,6 +30,16 @@ def run(
         "--output-root",
         help="Optional storage root override. Defaults to filesystem root so the YAML paths resolve as-is.",
     ),
+    skip_fresh: bool = typer.Option(
+        False,
+        "--skip-fresh",
+        help="Skip recomputing outputs already up to date; run only what stale outputs need.",
+    ),
+    digest: str | None = typer.Option(
+        None,
+        "--digest",
+        help="Override the input-digest strategy: size_mtime | content | backend.",
+    ),
 ) -> None:
     """Execute a v3 pipeline template (cfdmod.core.pipeline_yaml).
 
@@ -37,13 +47,49 @@ def run(
     this command just loads the YAML and runs it via XdmfH5Storage.
     """
     try:
-        bindings = run_yaml(template, output_root=output_root)
+        bindings = run_yaml(
+            template, output_root=output_root, skip_fresh=skip_fresh, digest=digest
+        )
     except (KeyError, ValueError, FileNotFoundError, ValidationError) as exc:
         # These are user/config errors (bad template, missing file, typo'd
         # field). Show the message alone, not a multi-screen traceback.
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=1) from exc
-    typer.echo(f"ran template '{template}': {len(bindings)} bindings produced.")
+    if skip_fresh and not bindings:
+        typer.echo(f"template '{template}': all outputs already fresh; nothing to do.")
+    else:
+        typer.echo(f"ran template '{template}': {len(bindings)} bindings produced.")
+
+
+@app.command("status")
+def status(
+    template: pathlib.Path = typer.Argument(..., help="Path to a v3 pipeline YAML template."),
+    output_root: pathlib.Path | None = typer.Option(
+        None, "--output-root", help="Optional storage root override."
+    ),
+    digest: str | None = typer.Option(
+        None, "--digest", help="Override the input-digest strategy."
+    ),
+) -> None:
+    """Report per-output freshness (fresh | stale | missing) without running.
+
+    Exits non-zero if any declared output is stale or missing, so the
+    command is usable as a CI / Makefile freshness gate.
+    """
+    try:
+        statuses = status_yaml(template, output_root=output_root, digest=digest)
+    except (KeyError, ValueError, FileNotFoundError, ValidationError) as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+    if not statuses:
+        typer.echo(f"template '{template}': no declared outputs.")
+        return
+    any_dirty = False
+    for name, st in statuses.items():
+        if not st.is_fresh:
+            any_dirty = True
+        typer.echo(f"{st.status:>7}  {name}  ({st.reason})")
+    raise typer.Exit(code=1 if any_dirty else 0)
 
 
 if __name__ == "__main__":

--- a/cfdmod/adapters/memory/storage.py
+++ b/cfdmod/adapters/memory/storage.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 __all__ = ["MemoryStorage"]
 
+import hashlib
 from typing import Iterable
+
+import numpy as np
 
 from cfdmod.core.data_source import DataSource
 from cfdmod.core.errors import StorageKeyError
@@ -27,10 +30,11 @@ class MemoryStorage:
     frozen, so this is consistent with the functional-core principle.
     """
 
-    __slots__ = ("_items",)
+    __slots__ = ("_items", "_signatures")
 
     def __init__(self) -> None:
         self._items: dict[str, DataSource] = {}
+        self._signatures: dict[str, str] = {}
 
     def keys(self) -> Iterable[str]:
         return self._items.keys()
@@ -45,3 +49,41 @@ class MemoryStorage:
 
     def write_data_source(self, key: str, ds: DataSource) -> None:
         self._items[key] = ds
+
+    # --- Freshness --------------------------------------------------------
+
+    def digest(self, key: str, strategy: str = "size_mtime") -> str:
+        """Content digest of the in-RAM data source under ``key``.
+
+        RAM has no size/mtime, so every strategy degrades to a stable
+        content hash of the topology + fields. The requested strategy is
+        still embedded so a signature computed with one strategy does not
+        silently match one computed with another.
+        """
+        if key not in self._items:
+            raise StorageKeyError(f"MemoryStorage has no data source under key {key!r}")
+        return f"{strategy}:mem:{_data_source_content_hash(self._items[key])}"
+
+    def read_signature(self, key: str) -> str | None:
+        return self._signatures.get(key)
+
+    def write_signature(self, key: str, signature: str) -> None:
+        self._signatures[key] = signature
+
+
+def _data_source_content_hash(ds: DataSource) -> str:
+    """Stable hash of a data source's kind, topology, time axis, and fields."""
+    h = hashlib.blake2b(digest_size=32)
+    h.update(ds.kind.encode("utf-8"))
+    if ds.topology is not None:
+        h.update(np.ascontiguousarray(ds.topology.vertices, dtype=np.float64).tobytes())
+        conn = ds.topology.connectivity
+        if conn is not None:
+            h.update(np.ascontiguousarray(conn, dtype=np.int64).tobytes())
+    h.update(str(ds.time.n_timesteps).encode("utf-8"))
+    for name in sorted(ds.fields.keys()):
+        arr = np.ascontiguousarray(ds.fields.read(name), dtype=np.float64)
+        h.update(name.encode("utf-8"))
+        h.update(str(arr.shape).encode("utf-8"))
+        h.update(arr.tobytes())
+    return h.hexdigest()

--- a/cfdmod/adapters/xdmf_h5/blob_storage.py
+++ b/cfdmod/adapters/xdmf_h5/blob_storage.py
@@ -81,3 +81,39 @@ class XdmfH5BlobStorage:
                 produced = root / f"{key}{suffix}"
                 if produced.exists():
                     self._blobs.put_bytes(f"{key}{suffix}", produced.read_bytes())
+
+    # --- Freshness --------------------------------------------------------
+
+    def digest(self, key: str, strategy: str = "size_mtime") -> str:
+        """Change-detecting token for the object bytes under ``key``.
+
+        A plain ``BlobStore`` exposes no native size/mtime/ETag, so every
+        strategy degrades to a content hash of the ``.h5`` (+ ``.xdmf``)
+        blobs. The requested strategy is embedded so a strategy switch is
+        still a change signal. A backend that exposes an S3 ETag / checksum
+        can subclass and override ``backend`` without transferring bytes.
+        """
+        import hashlib
+
+        blob_key = f"{key}.h5"
+        try:
+            data = self._blobs.get_bytes(blob_key)
+        except KeyError as exc:
+            raise StorageKeyError(
+                f"XdmfH5BlobStorage has no data source under key {key!r} (blob {blob_key!r})"
+            ) from exc
+        h = hashlib.blake2b(digest_size=32)
+        h.update(data)
+        xdmf_key = f"{key}.xdmf"
+        if xdmf_key in self._blobs:
+            h.update(self._blobs.get_bytes(xdmf_key))
+        return f"{strategy}:blob:{h.hexdigest()}"
+
+    def read_signature(self, key: str) -> str | None:
+        sig_key = f"{key}.sig"
+        if sig_key not in self._blobs:
+            return None
+        return self._blobs.get_bytes(sig_key).decode("utf-8")
+
+    def write_signature(self, key: str, signature: str) -> None:
+        self._blobs.put_bytes(f"{key}.sig", signature.encode("utf-8"))

--- a/cfdmod/adapters/xdmf_h5/storage.py
+++ b/cfdmod/adapters/xdmf_h5/storage.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 __all__ = ["XdmfH5Storage"]
 
+import hashlib
 import pathlib
 from typing import Iterable
 
@@ -50,6 +51,11 @@ from cfdmod.core.field_meta import FieldMeta
 from cfdmod.core.time_axis import TimeAxis
 from cfdmod.core.topology import ElementMeta, Topology
 from cfdmod.io import xdmf as _xdmf
+
+# Root-level h5 attribute the freshness layer stamps an output's signature
+# under. It lives in ``.attrs`` (not a dataset), so ``read_data_source``
+# ignores it and the round-trip byte layout is unchanged.
+_SIGNATURE_ATTR = "cfdmod_signature"
 
 _RESERVED_ROOT_KEYS = frozenset({"Triangles", "Geometry", "Connectivity", "meta"})
 # Geometry datasets embedded inside a stats group (so write_stats_xdmf can
@@ -318,6 +324,58 @@ class XdmfH5Storage:
                 _xdmf.write_stats_xdmf(h5_path, xdmf_path)
             elif groups_for_xdmf:
                 _xdmf.write_temporal_xdmf(h5_path, xdmf_path, groups_for_xdmf)
+
+    # --- Freshness ---------------------------------------------------------
+
+    def digest(self, key: str, strategy: str = "size_mtime") -> str:
+        """Change-detecting token for the ``<key>.h5`` (+ ``.xdmf``) pair.
+
+        - ``size_mtime`` (default): size + mtime of the file(s); no reads.
+        - ``content``: a blake2b hash of the file bytes, streamed.
+        - ``backend``: the local filesystem has no native token, so this
+          falls back to ``size_mtime`` (tagged so the fallback is visible).
+        """
+        h5_path = self.h5_path(key)
+        if not h5_path.exists():
+            raise StorageKeyError(
+                f"XdmfH5Storage has no data source under key {key!r} ({h5_path})"
+            )
+        paths = [h5_path]
+        xdmf = self.xdmf_path(key)
+        if xdmf.exists():
+            paths.append(xdmf)
+
+        if strategy == "content":
+            h = hashlib.blake2b(digest_size=32)
+            for p in paths:
+                with open(p, "rb") as f:
+                    for block in iter(lambda: f.read(1 << 20), b""):
+                        h.update(block)
+            return f"content:{h.hexdigest()}"
+
+        # size_mtime and backend (backend has no FS-native token -> fall back)
+        prefix = "size_mtime" if strategy != "backend" else "backend_fs"
+        parts = [f"{p.stat().st_size}:{p.stat().st_mtime_ns}" for p in paths]
+        return f"{prefix}:" + "|".join(parts)
+
+    def read_signature(self, key: str) -> str | None:
+        h5_path = self.h5_path(key)
+        if not h5_path.exists():
+            return None
+        with h5py.File(h5_path, "r") as f:
+            raw = f.attrs.get(_SIGNATURE_ATTR)
+        if raw is None:
+            return None
+        return raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+
+    def write_signature(self, key: str, signature: str) -> None:
+        h5_path = self.h5_path(key)
+        if not h5_path.exists():
+            raise StorageKeyError(
+                f"cannot stamp signature: no h5 under key {key!r} ({h5_path})"
+            )
+        with h5py.File(h5_path, "a") as f:
+            f.attrs[_SIGNATURE_ATTR] = signature
 
 
 def _groups_to_parent_surface(ds: GroupsDataSource) -> SurfaceDataSource:

--- a/cfdmod/core/__init__.py
+++ b/cfdmod/core/__init__.py
@@ -35,8 +35,15 @@ from cfdmod.core.data_source import (
 from cfdmod.core.field_meta import FieldMeta
 from cfdmod.core.grouping import Grouping, elements_in_group, groups_in
 from cfdmod.core.pipeline import Pipeline, compose, identity
+from cfdmod.core.freshness import (
+    OutputStatus,
+    output_status,
+    signature,
+)
 from cfdmod.core.pipeline_yaml import (
     OP_REGISTRY,
+    DigestStrategy,
+    FreshnessConfig,
     OpInfo,
     PipelineTemplate,
     list_ops,
@@ -81,6 +88,11 @@ __all__ = [
     "OpInfo",
     "list_ops",
     "op_info",
+    "DigestStrategy",
+    "FreshnessConfig",
+    "OutputStatus",
+    "output_status",
+    "signature",
     "CfdmodError",
     "TemplateError",
     "TemplateReferenceError",

--- a/cfdmod/core/freshness.py
+++ b/cfdmod/core/freshness.py
@@ -1,0 +1,292 @@
+"""Output-staleness detection for pipeline templates.
+
+A generated output is *fresh* when nothing that determines it has changed
+since it was last written, and *stale* otherwise. "Everything that
+determines it" is captured by a **signature**: a hash over
+
+1. the params + wiring of every step in the output's dependency subgraph,
+2. a change-detecting digest of each ``inputs:`` file that subgraph
+   touches (obtained via :meth:`Storage.digest` -- no byte transfer for the
+   default ``size_mtime`` strategy, an object-store ETag for ``backend``),
+3. a code/format version tag, so a change in op semantics or the on-disk
+   layout invalidates old outputs.
+
+:func:`run_template` stamps the signature next to each output it writes
+(``Storage.write_signature``); :func:`output_status` recomputes and
+compares, and ``run_template(..., skip_fresh=True)`` uses the comparison to
+skip recomputing fresh outputs and prune the steps only they need.
+
+The dependency walk mirrors the wiring the runner and
+:func:`~cfdmod.core.pipeline_yaml.validate_template` already use: each step
+depends on its ``source`` (plus ``rhs`` for a binary op, plus any
+``sources`` map a recipe step declares). It reads no data -- only metadata
+digests -- so freshness decisions are cheap.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "FORMAT_VERSION",
+    "DEFAULT_DIGEST",
+    "OutputStatus",
+    "Status",
+    "code_version",
+    "immediate_deps",
+    "output_closure",
+    "closure_for_outputs",
+    "signature",
+    "output_status",
+    "resolve_strategy",
+]
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel
+
+from cfdmod.core.errors import StorageKeyError
+from cfdmod.core.pipeline_yaml import (
+    DigestStrategy,
+    OpSpec,
+    PipelineTemplate,
+    _resolve_key,
+)
+from cfdmod.core.protocols import Storage
+
+# Bump when op semantics or the on-disk layout change in a way that
+# invalidates previously generated outputs, independent of the package
+# version. Folded into every signature.
+FORMAT_VERSION = "1"
+
+DEFAULT_DIGEST: DigestStrategy = "size_mtime"
+
+# Step-level keys that are structural (not params). Everything else on a
+# step is a parameter that affects the output and must enter the signature.
+_STRUCTURAL_KEYS = frozenset({"id", "kind", "source", "rhs", "recipe", "sources"})
+
+Status = Literal["fresh", "stale", "missing"]
+
+
+def code_version() -> str:
+    """Return the code-version tag folded into signatures.
+
+    Combines the installed package version (best-effort) with
+    :data:`FORMAT_VERSION`. A version bump or a format bump changes every
+    signature, so outputs regenerate rather than being trusted across an
+    upgrade that could have changed their meaning.
+    """
+    try:
+        from importlib.metadata import version
+
+        pkg = version("aerosim-cfdmod")
+    except Exception:
+        pkg = "unknown"
+    return f"{pkg}+fmt{FORMAT_VERSION}"
+
+
+class OutputStatus(BaseModel):
+    """Freshness verdict for one declared output.
+
+    Attributes:
+        name: The ``outputs:`` key.
+        status: ``fresh`` (up to date), ``stale`` (inputs/params changed),
+            or ``missing`` (never stamped).
+        reason: Human-readable explanation.
+        expected: The freshly computed signature (``None`` if it could not
+            be computed, e.g. a required input is absent).
+        stored: The signature currently stamped on the output, if any.
+    """
+
+    model_config = {"frozen": True}
+
+    name: str
+    status: Status
+    reason: str
+    expected: str | None = None
+    stored: str | None = None
+
+    @property
+    def is_fresh(self) -> bool:
+        return self.status == "fresh"
+
+
+def _step_id(index: int, step: OpSpec) -> str:
+    """Resolve a step's id the same way the runner does."""
+    return step.id or f"step_{index}"
+
+
+def _step_deps(step: OpSpec) -> list[str]:
+    """Binding names a step consumes: source (+ rhs) (+ recipe sources)."""
+    dump = step.model_dump()
+    deps = [dump["source"]]
+    rhs = dump.get("rhs")
+    if rhs is not None:
+        deps.append(rhs)
+    sources = dump.get("sources")
+    if isinstance(sources, dict):
+        deps.extend(str(v) for v in sources.values())
+    return deps
+
+
+def immediate_deps(template: PipelineTemplate) -> dict[str, list[str]]:
+    """Map each step id to the binding names it directly consumes."""
+    return {_step_id(i, step): _step_deps(step) for i, step in enumerate(template.pipeline)}
+
+
+def _closure(template: PipelineTemplate, targets: list[str]) -> tuple[set[str], set[str]]:
+    """Transitive dependency closure of ``targets`` over the step graph.
+
+    Returns ``(step_ids, input_names)`` reachable from the targets. Unknown
+    names (which :func:`validate_template` would already have rejected) are
+    ignored here.
+    """
+    deps = immediate_deps(template)
+    input_names = set(template.inputs)
+    needed_steps: set[str] = set()
+    needed_inputs: set[str] = set()
+    stack = list(targets)
+    while stack:
+        name = stack.pop()
+        if name in input_names:
+            needed_inputs.add(name)
+            continue
+        if name in needed_steps:
+            continue
+        if name in deps:
+            needed_steps.add(name)
+            stack.extend(deps[name])
+    return needed_steps, needed_inputs
+
+
+def output_closure(template: PipelineTemplate, output_name: str) -> tuple[set[str], set[str]]:
+    """Steps + inputs a single declared output depends on."""
+    out = template.outputs[output_name]
+    return _closure(template, [out.source])
+
+
+def closure_for_outputs(
+    template: PipelineTemplate, output_names: set[str] | list[str]
+) -> tuple[set[str], set[str]]:
+    """Union of the dependency closures of several outputs."""
+    targets = [template.outputs[n].source for n in output_names]
+    return _closure(template, targets)
+
+
+def resolve_strategy(
+    template: PipelineTemplate, override: DigestStrategy | None = None
+) -> DigestStrategy:
+    """Pick the digest strategy: explicit override wins, else the template's."""
+    if override is not None:
+        return override
+    return template.freshness.digest
+
+
+def _input_strategy(
+    template: PipelineTemplate, input_name: str, strategy: DigestStrategy
+) -> DigestStrategy:
+    return template.freshness.per_input.get(input_name, strategy)
+
+
+def signature(
+    template: PipelineTemplate,
+    output_name: str,
+    storage: Storage,
+    strategy: DigestStrategy = DEFAULT_DIGEST,
+) -> str:
+    """Compute the freshness signature of one declared output.
+
+    Deterministic across runs and machines: dict keys are sorted, paths are
+    normalized to storage keys, and no wall-clock / RNG enters the fold.
+
+    Raises :class:`StorageKeyError` if a required input has no digestible
+    object yet (i.e. it has not been produced) -- the caller treats that as
+    "cannot be fresh".
+    """
+    needed_steps, needed_inputs = output_closure(template, output_name)
+
+    steps_repr = []
+    for i, step in enumerate(template.pipeline):
+        sid = _step_id(i, step)
+        if sid not in needed_steps:
+            continue
+        dump = step.model_dump()
+        params = {k: v for k, v in dump.items() if k not in _STRUCTURAL_KEYS}
+        steps_repr.append(
+            {
+                "id": sid,
+                "kind": dump.get("kind"),
+                "recipe": dump.get("recipe"),
+                "source": dump.get("source"),
+                "rhs": dump.get("rhs"),
+                "sources": dump.get("sources"),
+                "params": params,
+            }
+        )
+
+    inputs_repr = {}
+    for name in sorted(needed_inputs):
+        spec = template.inputs[name]
+        key = _resolve_key(template.root, spec.path)
+        strat = _input_strategy(template, name, strategy)
+        inputs_repr[name] = {
+            "kind": spec.kind,
+            "field": spec.field,
+            "key": key,
+            "digest": storage.digest(key, strat),
+        }
+
+    out = template.outputs[output_name]
+    payload = {
+        "code_version": code_version(),
+        "output": {
+            "name": output_name,
+            "key": _resolve_key(template.root, out.path),
+            "format": out.format,
+        },
+        "steps": steps_repr,
+        "inputs": inputs_repr,
+    }
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.blake2b(blob.encode("utf-8"), digest_size=32).hexdigest()
+
+
+def output_status(
+    template: PipelineTemplate,
+    storage: Storage,
+    strategy: DigestStrategy | None = None,
+) -> dict[str, OutputStatus]:
+    """Report ``fresh | stale | missing`` for every declared output.
+
+    Pure inspection -- reads input digests and the stored signatures, runs
+    no ops and writes nothing.
+    """
+    strat = resolve_strategy(template, strategy)
+    result: dict[str, OutputStatus] = {}
+    for name, out in template.outputs.items():
+        out_key = _resolve_key(template.root, out.path)
+        try:
+            expected = signature(template, name, storage, strat)
+        except StorageKeyError as exc:
+            result[name] = OutputStatus(
+                name=name,
+                status="stale",
+                reason=f"input unavailable: {exc}",
+                expected=None,
+                stored=None,
+            )
+            continue
+        stored = storage.read_signature(out_key)
+        if stored is None:
+            status: Status = "missing"
+            reason = "no stored signature (not generated with freshness tracking)"
+        elif stored == expected:
+            status = "fresh"
+            reason = "up to date"
+        else:
+            status = "stale"
+            reason = "inputs or params changed since last run"
+        result[name] = OutputStatus(
+            name=name, status=status, reason=reason, expected=expected, stored=stored
+        )
+    return result

--- a/cfdmod/core/pipeline_yaml.py
+++ b/cfdmod/core/pipeline_yaml.py
@@ -77,6 +77,8 @@ __all__ = [
     "OpInfo",
     "list_ops",
     "op_info",
+    "DigestStrategy",
+    "FreshnessConfig",
 ]
 
 import pathlib
@@ -370,6 +372,26 @@ def op_info(kind: str) -> OpInfo:
 
 InputKind = Literal["surface", "volume", "points", "groups", "modes"]
 
+DigestStrategy = Literal["size_mtime", "content", "backend"]
+"""How an input's change-detection token is derived. See :meth:`Storage.digest`."""
+
+
+class FreshnessConfig(BaseModel):
+    """Output-staleness settings for a template.
+
+    Attributes:
+        digest: Default strategy used to digest input dependencies when
+            computing an output's signature. ``size_mtime`` (the default)
+            reads no bytes.
+        per_input: Optional per-input override, mapping an ``inputs:`` name
+            to a strategy that wins over ``digest`` for that input only.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    digest: DigestStrategy = "size_mtime"
+    per_input: dict[str, DigestStrategy] = Field(default_factory=dict)
+
 
 class InputSpec(BaseModel):
     """One entry under ``inputs:``.
@@ -436,6 +458,7 @@ class PipelineTemplate(BaseModel):
     inputs: dict[str, InputSpec] = Field(default_factory=dict)
     pipeline: list[OpSpec] = Field(default_factory=list)
     outputs: dict[str, OutputSpec] = Field(default_factory=dict)
+    freshness: FreshnessConfig = Field(default_factory=FreshnessConfig)
 
 
 # Backwards-compat alias for symmetry with OpSpec.
@@ -702,20 +725,56 @@ def run_template(
     template: PipelineTemplate,
     *,
     storage: Storage,
+    skip_fresh: bool = False,
 ) -> dict[str, DataSource]:
     """Run a parsed template against a :class:`Storage`.
 
     Returns the dict of all named values (inputs + step outputs) so
     callers can inspect intermediates. The ``outputs:`` block is
     written through ``storage.write_data_source`` as a side effect.
+
+    Each written output is stamped with a freshness signature (via
+    ``storage.write_signature``) when the backend supports it, so a later
+    :func:`~cfdmod.core.freshness.output_status` / ``skip_fresh`` run can
+    tell fresh outputs from stale ones.
+
+    With ``skip_fresh=True`` the runner first asks which outputs are stale
+    (``freshness.output_status``), then runs only the steps and loads only
+    the inputs those stale outputs depend on -- fresh outputs are neither
+    recomputed nor rewritten. If every declared output is already fresh the
+    run is a no-op and returns an empty binding dict.
     """
     _populate_default_registry()
     # Static validation first: fail on typos/dangling refs before any I/O.
     validate_template(template)
 
-    # 1. Load inputs.
+    strategy = template.freshness.digest
+    supports_freshness = hasattr(storage, "write_signature") and hasattr(storage, "digest")
+
+    stale_outputs: set[str] | None = None
+    needed_steps: set[str] | None = None
+    needed_inputs: set[str] | None = None
+    if skip_fresh:
+        if not supports_freshness:
+            raise TemplateError(
+                "skip_fresh=True requires a storage backend with digest/read_signature/"
+                "write_signature; this backend has none"
+            )
+        from cfdmod.core.freshness import closure_for_outputs, output_status
+
+        statuses = output_status(template, storage, strategy)
+        stale_outputs = {n for n, s in statuses.items() if not s.is_fresh}
+        if template.outputs and not stale_outputs:
+            # Everything is up to date -- nothing to load, run, or write.
+            return {}
+        needed_steps, needed_inputs = closure_for_outputs(template, stale_outputs)
+
+    # 1. Load inputs (all, or -- under skip_fresh -- only those the stale
+    #    outputs depend on).
     bindings: dict[str, DataSource] = {}
     for name, spec in template.inputs.items():
+        if needed_inputs is not None and name not in needed_inputs:
+            continue
         # Storage keys are logical names. We treat the resolved path as
         # the storage key so the adapter can map it to its on-disk
         # layout.
@@ -734,6 +793,8 @@ def run_template(
     # 2. Walk pipeline.
     for i, step in enumerate(template.pipeline):
         step_id = step.id or f"step_{i}"
+        if needed_steps is not None and step_id not in needed_steps:
+            continue
         if step.kind not in OP_REGISTRY:
             raise TemplateReferenceError(
                 f"unknown op kind {step.kind!r} at step {step_id!r}; "
@@ -776,12 +837,21 @@ def run_template(
 
         bindings[step_id] = result
 
-    # 3. Write outputs.
-    for _, out in template.outputs.items():
+    # 3. Write outputs (skipping fresh ones under skip_fresh) and stamp each
+    #    with its freshness signature when the backend supports it.
+    sign = None
+    if supports_freshness and template.outputs:
+        from cfdmod.core.freshness import signature as sign
+
+    for out_name, out in template.outputs.items():
+        if stale_outputs is not None and out_name not in stale_outputs:
+            continue
         if out.source not in bindings:
             raise TemplateReferenceError(f"output references unknown source {out.source!r}")
         key = _resolve_key(template.root, out.path)
         storage.write_data_source(key, bindings[out.source])
+        if sign is not None:
+            storage.write_signature(key, sign(template, out_name, storage, strategy))
 
     return bindings
 

--- a/cfdmod/core/protocols.py
+++ b/cfdmod/core/protocols.py
@@ -161,6 +161,43 @@ class Storage(Protocol):
         """Iterate the logical keys held by this storage."""
         ...
 
+    # --- Freshness / provenance (optional) --------------------------------
+    #
+    # The three methods below back output-staleness detection (skip vs.
+    # recompute). They are part of the protocol so every built-in adapter
+    # implements them, but the default ``run_template`` path calls them only
+    # when the backend advertises them (``hasattr``), so a pre-existing
+    # third-party ``Storage`` that omits them keeps working unchanged.
+
+    def digest(self, key: str, strategy: str = "size_mtime") -> str:
+        """Return a cheap change-detecting token for the object under ``key``.
+
+        ``strategy`` selects how the token is derived:
+
+        - ``"size_mtime"`` -- size + mtime, no byte reads (default; fast).
+        - ``"content"`` -- a strong content hash of the stored bytes.
+        - ``"backend"`` -- the backend's own token (e.g. an object-store
+          ETag) resolved without transferring bytes; adapters with no
+          native token fall back to ``size_mtime``.
+
+        The returned string embeds the strategy so switching strategy is
+        itself a change signal. Raises :class:`StorageKeyError` when the
+        key is absent.
+        """
+        ...
+
+    def read_signature(self, key: str) -> "str | None":
+        """Return the freshness signature stamped on ``key``, or ``None``.
+
+        ``None`` means "no signature recorded" (never written with
+        freshness tracking) and is treated as ``missing`` by the caller.
+        """
+        ...
+
+    def write_signature(self, key: str, signature: str) -> None:
+        """Stamp ``signature`` onto an already-written object at ``key``."""
+        ...
+
 
 @runtime_checkable
 class BlobStore(Protocol):

--- a/cfdmod/core/recipes/__init__.py
+++ b/cfdmod/core/recipes/__init__.py
@@ -47,6 +47,7 @@ __all__ = [
     "ComfortConfig",
     "build_point_accelerations",
     "run_yaml",
+    "status_yaml",
 ]
 
 from cfdmod.core.recipes.ce import CeRecipeConfig, ce_pipeline
@@ -67,5 +68,5 @@ from cfdmod.core.recipes.dynamic import (
     identity_solver,
     sdof_rk45_solver,
 )
-from cfdmod.core.recipes.run_yaml import run_yaml
+from cfdmod.core.recipes.run_yaml import run_yaml, status_yaml
 from cfdmod.core.recipes.s1 import S1RecipeConfig, build_s1, s1_pipeline

--- a/cfdmod/core/recipes/run_yaml.py
+++ b/cfdmod/core/recipes/run_yaml.py
@@ -19,18 +19,31 @@ let the YAML pick per-input adapters explicitly.
 
 from __future__ import annotations
 
-__all__ = ["run_yaml"]
+__all__ = ["run_yaml", "status_yaml"]
 
 import pathlib
 
 from cfdmod.core.data_source import DataSource
-from cfdmod.core.pipeline_yaml import load_template, run_template
+from cfdmod.core.pipeline_yaml import DigestStrategy, load_template, run_template
+
+
+def _load_with_digest(
+    template_path: pathlib.Path | str, digest: DigestStrategy | None
+):
+    template = load_template(pathlib.Path(template_path))
+    if digest is not None:
+        template = template.model_copy(
+            update={"freshness": template.freshness.model_copy(update={"digest": digest})}
+        )
+    return template
 
 
 def run_yaml(
     template_path: pathlib.Path | str,
     *,
     output_root: pathlib.Path | str | None = None,
+    skip_fresh: bool = False,
+    digest: DigestStrategy | None = None,
 ) -> dict[str, DataSource]:
     """Load and run a v3 pipeline template.
 
@@ -41,6 +54,9 @@ def run_yaml(
             storage is rooted at the filesystem root (``/``) so the
             YAML's absolute / template-relative paths resolve directly;
             pass a directory here to redirect outputs.
+        skip_fresh: When True, skip recomputing outputs already up to date
+            and run only the steps the stale outputs depend on.
+        digest: Optional override of the template's input-digest strategy.
 
     Returns:
         The dict of every named binding the runner produced (inputs +
@@ -51,10 +67,29 @@ def run_yaml(
     # free of h5py -- the schema / catalog surface must import light (#147).
     from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
 
-    template_path = pathlib.Path(template_path)
-    template = load_template(template_path)
+    template = _load_with_digest(template_path, digest)
 
     root = pathlib.Path(output_root) if output_root is not None else pathlib.Path("/")
     storage = XdmfH5Storage(root)
 
-    return run_template(template, storage=storage)
+    return run_template(template, storage=storage, skip_fresh=skip_fresh)
+
+
+def status_yaml(
+    template_path: pathlib.Path | str,
+    *,
+    output_root: pathlib.Path | str | None = None,
+    digest: DigestStrategy | None = None,
+) -> dict:
+    """Report per-output freshness for a template without running anything.
+
+    Returns a mapping ``output name -> OutputStatus`` (``fresh`` / ``stale``
+    / ``missing`` plus a reason).
+    """
+    from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+    from cfdmod.core.freshness import output_status
+
+    template = _load_with_digest(template_path, digest)
+    root = pathlib.Path(output_root) if output_root is not None else pathlib.Path("/")
+    storage = XdmfH5Storage(root)
+    return output_status(template, storage)

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -55,6 +55,25 @@ public v3 symbol is removed or changed in signature.
   (`sample_field_along_line`) for cutting through a volume field.
 - `moving_average_stats` reuses the core `moving_average` op.
 
+### Output freshness / incremental runs
+
+- Each output a template writes is stamped with a **signature** hashed over
+  the params and wiring of the steps that feed it, a change-detecting
+  digest of the input files it depends on, and a code/format version tag.
+- `output_status(template, storage)` reports each declared output as
+  `fresh`, `stale`, or `missing` without running anything; `cfdmod status
+  <template>` prints the same and exits non-zero if anything is stale
+  (usable as a CI / Makefile gate).
+- `run_template(..., skip_fresh=True)` (and `cfdmod run --skip-fresh`)
+  skips recomputing outputs that are already up to date and runs only the
+  steps the stale outputs depend on, so touching one late stage no longer
+  recomputes fresh upstreams.
+- The input-digest strategy is configurable (template `freshness.digest`
+  or `--digest`): `size_mtime` (default, no byte reads), `content` (a
+  strong hash), or `backend` (the backend's native token). `Storage` gains
+  `digest` / `read_signature` / `write_signature`; the default run path is
+  unchanged for backends that do not implement them.
+
 ## v3.1.0
 
 Minor release. Turns the v3 core from "a library you call" into "a

--- a/tests/core/test_freshness.py
+++ b/tests/core/test_freshness.py
@@ -1,0 +1,301 @@
+"""Tests for output-staleness detection (cfdmod.core.freshness)."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+from cfdmod.core import (
+    ElementMeta,
+    PipelineTemplate,
+    SurfaceDataSource,
+    TimeAxis,
+    Topology,
+    output_status,
+    run_template,
+)
+from cfdmod.core import freshness as fr
+
+
+def _surface(values: np.ndarray, dt: float = 0.1) -> SurfaceDataSource:
+    n_elements, n_t = values.shape
+    verts = np.tile(np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0]]), (n_elements, 1)).astype(
+        np.float64
+    )
+    tris = np.arange(n_elements * 3).reshape(n_elements, 3).astype(np.int32)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=dt, n_timesteps=n_t),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"pressure": values.astype(np.float64)}),
+    )
+
+
+def _scale_template(factor: float = 3.0) -> PipelineTemplate:
+    return PipelineTemplate(
+        inputs={"body": {"kind": "surface", "path": "body"}},
+        pipeline=[
+            {
+                "id": "cp",
+                "kind": "scale",
+                "source": "body",
+                "field": "pressure",
+                "factor": factor,
+            }
+        ],
+        outputs={"cp": {"source": "cp", "path": "cp"}},
+    )
+
+
+# --- dependency closure ----------------------------------------------------
+
+
+def test_output_closure_is_transitive_and_prunes_unrelated_steps():
+    tpl = PipelineTemplate(
+        inputs={
+            "a": {"kind": "surface", "path": "a"},
+            "b": {"kind": "surface", "path": "b"},
+        },
+        pipeline=[
+            {"id": "s1", "kind": "scale", "source": "a", "field": "pressure", "factor": 2.0},
+            {"id": "s2", "kind": "scale", "source": "s1", "field": "pressure", "factor": 2.0},
+            {"id": "u1", "kind": "scale", "source": "b", "field": "pressure", "factor": 9.0},
+        ],
+        outputs={
+            "out_s2": {"source": "s2", "path": "o1"},
+            "out_u1": {"source": "u1", "path": "o2"},
+        },
+    )
+    steps, inputs = fr.output_closure(tpl, "out_s2")
+    assert steps == {"s1", "s2"}
+    assert inputs == {"a"}
+
+    all_steps, all_inputs = fr.closure_for_outputs(tpl, {"out_s2", "out_u1"})
+    assert all_steps == {"s1", "s2", "u1"}
+    assert all_inputs == {"a", "b"}
+
+
+def test_closure_includes_binary_rhs():
+    tpl = PipelineTemplate(
+        inputs={
+            "lhs": {"kind": "surface", "path": "lhs"},
+            "rhs": {"kind": "surface", "path": "rhs"},
+        },
+        pipeline=[
+            {
+                "id": "d",
+                "kind": "sub",
+                "source": "lhs",
+                "rhs": "rhs",
+                "field": "pressure",
+                "out": "dp",
+            }
+        ],
+        outputs={"d": {"source": "d", "path": "d"}},
+    )
+    steps, inputs = fr.output_closure(tpl, "d")
+    assert steps == {"d"}
+    assert inputs == {"lhs", "rhs"}
+
+
+# --- signature -------------------------------------------------------------
+
+
+def test_signature_is_stable_across_runs():
+    storage = MemoryStorage()
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    tpl = _scale_template()
+    s1 = fr.signature(tpl, "cp", storage, "content")
+    s2 = fr.signature(tpl, "cp", storage, "content")
+    assert s1 == s2
+
+
+def test_signature_changes_when_param_changes():
+    storage = MemoryStorage()
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    s_a = fr.signature(_scale_template(3.0), "cp", storage, "content")
+    s_b = fr.signature(_scale_template(4.0), "cp", storage, "content")
+    assert s_a != s_b
+
+
+def test_signature_changes_when_input_changes():
+    storage = MemoryStorage()
+    tpl = _scale_template()
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    s_before = fr.signature(tpl, "cp", storage, "content")
+    storage.write_data_source("body", _surface(np.full((2, 3), 6.0)))
+    s_after = fr.signature(tpl, "cp", storage, "content")
+    assert s_before != s_after
+
+
+def test_signature_changes_when_format_version_bumps(monkeypatch):
+    storage = MemoryStorage()
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    tpl = _scale_template()
+    s_v1 = fr.signature(tpl, "cp", storage, "content")
+    monkeypatch.setattr(fr, "FORMAT_VERSION", "999")
+    s_v2 = fr.signature(tpl, "cp", storage, "content")
+    assert s_v1 != s_v2
+
+
+def test_signature_missing_input_raises():
+    from cfdmod.core.errors import StorageKeyError
+
+    storage = MemoryStorage()  # body never written
+    with pytest.raises(StorageKeyError):
+        fr.signature(_scale_template(), "cp", storage, "content")
+
+
+# --- output_status ---------------------------------------------------------
+
+
+def test_output_status_missing_then_fresh_then_stale_memory():
+    storage = MemoryStorage()
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    tpl = _scale_template()
+
+    # Never run -> missing.
+    st = output_status(tpl, storage)
+    assert st["cp"].status == "missing"
+
+    # Run stamps a signature -> fresh.
+    run_template(tpl, storage=storage)
+    st = output_status(tpl, storage)
+    assert st["cp"].status == "fresh"
+
+    # Change an input -> stale.
+    storage.write_data_source("body", _surface(np.full((2, 3), 9.0)))
+    st = output_status(tpl, storage)
+    assert st["cp"].status == "stale"
+
+
+# --- skip_fresh run mode ---------------------------------------------------
+
+
+class _SpyStorage(MemoryStorage):
+    """MemoryStorage that records which keys were (re)written."""
+
+    def __init__(self):
+        super().__init__()
+        self.writes = []
+
+    def write_data_source(self, key, ds):
+        self.writes.append(key)
+        super().write_data_source(key, ds)
+
+
+def test_skip_fresh_no_op_when_all_fresh():
+    storage = _SpyStorage()
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    tpl = _scale_template()
+
+    run_template(tpl, storage=storage)
+    storage.writes.clear()
+
+    bindings = run_template(tpl, storage=storage, skip_fresh=True)
+    assert bindings == {}
+    assert storage.writes == []  # nothing rewritten
+
+
+def test_skip_fresh_recomputes_only_stale_output():
+    storage = _SpyStorage()
+    storage.write_data_source("a", _surface(np.full((2, 3), 1.0)))
+    storage.write_data_source("b", _surface(np.full((2, 3), 1.0)))
+    tpl = PipelineTemplate(
+        inputs={
+            "a": {"kind": "surface", "path": "a"},
+            "b": {"kind": "surface", "path": "b"},
+        },
+        pipeline=[
+            {"id": "sa", "kind": "scale", "source": "a", "field": "pressure", "factor": 2.0},
+            {"id": "sb", "kind": "scale", "source": "b", "field": "pressure", "factor": 2.0},
+        ],
+        outputs={
+            "oa": {"source": "sa", "path": "oa"},
+            "ob": {"source": "sb", "path": "ob"},
+        },
+    )
+    run_template(tpl, storage=storage)
+
+    # Touch only input b -> only ob should be recomputed.
+    storage.write_data_source("b", _surface(np.full((2, 3), 7.0)))
+    storage.writes.clear()
+    run_template(tpl, storage=storage, skip_fresh=True)
+    assert storage.writes == ["ob"]
+
+
+def test_skip_fresh_requires_supporting_backend():
+    class _Bare:
+        def read_data_source(self, key):
+            raise KeyError(key)
+
+        def write_data_source(self, key, ds):
+            pass
+
+        def keys(self):
+            return []
+
+    from cfdmod.core.errors import TemplateError
+
+    with pytest.raises(TemplateError, match="skip_fresh"):
+        run_template(_scale_template(), storage=_Bare(), skip_fresh=True)
+
+
+# --- XdmfH5 digest + stamping ----------------------------------------------
+
+
+def test_xdmf_digest_size_mtime_flips_on_touch(tmp_path):
+    storage = XdmfH5Storage(tmp_path)
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    d1 = storage.digest("body", "size_mtime")
+    # Bump mtime by a second so st_mtime_ns changes deterministically.
+    st = (tmp_path / "body.h5").stat()
+    os.utime(tmp_path / "body.h5", ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+    d2 = storage.digest("body", "size_mtime")
+    assert d1 != d2
+
+
+def test_xdmf_digest_content_stable_across_identical_copy(tmp_path):
+    s1 = XdmfH5Storage(tmp_path / "a")
+    s2 = XdmfH5Storage(tmp_path / "b")
+    ds = _surface(np.full((2, 3), 5.0))
+    s1.write_data_source("body", ds)
+    s2.write_data_source("body", ds)
+    assert s1.digest("body", "content") == s2.digest("body", "content")
+
+
+def test_xdmf_digest_missing_key_raises(tmp_path):
+    from cfdmod.core.errors import StorageKeyError
+
+    with pytest.raises(StorageKeyError):
+        XdmfH5Storage(tmp_path).digest("nope", "size_mtime")
+
+
+def test_xdmf_run_stamps_and_status_roundtrips(tmp_path):
+    storage = XdmfH5Storage(tmp_path)
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    tpl = PipelineTemplate(
+        root=str(tmp_path),
+        inputs={"body": {"kind": "surface", "path": "body"}},
+        pipeline=[
+            {"id": "cp", "kind": "scale", "source": "body", "field": "pressure", "factor": 2.0}
+        ],
+        outputs={"cp": {"source": "cp", "path": "cp"}},
+    )
+    assert output_status(tpl, storage)["cp"].status == "missing"
+    run_template(tpl, storage=storage)
+    assert output_status(tpl, storage)["cp"].status == "fresh"
+
+    # Stamping must not corrupt the readable data source.
+    back = storage.read_data_source("cp")
+    np.testing.assert_allclose(back.fields.read("pressure"), 10.0)
+
+
+def test_xdmf_read_signature_none_when_unstamped(tmp_path):
+    storage = XdmfH5Storage(tmp_path)
+    storage.write_data_source("body", _surface(np.full((2, 3), 5.0)))
+    assert storage.read_signature("body") is None


### PR DESCRIPTION
## What

Adds **output freshness / staleness detection** to pipeline templates, so a
caller can tell whether a generated file is up to date or must be regenerated,
and skip recomputing the parts that haven't changed.

Closes #188 (core + run slice; the object-store-native ETag digest and
recipe-step signature folding remain as the follow-ups noted on the issue).

## How it works

Each output a template writes is stamped with a **signature** hashed over:

1. the params + wiring of every step in that output's dependency subgraph,
2. a change-detecting **digest** of each input file the subgraph touches, and
3. a code/format version tag (bumps invalidate stale outputs across upgrades).

`output_status` recomputes and compares stored vs. expected signatures;
`run_template(..., skip_fresh=True)` uses the comparison to prune to the
closure of the *stale* outputs only.

## API / surface

- `cfdmod.core.freshness`: `signature`, `output_status`, `OutputStatus`,
  dependency-closure helpers, `FORMAT_VERSION` / `code_version`.
- `Storage` protocol gains `digest(key, strategy)` / `read_signature` /
  `write_signature`. Implemented for `MemoryStorage`, `XdmfH5Storage` (signature
  in an h5 root attr; `size_mtime` default, `content`, `backend` strategies) and
  `XdmfH5BlobStorage` (`.sig` blob). **Backends that don't implement them keep
  working** -- the default run path only stamps via `hasattr`, and `skip_fresh`
  raises a clear error if unsupported.
- `run_template(..., skip_fresh=False)`: default behavior unchanged, but written
  outputs are now stamped when the backend supports it.
- Template config: `freshness.digest` / `freshness.per_input`.
- CLI: `cfdmod run --skip-fresh --digest <strategy>` and a new `cfdmod status
  <template>` (prints per-output `fresh|stale|missing`, exits non-zero if any is
  dirty -- usable as a CI / Makefile gate).
- Public exports: `output_status`, `OutputStatus`, `FreshnessConfig`.

## Design notes

- **Digest strategy is user-configurable, default `size_mtime`** (no byte reads;
  a few `stat()` calls). `content` = blake2b of bytes; `backend` = the backend's
  native token (falls back to `size_mtime` on the local FS, which has none). The
  strategy is embedded in the token, so switching strategy is itself a stale
  signal (visible in the smoke test: an output stamped `size_mtime` reads `stale`
  when queried with `content`).
- **Determinism:** sorted keys, paths normalized to storage keys, no clock/RNG in
  the fold, so a signature is stable across runs and machines.
- **Signature home:** h5 root attribute for the FS adapter (lives in `.attrs`, so
  `read_data_source` ignores it and the round-trip byte layout is unchanged); a
  `.sig` blob for the object-store adapter.
- Forward-compatible with the recipe-registry work (#187): the dependency walk
  and signature already fold a step's `recipe` name and `sources` map when
  present.

## Tests

`tests/core/test_freshness.py` (16 tests): dependency-closure transitivity +
binary-rhs inclusion; signature stability and sensitivity to param / input /
`FORMAT_VERSION` change; `output_status` missing->fresh->stale; `skip_fresh`
no-op when all fresh, recompute-only-stale (spy storage), unsupported-backend
error; XdmfH5 `size_mtime` flip on touch, `content` stable across identical copy,
stamping doesn't corrupt reads.

Full suite green (`ruff format` + `ruff check` clean). Pre-existing collection
errors for `tests/io`, `tests/s1`, `tests/altimetry` are unrelated -- they need
`vtkmodules` / `trimesh`, not installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
