### PR TITLE
examples: consulting post-processing notebook template

### DIFF
--- a/examples/consulting_template/01_inflow.ipynb
+++ b/examples/consulting_template/01_inflow.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 01 - Inlet profile validation\n",
+    "\n",
+    "Two parts:\n",
+    "1. **Directional design speed** (NBR 6123 / EN 1991-1-4) from the\n",
+    "   wind-analysis CSVs -- no simulation data needed.\n",
+    "2. **ABL profile validation** per terrain category -- mean velocity + TI vs\n",
+    "   code, spectrum, integral length.\n",
+    "\n",
+    "The ABL probe lines are read **directly from the h5 files** (a plain pandas\n",
+    "HDFStore read -- same idea as the old `read_df`), so this notebook does NOT\n",
+    "import `nassu`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json, pathlib\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from cfdmod import plot_config\n",
+    "from cfdmod.analytical import WindProfile_NBR, WindProfile_EU\n",
+    "from cfdmod.inflow import InflowData, NormalizationParameters\n",
+    "from cfdmod import inflow_report as ir\n",
+    "\n",
+    "import logging\n",
+    "logging.getLogger(\"cfdmod\").setLevel(logging.WARNING)\n",
+    "plot_config.apply_style()\n",
+    "\n",
+    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")\n",
+    "case_data = project / \"post_processing/pp_config/case_data\"\n",
+    "results   = project / \"results\"\n",
+    "dct_case = json.loads((case_data / \"global_data.json\").read_text())\n",
+    "batch = dct_case[\"analysis\"][\"batch_name\"]\n",
+    "H, V0 = float(dct_case[\"H\"]), float(dct_case[\"V0\"])\n",
+    "cats = sorted(k.split(\"directions_cat\")[1] for k in dct_case[\"analysis\"] if k.startswith(\"directions_cat\"))\n",
+    "print(f\"H={H} V0={V0} | terrain categories {cats}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Directional design speed (NBR + EU)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "wp_nbr = WindProfile_NBR.build(case_data / \"wind_analysis_NBR.csv\", V0=V0)\n",
+    "wp_eu  = WindProfile_EU.build(case_data / \"wind_analysis_EU.csv\", Vb=V0)\n",
+    "\n",
+    "u_nbr = ir.directional_reference_speed(wp_nbr, height=H, recurrence_period=50, use_kd=True)\n",
+    "u_eu  = ir.directional_reference_speed(wp_eu,  height=H, recurrence_period=50, use_kd=True)\n",
+    "print(f\"governing U_H @ {H:g} m: NBR {u_nbr.max():.2f} @ {u_nbr.idxmax():g} deg \"\n",
+    "      f\"| EU {u_eu.max():.2f} @ {u_eu.idxmax():g} deg\")\n",
+    "\n",
+    "fig, ax = plot_config.new_axes(xlabel=\"wind direction [deg]\", ylabel=\"U_H [m/s]\",\n",
+    "                               title=f\"Directional design speed @ H={H:g} m\")\n",
+    "ax.plot(u_nbr.index, u_nbr.to_numpy(), \"-o\", ms=3, label=\"NBR 6123\")\n",
+    "ax.plot(u_eu.index, u_eu.to_numpy(), \"-s\", ms=3, label=\"EN 1991-1-4\")\n",
+    "ax.legend()\n",
+    "plt.show()\n",
+    "u_nbr.rename(\"U_H_NBR\").to_frame().join(u_eu.rename(\"U_H_EU\")).round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. ABL profile validation (nassu-free probe read)\n",
+    "\n",
+    "`read_line` reads one probe line's velocity h5 straight into a wide frame\n",
+    "(time_step + one column per point), then we reshape to the long form\n",
+    "`InflowData` wants. One representative direction per terrain category."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def read_line(h5_path):\n",
+    "    \"\"\"Probe line velocity h5 -> wide DataFrame (time_step + point columns).\"\"\"\n",
+    "    parts = []\n",
+    "    with pd.HDFStore(h5_path, mode=\"r\") as store:\n",
+    "        for key in store.keys():\n",
+    "            parts.append(pd.read_hdf(store, key=key))\n",
+    "    return pd.concat(parts).reset_index(drop=True)\n",
+    "\n",
+    "\n",
+    "def build_inflow(direction, line=\"line0\", component=\"ux\"):\n",
+    "    \"\"\"Read one ABL probe line into a cfdmod InflowData (no nassu).\"\"\"\n",
+    "    folder = (results / batch / f\"BaciadaVovo_noBody_{direction}\" / \"000/probes\"\n",
+    "              / \"hist_series\" / \"abl_profile\")\n",
+    "    wide = read_line(folder / f\"line.{line}.{component}.h5\")\n",
+    "    num = [c for c in wide.columns if str(c).isnumeric()]\n",
+    "    long = wide.melt(id_vars=[\"time_step\"], value_vars=num,\n",
+    "                     var_name=\"point_idx\", value_name=component)\n",
+    "    long[\"point_idx\"] = long[\"point_idx\"].astype(int)\n",
+    "    points = pd.read_csv(folder / f\"line.{line}.points.csv\")\n",
+    "    return InflowData(data=long, points=points), folder"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# representative direction + EU/NBR category labels per terrain category\n",
+    "REP = {\"0\": (\"000.0\", \"0\", \"I\"), \"3\": (\"022.5\", \"III\", \"III\")}\n",
+    "\n",
+    "measured_u_ref = {}  # per category, handed to the load notebooks via _shared.json\n",
+    "for c in cats:\n",
+    "    rep_dir, cat_eu, cat_nbr = REP.get(c, (dct_case[\"analysis\"][f\"directions_cat{c}\"][0], \"III\", \"III\"))\n",
+    "    inflow, folder = build_inflow(rep_dir)\n",
+    "    if not folder.exists():\n",
+    "        print(f\"[cat{c}] no ABL data at {folder}\"); continue\n",
+    "    prof = ir.detect_profiles(inflow, min_points=3)[0]\n",
+    "    u_ref = ir.reference_velocity(prof, inflow, H)\n",
+    "    L = ir.integral_length_scale(inflow, prof.nearest_index(H), u_ref)\n",
+    "    print(f\"[cat{c}] dir {rep_dir}: u_ref(H)={u_ref:.2f} m/s | L(H)={L:.1f} m\")\n",
+    "    measured_u_ref[c] = float(u_ref)\n",
+    "    norm = NormalizationParameters(reference_velocity=max(u_ref, 1e-6), characteristic_length=H)\n",
+    "\n",
+    "    fig, _ = ir.plot_profile_vs_code(prof, inflow, H, cat_eu=cat_eu, cat_nbr=cat_nbr)\n",
+    "    plt.show()\n",
+    "    fig = ir.plot_spectrum(prof, inflow, H, norm)\n",
+    "    plt.show()\n",
+    "    L_num = ir.integral_length_scale_profile(inflow, prof)\n",
+    "    fig, _ = ir.plot_integral_length_scale(prof.z, L_num, H)\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Handoff to the load notebooks\n",
+    "\n",
+    "Write the values 02/03 need into a local `_shared.json` in this folder, so\n",
+    "they read them instead of you copy-pasting numbers between notebooks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "shared = {\n",
+    "    \"H\": H, \"V0\": V0,\n",
+    "    \"governing_design_U_H\": {\"NBR\": float(u_nbr.max()), \"EU\": float(u_eu.max())},\n",
+    "    \"design_U_H_by_direction_NBR\": {f\"{float(d):g}\": float(v) for d, v in u_nbr.items()},\n",
+    "    \"measured_u_ref_by_category\": measured_u_ref,\n",
+    "}\n",
+    "out = pathlib.Path.cwd() / \"_shared.json\"\n",
+    "out.write_text(json.dumps(shared, indent=2))\n",
+    "print(\"wrote\", out)\n",
+    "shared"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/consulting_template/02_static_loads.ipynb
+++ b/examples/consulting_template/02_static_loads.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 02 - Static wind loads\n",
+    "\n",
+    "For each wind direction: `Cp = (p - p_ref)/q`, per-floor force/moment\n",
+    "coefficients (`cfdmod.building.per_floor_loads`), then dimensional\n",
+    "static-equivalent floor loads. Produces the per-direction floor Fx/Fy/Mz\n",
+    "profiles, the directional global envelope, and the Eberick peak-load tables.\n",
+    "\n",
+    "Same shape as the old `hfpi_static.ipynb`: config read inline, the\n",
+    "direction loop is right here in a cell, heavy compute called straight from\n",
+    "`cfdmod`. Run it against any kernel that has cfdmod v3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json, pathlib\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import h5py\n",
+    "%matplotlib inline\n",
+    "from matplotlib.ticker import FuncFormatter\n",
+    "\n",
+    "from cfdmod import plot_config\n",
+    "from cfdmod.adapters.xdmf_h5 import XdmfH5Storage\n",
+    "from cfdmod.adapters.memory import MemoryFieldStore\n",
+    "from cfdmod.core import PointsDataSource, Topology, ElementMeta\n",
+    "from cfdmod.core.container import Container\n",
+    "from cfdmod.building import BuildingCase, per_floor_loads\n",
+    "from cfdmod.analytical import WindProfile_NBR\n",
+    "from cfdmod.dynamics import (\n",
+    "    DimensionalData, BuildingCaseParameters,\n",
+    "    get_stats_forces_effective, filter_by_xi, join_by_direction,\n",
+    ")\n",
+    "from cfdmod.dynamics.plotting import (\n",
+    "    plot_floor_by_floor_mean_peaks, plot_global_stats_per_direction,\n",
+    "    effective_peak_loads_per_direction, add_eberick_floor_height_and_pavements,\n",
+    ")\n",
+    "\n",
+    "import logging\n",
+    "logging.getLogger(\"cfdmod\").setLevel(logging.WARNING)  # quiet per-direction INFO spam\n",
+    "plot_config.apply_style()\n",
+    "TF = 1.0 / 9806.65  # N -> tonne-force"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Case config (read inline from the existing case_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")\n",
+    "case_data = project / \"post_processing/pp_config/case_data\"\n",
+    "results   = project / \"results\"\n",
+    "\n",
+    "dct_case = json.loads((case_data / \"global_data.json\").read_text())\n",
+    "dct_case"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from ruamel.yaml import YAML\n",
+    "yaml = YAML(typ=\"safe\")\n",
+    "\n",
+    "batch = dct_case[\"analysis\"][\"batch_name\"]\n",
+    "H  = float(dct_case[\"H\"])\n",
+    "L  = float(dct_case[\"L\"])\n",
+    "V0 = float(dct_case[\"V0\"])\n",
+    "bodies = dct_case[\"analysis\"][\"body_names\"]\n",
+    "\n",
+    "# terrain categories -> directions (each category has its own inlet U_H)\n",
+    "cats = sorted(k.split(\"directions_cat\")[1] for k in dct_case[\"analysis\"]            if k.startswith(\"directions_cat\"))\n",
+    "dirs_by_cat = {c: [str(d) for d in dct_case[\"analysis\"][f\"directions_cat{c}\"]] for c in cats}\n",
+    "\n",
+    "# per-category simulation U_H + reference area/volume + per-body floor z-edges,\n",
+    "# read straight from the params_cat*.yaml the case already ships\n",
+    "simul_u_h, floor_heights = {}, {}\n",
+    "for c in cats:\n",
+    "    params = yaml.load((case_data / f\"params_cat{c}.yaml\").open())\n",
+    "    cp0 = next(iter(params[\"pressure_coefficient\"].values()))\n",
+    "    simul_u_h[c] = float(cp0[\"simul_U_H\"])\n",
+    "    fluid_density = float(cp0.get(\"fluid_density\", 1.225))\n",
+    "    fc0 = next(iter(params[\"force_coefficient\"].values()))\n",
+    "    nominal_area   = float(fc0[\"nominal_area\"])\n",
+    "    nominal_volume = float(next(iter(params[\"moment_coefficient\"].values()))[\"nominal_volume\"])\n",
+    "    if not floor_heights:\n",
+    "        for b in bodies:\n",
+    "            blk = params[\"force_coefficient\"].get(f\"building_{b}\") or fc0\n",
+    "            floor_heights[b] = [float(z) for z in blk[\"bodies\"][0][\"sub_bodies\"][\"z_intervals\"]]\n",
+    "\n",
+    "directions = [d for c in cats for d in dirs_by_cat[c]]\n",
+    "category_of = lambda d: next(c for c, ds in dirs_by_cat.items() if d in ds)\n",
+    "print(f\"H={H} L={L} V0={V0} | bodies={bodies}\")\n",
+    "print(f\"cats={cats} simul_U_H={simul_u_h} | {len(directions)} directions\")\n",
+    "\n",
+    "# design speeds computed in 01_inflow are handed over via a local _shared.json,\n",
+    "# so we do not copy-paste them between notebooks\n",
+    "shared = {}\n",
+    "sp = pathlib.Path.cwd() / \"_shared.json\"\n",
+    "if sp.exists():\n",
+    "    shared = json.loads(sp.read_text())\n",
+    "    print(\"loaded _shared.json from 01_inflow:\", list(shared))\n",
+    "else:\n",
+    "    print(\"no _shared.json (run 01_inflow first); design speed computed inline instead\")\n",
+    "design_by_dir = {float(k): v for k, v in shared.get(\"design_U_H_by_direction_NBR\", {}).items()}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick a body + tiny glue (kept visible here)\n",
+    "\n",
+    "Two small helpers cfdmod v3 does not yet expose as one call -- slated to move\n",
+    "into `cfdmod.building` so these cells become a single import. For now they are\n",
+    "right here so you can read/change them:\n",
+    "- `read_point_probe`: the reference-pressure probe has no `/Triangles`, so\n",
+    "  `XdmfH5Storage` rejects it; read it straight into a `PointsDataSource`.\n",
+    "- `static_response`: dimensionalize per-floor Cf/Cm into static-equivalent\n",
+    "  floor loads (`DimensionalData` convention: `F = cf * base * H * q`), keeping\n",
+    "  empty floor bands so the profile stays aligned to the storey table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "body = \"base\"\n",
+    "# body = \"torre01\"\n",
+    "# body = \"torre02\"\n",
+    "# body = \"torre03\"\n",
+    "# body = \"torre04\"\n",
+    "\n",
+    "mesh_path = project / f\"run/artifacts/lnas/{body}.lnas\"\n",
+    "probe_folder = lambda d: results / batch / f\"BaciadaVovo_{d}\" / \"000/probes/hist_series\" / f\"cp_analysis_{body}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def read_point_probe(h5_path, time_axis):\n",
+    "    \"\"\"Reference-pressure probe (points.point0.h5) -> PointsDataSource.\"\"\"\n",
+    "    with h5py.File(h5_path, \"r\") as h:\n",
+    "        grp = h[\"pressure\"]\n",
+    "        keys = sorted(grp.keys(), key=lambda k: float(k[1:]))\n",
+    "        arr = np.empty((1, len(keys)), dtype=np.float32)\n",
+    "        for i, k in enumerate(keys):\n",
+    "            arr[0, i] = grp[k][()][0]\n",
+    "        pts = np.zeros((1, 3))\n",
+    "        if \"Geometry\" in h:\n",
+    "            pts[0] = np.asarray(h[\"Geometry\"])[0]\n",
+    "    return PointsDataSource(time=time_axis, topology=Topology.points(pts),\n",
+    "                            elements=ElementMeta(position=pts),\n",
+    "                            fields=MemoryFieldStore({\"pressure\": arr}))\n",
+    "\n",
+    "\n",
+    "def static_response(cf, cm, case, load_u_h):\n",
+    "    \"\"\"Per-floor Cf/Cm -> static-equivalent floor loads (feq_x/feq_y/meq_z).\"\"\"\n",
+    "    edges = np.asarray(case.floor_heights)\n",
+    "    n_bands = len(edges) - 1\n",
+    "    # zoning drops empty z-bands; recover which bands hold geometry to keep alignment\n",
+    "    from lnas import LnasFormat\n",
+    "    geo = LnasFormat.from_file(mesh_path).geometry\n",
+    "    cz = np.asarray(geo.vertices)[np.asarray(geo.triangles)][:, :, 2].mean(axis=1)\n",
+    "    bands = np.where(np.histogram(cz, bins=edges)[0] > 0)[0]\n",
+    "\n",
+    "    def scatter(rows):\n",
+    "        rows = np.asarray(rows, dtype=np.float64)\n",
+    "        if rows.shape[0] == n_bands:\n",
+    "            return rows\n",
+    "        full = np.zeros((n_bands, rows.shape[1]))\n",
+    "        full[bands[-rows.shape[0]:]] = rows\n",
+    "        return full\n",
+    "\n",
+    "    dim = DimensionalData(U_H=load_u_h, height=case.reference_height,\n",
+    "                          base=case.characteristic_length, integral_scale_multiplier=1.0)\n",
+    "    fx = scatter(cf.fields.read(\"cf_x\")) * dim.force_normalization_factor\n",
+    "    fy = scatter(cf.fields.read(\"cf_y\")) * dim.force_normalization_factor\n",
+    "    mz = scatter(cm.fields.read(\"cm_z\")) * dim.moments_normalization_factor\n",
+    "    z_mid = 0.5 * (edges[:-1] + edges[1:])\n",
+    "    pts = np.zeros((n_bands, 3)); pts[:, 2] = z_mid\n",
+    "    return PointsDataSource(time=cf.time, topology=Topology.points(pts),\n",
+    "                            elements=ElementMeta(position=pts),\n",
+    "                            fields=MemoryFieldStore({\"feq_x\": fx, \"feq_y\": fy, \"meq_z\": mz}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Solve every direction (the loop, right here)\n",
+    "\n",
+    "One direction at a time so the multi-GB body pressure array is released before\n",
+    "the next (`chunk_size` streams the Cp -> Cf/Cm chain). Cp is non-dimensionalized\n",
+    "by the simulation inlet U_H (in the `BuildingCase`); the static loads here are\n",
+    "referenced at that same `simul` U_H (swap to the NBR design U_H via the\n",
+    "commented `wp.get_U_H(...)` line for full-design forces)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "wp = WindProfile_NBR.build(case_data / \"wind_analysis_NBR.csv\", V0=V0)\n",
+    "\n",
+    "responses = {}\n",
+    "for d in directions:\n",
+    "    cat = category_of(d)\n",
+    "    folder = probe_folder(d)\n",
+    "    if not (folder / f\"bodies.{body}.h5\").exists():\n",
+    "        print(f\"  [skip] {body} {d}: no data\"); continue\n",
+    "    storage = XdmfH5Storage(folder)\n",
+    "    bdy  = storage.read_data_source(pathlib.Path(f\"bodies.{body}\"))\n",
+    "    pref = read_point_probe(folder / \"points.point0.h5\", bdy.time)\n",
+    "    case = BuildingCase(name=body, reference_height=H, characteristic_length=L,\n",
+    "                        basic_wind_speed=V0, simul_reference_velocity=simul_u_h[cat],\n",
+    "                        nominal_area=nominal_area, nominal_volume=nominal_volume,\n",
+    "                        floor_heights=floor_heights[body], fluid_density=fluid_density)\n",
+    "    cf, cm = per_floor_loads(bdy, pref, str(mesh_path), case, method=\"centroid\", chunk_size=3000)\n",
+    "    # design speed: from 01_inflow (_shared.json) if present, else computed inline\n",
+    "    design_u_h = design_by_dir.get(float(d)) or wp.get_U_H(H, float(d), 50, time_filter_seconds=3, use_kd=True)\n",
+    "    load_u_h = simul_u_h[cat]        # default: reference at the simulation inlet speed\n",
+    "    # load_u_h = design_u_h          # alternative: 50-year NBR design speed\n",
+    "    responses[float(d)] = static_response(cf, cm, case, load_u_h)\n",
+    "    del bdy, pref\n",
+    "    print(f\"  {body} {d} (cat{cat}): load U_H={load_u_h:.2f}\")\n",
+    "\n",
+    "sorted(responses)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Directional global envelope (base loads per direction)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# pack into the dynamics Container shape so the stock reducers/plotters work\n",
+    "cont = Container(items={\n",
+    "    BuildingCaseParameters(direction=d, xi=0.0, recurrence_period=50.0, use_kd=True): r\n",
+    "    for d, r in responses.items()\n",
+    "})\n",
+    "\n",
+    "# global base loads (sum floors) + overturning Mx/My (force x lever arm) + torsion Mz\n",
+    "rows_f, rows_m = [], []\n",
+    "for d in sorted(responses):\n",
+    "    r = responses[d]\n",
+    "    z  = np.asarray(r.elements.position)[:, 2]\n",
+    "    fx = np.asarray(r.fields.read(\"feq_x\")); fy = np.asarray(r.fields.read(\"feq_y\"))\n",
+    "    mz = np.asarray(r.fields.read(\"meq_z\"))\n",
+    "    g = {\"Fx\": fx.sum(0), \"Fy\": fy.sum(0), \"Mx\": (fy * z[:, None]).sum(0),\n",
+    "         \"My\": (fx * z[:, None]).sum(0), \"Mz\": mz.sum(0)}\n",
+    "    rf = {\"direction\": d}; rm = {\"direction\": d}\n",
+    "    for s, red in ((\"min\", np.min), (\"max\", np.max), (\"mean\", np.mean)):\n",
+    "        rf[f\"{s}_x\"] = red(g[\"Fx\"]); rf[f\"{s}_y\"] = red(g[\"Fy\"])\n",
+    "        rm[f\"{s}_x\"] = red(g[\"Mx\"]); rm[f\"{s}_y\"] = red(g[\"My\"]); rm[f\"{s}_z\"] = red(g[\"Mz\"])\n",
+    "    rows_f.append(rf); rows_m.append(rm)\n",
+    "stats = {\"forces_static\": pd.DataFrame(rows_f), \"moments_static\": pd.DataFrame(rows_m)}\n",
+    "\n",
+    "fig, _ = plot_global_stats_per_direction({0.0: stats}, unit_conversion=TF,\n",
+    "                                          unit_name=\"tf\", variable_types=[\"static\"], xticks=45)\n",
+    "# workaround: cfdmod labels each x-tick with ' deg' (they overlap); use a degree symbol\n",
+    "for ax in fig.axes:\n",
+    "    ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: rf\"${v:.0f}^\\circ$\"))\n",
+    "plt.show()\n",
+    "stats[\"forces_static\"].round(2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Per-direction floor-by-floor Fx / Fy / Mz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "n_floors = next(iter(responses.values())).n_elements\n",
+    "for d in sorted(responses):\n",
+    "    r = responses[d]\n",
+    "    vals = {s: get_stats_forces_effective(r, s) for s in (\"min\", \"max\", \"mean\")}\n",
+    "    fig, _ = plot_floor_by_floor_mean_peaks(vals_plot=vals, vals_labels=(\"Fx\", \"Fy\", \"Mz\"),\n",
+    "                                            wind_dir=d, unit_conversion=TF, unit_name=\"tf\",\n",
+    "                                            y_abs=(0, n_floors + 1))\n",
+    "    fig.suptitle(rf\"wind ${d:.0f}^\\circ$\", fontweight=\"bold\")  # workaround: cfdmod title says \" deg\"\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Eberick per-direction peak-load tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "alt = pd.read_csv(case_data / f\"alturas_{body}.csv\")\n",
+    "tables = effective_peak_loads_per_direction(filter_by_xi(cont, 0.0))\n",
+    "for axis, df in tables.items():\n",
+    "    if len(df) == len(alt):\n",
+    "        add_eberick_floor_height_and_pavements(df, alt[\"z_min\"].to_numpy(), alt[\"Pavimento\"].tolist())\n",
+    "tables[\"Fx\"].round(2)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/consulting_template/03_facade.ipynb
+++ b/examples/consulting_template/03_facade.ipynb
@@ -1,0 +1,156 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 03 - Facade mean-Cp snapshots\n",
+    "\n",
+    "Per-triangle mean-Cp renders of each facade for one body / direction, via\n",
+    "`cfdmod.mesh_field`. A quick visual sanity check of the pressure field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json, pathlib\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import h5py\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from cfdmod import plot_config, mesh_field\n",
+    "from cfdmod.adapters.xdmf_h5 import XdmfH5Storage\n",
+    "from cfdmod.adapters.memory import MemoryFieldStore\n",
+    "from cfdmod.core import PointsDataSource, Topology, ElementMeta\n",
+    "from cfdmod.building import BuildingCase, cp_from_pressure\n",
+    "from ruamel.yaml import YAML\n",
+    "\n",
+    "import logging\n",
+    "logging.getLogger(\"cfdmod\").setLevel(logging.WARNING)\n",
+    "plot_config.apply_style()\n",
+    "yaml = YAML(typ=\"safe\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Case config (read inline)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")\n",
+    "case_data = project / \"post_processing/pp_config/case_data\"\n",
+    "results   = project / \"results\"\n",
+    "dct_case = json.loads((case_data / \"global_data.json\").read_text())\n",
+    "batch = dct_case[\"analysis\"][\"batch_name\"]\n",
+    "H, L, V0 = float(dct_case[\"H\"]), float(dct_case[\"L\"]), float(dct_case[\"V0\"])\n",
+    "bodies = dct_case[\"analysis\"][\"body_names\"]\n",
+    "cats = sorted(k.split(\"directions_cat\")[1] for k in dct_case[\"analysis\"] if k.startswith(\"directions_cat\"))\n",
+    "dirs_by_cat = {c: [str(d) for d in dct_case[\"analysis\"][f\"directions_cat{c}\"]] for c in cats}\n",
+    "simul_u_h, floor_heights = {}, {}\n",
+    "for c in cats:\n",
+    "    params = yaml.load((case_data / f\"params_cat{c}.yaml\").open())\n",
+    "    cp0 = next(iter(params[\"pressure_coefficient\"].values()))\n",
+    "    simul_u_h[c] = float(cp0[\"simul_U_H\"]); fluid_density = float(cp0.get(\"fluid_density\", 1.225))\n",
+    "    fc0 = next(iter(params[\"force_coefficient\"].values()))\n",
+    "    nominal_area = float(fc0[\"nominal_area\"])\n",
+    "    nominal_volume = float(next(iter(params[\"moment_coefficient\"].values()))[\"nominal_volume\"])\n",
+    "    if not floor_heights:\n",
+    "        for b in bodies:\n",
+    "            blk = params[\"force_coefficient\"].get(f\"building_{b}\") or fc0\n",
+    "            floor_heights[b] = [float(z) for z in blk[\"bodies\"][0][\"sub_bodies\"][\"z_intervals\"]]\n",
+    "category_of = lambda d: next(c for c, ds in dirs_by_cat.items() if d in ds)\n",
+    "directions = [d for c in cats for d in dirs_by_cat[c]]\n",
+    "print(\"bodies\", bodies, \"| directions\", len(directions), \"| simul_u_h\", simul_u_h)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pick body + direction, read the body pressure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "body = \"base\"\n",
+    "wind_dir = directions[0]\n",
+    "mesh_path = project / f\"run/artifacts/lnas/{body}.lnas\"\n",
+    "folder = results / batch / f\"BaciadaVovo_{wind_dir}\" / \"000/probes/hist_series\" / f\"cp_analysis_{body}\"\n",
+    "\n",
+    "def read_point_probe(h5_path, time_axis):\n",
+    "    with h5py.File(h5_path, \"r\") as h:\n",
+    "        grp = h[\"pressure\"]; keys = sorted(grp.keys(), key=lambda k: float(k[1:]))\n",
+    "        arr = np.empty((1, len(keys)), dtype=np.float32)\n",
+    "        for i, k in enumerate(keys):\n",
+    "            arr[0, i] = grp[k][()][0]\n",
+    "        pts = np.zeros((1, 3))\n",
+    "        if \"Geometry\" in h: pts[0] = np.asarray(h[\"Geometry\"])[0]\n",
+    "    return PointsDataSource(time=time_axis, topology=Topology.points(pts),\n",
+    "                            elements=ElementMeta(position=pts), fields=MemoryFieldStore({\"pressure\": arr}))\n",
+    "\n",
+    "cat = category_of(wind_dir)\n",
+    "storage = XdmfH5Storage(folder)\n",
+    "bdy  = storage.read_data_source(pathlib.Path(f\"bodies.{body}\"))\n",
+    "pref = read_point_probe(folder / \"points.point0.h5\", bdy.time)\n",
+    "case = BuildingCase(name=body, reference_height=H, characteristic_length=L,\n",
+    "                    basic_wind_speed=V0, simul_reference_velocity=simul_u_h[cat],\n",
+    "                    nominal_area=nominal_area, nominal_volume=nominal_volume,\n",
+    "                    floor_heights=floor_heights[body], fluid_density=fluid_density)\n",
+    "\n",
+    "cp_mean = cp_from_pressure(bdy, pref, case, statistics=[\"mean\"]).fields.read(\"mean\")\n",
+    "print(f\"{body} {wind_dir}: mean Cp range [{np.nanmin(cp_mean):.2f}, {np.nanmax(cp_mean):.2f}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Render: iso view + per facade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "geom = mesh_field.load_geometry(str(mesh_path))\n",
+    "fig, _ = mesh_field.triangle_field_figure(geom, cp_mean, view=mesh_field.STANDARD_VIEWS[\"iso\"],\n",
+    "                                          title=rf\"{body} {float(wind_dir):.0f}$^\\circ$ mean Cp\", cbar_label=\"Cp [-]\")\n",
+    "plt.show()\n",
+    "\n",
+    "for name, grp in mesh_field.facade_groups(str(mesh_path)).items():\n",
+    "    fig, _ = mesh_field.triangle_field_figure(geom, cp_mean, subset=grp,\n",
+    "                                              title=f\"{name} mean Cp\", cbar_label=\"Cp [-]\")\n",
+    "    plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/consulting_template/README.md
+++ b/examples/consulting_template/README.md
@@ -1,0 +1,75 @@
+# Consulting post-processing template (cfdmod v3)
+
+A copy-per-case set of **self-contained notebooks** for building post-processing
+of a wind-tunnel / CFD consulting case. Copy this folder next to a case, edit one
+line, and run the notebooks top to bottom.
+
+The notebooks are the whole thing: config is read inline, the per-direction loop
+is visible in a cell, and all heavy computation is called straight from the
+installed `cfdmod` library. There is no per-case Python module, no CLI, and
+nothing to keep in sync across cases -- reusable logic lives in `cfdmod`.
+
+## Notebooks
+
+| Notebook | Produces |
+|---|---|
+| `01_inflow.ipynb` | Directional design speed (NBR 6123 / EN 1991-1-4); ABL mean/TI vs code, spectrum, integral length per terrain category. Writes `_shared.json`. |
+| `02_static_loads.ipynb` | Per-direction floor Fx/Fy/Mz profiles, directional global envelope, Eberick per-direction peak-load tables. |
+| `03_facade.ipynb` | Per-triangle mean-Cp renders per facade. |
+
+Run them in order: `01` writes a local `_shared.json` (reference/design speeds)
+that `02` and `03` read, so you never copy-paste numbers between notebooks. Each
+notebook still runs standalone (it falls back to computing those values inline if
+`_shared.json` is absent).
+
+## Use it on a new case
+
+1. Copy this folder into the case, e.g. `<case>/post_processing_v3/`.
+2. In the first config cell of each notebook, set the case root:
+
+   ```python
+   project = pathlib.Path("/data/eng/consulting/NNN_CaseName")
+   ```
+
+3. In `01_inflow`, set `REP` -- the representative ABL direction and the
+   EU/NBR terrain-category labels per terrain category, e.g.
+
+   ```python
+   REP = {"0": ("000.0", "0", "I"), "3": ("022.5", "III", "III")}
+   ```
+
+4. Pick the `body` in `02` / `03` (defaults to the first body).
+5. Run all cells. Figures render inline; save/versioned output is up to you.
+
+## Expected case layout
+
+The notebooks read the standard consulting `case_data` and results tree:
+
+```
+<case>/post_processing/pp_config/case_data/
+    global_data.json          # analysis.batch_name, body_names, directions_cat*, H, L, V0
+    params_cat<c>.yaml         # pressure_coefficient.simul_U_H, force/moment nominal_area/volume, floor z_intervals
+    alturas_<body>.csv         # storey table: z_min, z_max, Pavimento
+    wind_analysis_{NBR,EU}.csv
+<case>/run/artifacts/lnas/<body>.lnas
+<case>/results/<batch>/<Case>_<dir>/000/probes/hist_series/cp_analysis_<body>/
+    bodies.<body>.h5           # body pressure timeseries
+    points.point0.h5           # reference-pressure probe
+<case>/results/<batch>/<Case>_noBody_<dir>/000/probes/hist_series/abl_profile/
+    line.<lineN>.ux.h5 / .points.csv    # inflow ABL probe lines (01 only)
+```
+
+## Environment
+
+Any kernel with **cfdmod v3** plus `numpy`, `pandas`, `scipy`, `matplotlib`,
+`h5py`, `aerosim-lnas`, `ruamel.yaml`, and `tables` (PyTables, for reading the
+ABL probe h5 in `01`). The notebooks do **not** import `nassu` -- the ABL probe
+files are read directly with pandas.
+
+## Notes
+
+- The tiny glue kept visible in a cell (the reference-pressure point reader and
+  the static-load dimensionalization) is a candidate to move into `cfdmod`; until
+  then it stays in the notebook so it is easy to read and change.
+- Wind-direction labels from `cfdmod.dynamics.plotting` are reformatted to a
+  degree symbol in the notebook (the library default is being fixed upstream).


### PR DESCRIPTION
Adds `examples/consulting_template/` -- a copy-per-case set of self-contained
notebooks for consulting wind-load post-processing, built on the cfdmod v3
`building` / `dynamics` stack.

## Why

Transcribing a case's post-processing to v3 must not spawn a per-case shadow
library. The deliverable is notebooks the engineer can read, copy-paste, and run
cell by cell (the old `hfpi_static.ipynb` model). Reusable logic stays in
`cfdmod`; each case is just thin notebooks.

## What's in it

- `01_inflow.ipynb` - directional design speed (NBR/EU) + ABL validation per
  terrain category. Reads the Nassu `abl_profile` probe files **directly** (no
  `nassu` import). Writes a local `_shared.json`.
- `02_static_loads.ipynb` - per-floor Fx/Fy/Mz, directional global envelope,
  Eberick peak-load tables. The per-direction loop is visible in a cell.
- `03_facade.ipynb` - per-facade mean-Cp renders.
- `README.md` - copy-per-case usage + expected case layout + env.

## Notes

- Config is read inline from `global_data.json` / `params_cat*.yaml`; the only
  per-case edit is the `project` path (and the inflow `REP` map).
- Notebooks hand values between stages via `_shared.json` instead of copy-paste,
  and each still runs standalone (inline fallback).
- Wind-direction labels from `cfdmod.dynamics.plotting` are reformatted to a
  degree symbol in-notebook as a workaround for #191 (the ' deg' suffix overlaps).

Validated end-to-end on a real case (061 ArtHaus): all three notebooks execute
with inline figures and zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)