### PR TITLE
fix(examples): correct static-load dimensionalization (nominal_area/volume)

### DIFF
--- a/examples/consulting_template/01_inflow.ipynb
+++ b/examples/consulting_template/01_inflow.ipynb
@@ -2,24 +2,23 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c6cbd8b4",
+   "id": "a4583b4d",
    "metadata": {},
    "source": [
     "# 01 - Inlet profile validation\n",
     "\n",
     "1. **Directional design speed** (NBR 6123 / EN 1991-1-4) from the\n",
-    "   wind-analysis CSVs -- no simulation data needed.\n",
-    "2. **ABL profile validation** per terrain category -- mean velocity + TI vs\n",
-    "   code, spectrum, integral length.\n",
+    "   wind-analysis CSVs.\n",
+    "2. **ABL profile validation** per terrain category (mean velocity + TI vs\n",
+    "   code, spectrum, integral length), reading probe h5 directly (no `nassu`).\n",
     "\n",
-    "ABL probe lines are read directly from the h5 files (no `nassu`). Results are\n",
-    "shown inline AND written to `deliverables/<version>/inflow/`."
+    "Results render inline AND are written to `deliverables/<version>/inflow/`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d0e8319",
+   "id": "abf004be",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,8 +38,8 @@
     "logging.getLogger(\"cfdmod\").setLevel(logging.WARNING)\n",
     "plot_config.apply_style()\n",
     "\n",
-    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")  # <- set the case root\n",
-    "CASE = \"CaseName\"  # <- results case-name prefix: results/<batch>/<CASE>_<dir>/...\n",
+    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")\n",
+    "CASE = \"CaseName\"  # results/<batch>/<CASE>_<dir>/... and <CASE>_noBody_<dir>/...\n",
     "case_data = project / \"post_processing/pp_config/case_data\"\n",
     "results   = project / \"results\"\n",
     "dct_case = json.loads((case_data / \"global_data.json\").read_text())\n",
@@ -55,16 +54,18 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21b345f2",
+   "id": "ec51e5d6",
    "metadata": {},
    "source": [
-    "## 1. Directional design speed (NBR + EU)"
+    "## 1. Directional design speed (NBR + EU)\n",
+    "\n",
+    "10-min mean velocity (paired with peak Cp)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e30f821e",
+   "id": "67b5eabc",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a1f2e49",
+   "id": "d8e13d04",
    "metadata": {},
    "source": [
     "## 2. ABL profile validation (nassu-free probe read)\n",
@@ -102,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182c50fa",
+   "id": "e42b2d51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,11 +130,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86cad531",
+   "id": "3d83605e",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# representative direction + EU/NBR category labels per terrain category\n",
     "REP = {\"0\": (\"000.0\", \"0\", \"I\"), \"3\": (\"022.5\", \"III\", \"III\")}\n",
     "\n",
     "measured_u_ref = {}\n",
@@ -143,8 +143,8 @@
     "        inflow, folder = build_inflow(rep_dir)\n",
     "        prof = ir.detect_profiles(inflow, min_points=3)[0]\n",
     "        u_ref = ir.reference_velocity(prof, inflow, H)\n",
-    "        L = ir.integral_length_scale(inflow, prof.nearest_index(H), u_ref)\n",
-    "        print(f\"[cat{c}] dir {rep_dir}: u_ref(H)={u_ref:.2f} m/s | L(H)={L:.1f} m\")\n",
+    "        Lint = ir.integral_length_scale(inflow, prof.nearest_index(H), u_ref)\n",
+    "        print(f\"[cat{c}] dir {rep_dir}: u_ref(H)={u_ref:.2f} m/s | L(H)={Lint:.1f} m\")\n",
     "        measured_u_ref[c] = float(u_ref)\n",
     "        norm = NormalizationParameters(reference_velocity=max(u_ref, 1e-6), characteristic_length=H)\n",
     "        fig, _ = ir.plot_profile_vs_code(prof, inflow, H, cat_eu=cat_eu, cat_nbr=cat_nbr)\n",
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d44826ba",
+   "id": "612c46da",
    "metadata": {},
    "source": [
     "## Handoff to the load notebooks (`_shared.json`)"
@@ -169,7 +169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2293a0f",
+   "id": "d3e41ca7",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/examples/consulting_template/02_static_loads.ipynb
+++ b/examples/consulting_template/02_static_loads.ipynb
@@ -2,21 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "9a9f1147",
+   "id": "f61da048",
    "metadata": {},
    "source": [
     "# 02 - Static wind loads\n",
     "\n",
     "Per direction: `Cp = (p - p_ref)/q` -> per-floor Cf/Cm -> static-equivalent\n",
-    "floor loads. Produces the per-direction floor Fx/Fy/Mz profiles, the\n",
-    "directional global envelope, and the Eberick peak-load tables. Shown inline\n",
-    "AND written to `deliverables/<version>/static/<body>/`."
+    "floor loads. Produces per-direction floor Fx/Fy/Mz profiles, the directional\n",
+    "global envelope, and the peak-load tables. Shown inline AND written to\n",
+    "`deliverables/<version>/static/<body>/`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f33c6f81",
+   "id": "cd6d3da4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,8 +36,7 @@
     "from cfdmod.building import BuildingCase, per_floor_loads\n",
     "from cfdmod.analytical import WindProfile_NBR\n",
     "from cfdmod.dynamics import (\n",
-    "    DimensionalData, BuildingCaseParameters,\n",
-    "    get_stats_forces_effective, filter_by_xi, join_by_direction,\n",
+    "    BuildingCaseParameters, get_stats_forces_effective, filter_by_xi,\n",
     ")\n",
     "from cfdmod.dynamics.plotting import (\n",
     "    plot_floor_by_floor_mean_peaks, plot_global_stats_per_direction, floor_load_xlims,\n",
@@ -54,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e26fb811",
+   "id": "f1416efd",
    "metadata": {},
    "source": [
     "## Case config (read inline)"
@@ -63,12 +62,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ced033a9",
+   "id": "5817f912",
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")  # <- set the case root\n",
-    "CASE = \"CaseName\"  # <- results case-name prefix: results/<batch>/<CASE>_<dir>/...\n",
+    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")\n",
+    "CASE = \"CaseName\"  # results/<batch>/<CASE>_<dir>/... and <CASE>_noBody_<dir>/...\n",
     "case_data = project / \"post_processing/pp_config/case_data\"\n",
     "results   = project / \"results\"\n",
     "dct_case = json.loads((case_data / \"global_data.json\").read_text())\n",
@@ -78,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9041e96e",
+   "id": "e5508108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,13 +86,21 @@
     "\n",
     "batch = dct_case[\"analysis\"][\"batch_name\"]\n",
     "H  = float(dct_case[\"H\"]); L = float(dct_case[\"L\"]); V0 = float(dct_case[\"V0\"])\n",
-    "bodies = dct_case[\"analysis\"][\"body_names\"]\n",
     "cats = sorted(k.split(\"directions_cat\")[1] for k in dct_case[\"analysis\"] if k.startswith(\"directions_cat\"))\n",
     "dirs_by_cat = {c: [str(d) for d in dct_case[\"analysis\"][f\"directions_cat{c}\"]] for c in cats}\n",
+    "params_by_cat = {c: yaml.load((case_data / f\"params_cat{c}.yaml\").open()) for c in cats}\n",
+    "\n",
+    "# bodies: prefer the per-body force_coefficient keys (building_<body>) since that\n",
+    "# is where the per-body floor divisions live; fall back to global_data body_names\n",
+    "fc_keys = list(params_by_cat[cats[0]][\"force_coefficient\"])\n",
+    "if len(fc_keys) > 1 and all(k.startswith(\"building_\") for k in fc_keys):\n",
+    "    bodies = [k[len(\"building_\"):] for k in fc_keys]\n",
+    "else:\n",
+    "    bodies = list(dct_case[\"analysis\"][\"body_names\"])\n",
     "\n",
     "simul_u_h, floor_heights = {}, {}\n",
     "for c in cats:\n",
-    "    params = yaml.load((case_data / f\"params_cat{c}.yaml\").open())\n",
+    "    params = params_by_cat[c]\n",
     "    cp0 = next(iter(params[\"pressure_coefficient\"].values()))\n",
     "    simul_u_h[c] = float(cp0[\"simul_U_H\"]); fluid_density = float(cp0.get(\"fluid_density\", 1.225))\n",
     "    fc0 = next(iter(params[\"force_coefficient\"].values()))\n",
@@ -103,7 +110,6 @@
     "        for b in bodies:\n",
     "            blk = params[\"force_coefficient\"].get(f\"building_{b}\") or fc0\n",
     "            floor_heights[b] = [float(z) for z in blk[\"bodies\"][0][\"sub_bodies\"][\"z_intervals\"]]\n",
-    "\n",
     "directions = [d for c in cats for d in dirs_by_cat[c]]\n",
     "category_of = lambda d: next(c for c, ds in dirs_by_cat.items() if d in ds)\n",
     "print(f\"H={H} L={L} V0={V0} | bodies={bodies}\")\n",
@@ -120,41 +126,43 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0d19f85f",
+   "id": "c92dc0db",
    "metadata": {},
    "source": [
     "## Pick a body + tiny glue (kept visible)\n",
     "\n",
-    "`read_point_probe` reads the reference-pressure point probe into a\n",
-    "`PointsDataSource`; `static_response` dimensionalizes per-floor Cf/Cm into\n",
-    "static-equivalent floor loads, keeping empty floor bands aligned to the\n",
-    "storey table."
+    "`read_point_probe` reads the reference-pressure point probe;\n",
+    "`static_response` turns per-floor Cf/Cm into static-equivalent floor loads.\n",
+    "The dimensionalization matches `cfdmod.building` (`F = cf * q * nominal_area`,\n",
+    "`M = cm * q * nominal_volume`, `q = 0.5 * rho * U_H^2`) and keeps empty floor\n",
+    "bands so the profile stays aligned to the storey table."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b73b39ec",
+   "id": "e7bee91c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "body = bodies[0]\n",
-    "# body = bodies[1]\n",
+    "body = next((b for b in bodies if b.lower() != \"base\"), bodies[0])\n",
+    "# body = \"base\"\n",
     "\n",
     "mesh_path = project / f\"run/artifacts/lnas/{body}.lnas\"\n",
     "probe_folder = lambda d: results / batch / f\"{CASE}_{d}\" / \"000/probes/hist_series\" / f\"cp_analysis_{body}\"\n",
     "dbg = DebugWriter(pathlib.Path.cwd(), stage=f\"static/{body}\", version=VERSION)\n",
-    "print(\"deliverables ->\", dbg.deliverables_dir)"
+    "print(\"body:\", body); print(\"deliverables ->\", dbg.deliverables_dir)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef626277",
+   "id": "ad0914eb",
    "metadata": {},
    "outputs": [],
    "source": [
     "def read_point_probe(h5_path, time_axis):\n",
+    "    \"\"\"Reference-pressure probe (points.point0.h5) -> PointsDataSource.\"\"\"\n",
     "    with h5py.File(h5_path, \"r\") as h:\n",
     "        grp = h[\"pressure\"]; keys = sorted(grp.keys(), key=lambda k: float(k[1:]))\n",
     "        arr = np.empty((1, len(keys)), dtype=np.float32)\n",
@@ -165,8 +173,11 @@
     "    return PointsDataSource(time=time_axis, topology=Topology.points(pts),\n",
     "                            elements=ElementMeta(position=pts), fields=MemoryFieldStore({\"pressure\": arr}))\n",
     "\n",
-    "\n",
     "def static_response(cf, cm, case, load_u_h):\n",
+    "    \"\"\"Per-floor Cf/Cm -> static-equivalent floor loads (feq_x/feq_y/meq_z).\n",
+    "\n",
+    "    F = cf * q * nominal_area, M = cm * q * nominal_volume, q = 0.5*rho*U_H^2\n",
+    "    (same convention as cfdmod.building).\"\"\"\n",
     "    edges = np.asarray(case.floor_heights); n_bands = len(edges) - 1\n",
     "    from lnas import LnasFormat\n",
     "    geo = LnasFormat.from_file(mesh_path).geometry\n",
@@ -180,11 +191,10 @@
     "        full = np.zeros((n_bands, rows.shape[1])); full[bands[-rows.shape[0]:]] = rows\n",
     "        return full\n",
     "\n",
-    "    dim = DimensionalData(U_H=load_u_h, height=case.reference_height,\n",
-    "                          base=case.characteristic_length, integral_scale_multiplier=1.0)\n",
-    "    fx = scatter(cf.fields.read(\"cf_x\")) * dim.force_normalization_factor\n",
-    "    fy = scatter(cf.fields.read(\"cf_y\")) * dim.force_normalization_factor\n",
-    "    mz = scatter(cm.fields.read(\"cm_z\")) * dim.moments_normalization_factor\n",
+    "    q = 0.5 * case.fluid_density * load_u_h**2   # dynamic pressure at the load speed\n",
+    "    fx = scatter(cf.fields.read(\"cf_x\")) * q * case.nominal_area\n",
+    "    fy = scatter(cf.fields.read(\"cf_y\")) * q * case.nominal_area\n",
+    "    mz = scatter(cm.fields.read(\"cm_z\")) * q * case.nominal_volume\n",
     "    z_mid = 0.5 * (edges[:-1] + edges[1:]); pts = np.zeros((n_bands, 3)); pts[:, 2] = z_mid\n",
     "    return PointsDataSource(time=cf.time, topology=Topology.points(pts),\n",
     "                            elements=ElementMeta(position=pts),\n",
@@ -193,16 +203,21 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ff19804",
+   "id": "4cd3f5c8",
    "metadata": {},
    "source": [
-    "## Solve every direction (the loop, right here)"
+    "## Solve every direction (the loop, right here)\n",
+    "\n",
+    "One direction at a time so the multi-GB body pressure array is released before\n",
+    "the next. Cp is non-dimensionalized by the simulation inlet U_H; the static\n",
+    "loads are referenced at that same `simul` U_H (swap `load_u_h = design_u_h`\n",
+    "for the 50-year NBR design speed)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe90ecf5",
+   "id": "b02d5691",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea9c3600",
+   "id": "9496ae4d",
    "metadata": {},
    "source": [
     "## Directional global envelope (base loads per direction)"
@@ -243,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7ffbbcf",
+   "id": "f204155c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +289,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "149a4439",
+   "id": "cc4ddfe5",
    "metadata": {},
    "source": [
     "## Per-direction floor-by-floor Fx / Fy / Mz\n",
@@ -286,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "891d6c73",
+   "id": "1194a99c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +309,7 @@
     "vals_by_dir = {d: {s: get_stats_forces_effective(responses[d], s) for s in (\"min\", \"max\", \"mean\")}\n",
     "               for d in sorted(responses)}\n",
     "x_lims = floor_load_xlims(vals_by_dir.values(), unit_conversion=TF)\n",
-    "print(\"shared floor-load x-limits:\", x_lims)\n",
+    "print(\"shared floor-load x-limits (tf):\", x_lims)\n",
     "\n",
     "for d, vals in vals_by_dir.items():\n",
     "    fig, _ = plot_floor_by_floor_mean_peaks(vals_plot=vals, vals_labels=(\"Fx\", \"Fy\", \"Mz\"),\n",
@@ -306,16 +321,16 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91c9ae74",
+   "id": "dd0f4735",
    "metadata": {},
    "source": [
-    "## Eberick per-direction peak-load tables"
+    "## Per-direction peak-load tables (+ Eberick xlsx when the storey table aligns)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92fea60d",
+   "id": "323e1d44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,19 +339,18 @@
     "for name, df in tables.items():\n",
     "    dbg.save_csv(df.round(4), f\"peak_loads_{name}.csv\", deliverable=True)\n",
     "\n",
-    "# Eberick xlsx needs the storey table to line up with the floor bands\n",
     "alt_path = case_data / f\"alturas_{body}.csv\"\n",
-    "if alt_path.exists():\n",
+    "if not alt_path.exists():\n",
+    "    alt_path = case_data / \"alturas.csv\"\n",
+    "if alt_path.exists() and len(pd.read_csv(alt_path)) == n_bands:\n",
     "    alt = pd.read_csv(alt_path)\n",
-    "    if len(alt) == n_bands:\n",
-    "        for name, df in tables.items():\n",
-    "            add_eberick_floor_height_and_pavements(df, alt[\"z_min\"].to_numpy(), alt[\"Pavimento\"].tolist())\n",
-    "        export_eberick_tables_to_xlsx(tables, dbg.deliverable_path(\"eberick_loads.xlsx\"))\n",
-    "        print(\"wrote eberick_loads.xlsx\")\n",
-    "    else:\n",
-    "        print(f\"[eberick] {alt_path.name}: {len(alt)} rows vs {n_bands} floor bands; wrote peak_loads_*.csv only\")\n",
+    "    for name, df in tables.items():\n",
+    "        add_eberick_floor_height_and_pavements(df, alt[\"z_min\"].to_numpy(), alt[\"Pavimento\"].tolist())\n",
+    "    export_eberick_tables_to_xlsx(tables, dbg.deliverable_path(\"eberick_loads.xlsx\"))\n",
+    "    print(\"wrote eberick_loads.xlsx\")\n",
     "else:\n",
-    "    print(f\"[eberick] {alt_path.name} not found; wrote peak_loads_*.csv only\")\n",
+    "    got = len(pd.read_csv(alt_path)) if alt_path.exists() else \"no file\"\n",
+    "    print(f\"[eberick] storey table ({got}) != {n_bands} floor bands; wrote peak_loads_*.csv only\")\n",
     "print(\"deliverables ->\", dbg.deliverables_dir)\n",
     "tables[\"Fx\"].round(2)"
    ]

--- a/examples/consulting_template/03_facade.ipynb
+++ b/examples/consulting_template/03_facade.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "4ba86c22",
+   "id": "7ae126fa",
    "metadata": {},
    "source": [
     "# 03 - Facade mean-Cp snapshots\n",
@@ -14,7 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a89f90e0",
+   "id": "8af479b9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b0a24f4a",
+   "id": "47c57d6a",
    "metadata": {},
    "source": [
     "## Case config (read inline)"
@@ -50,23 +50,35 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b35b4f5a",
+   "id": "aa1d256d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")  # <- set the case root\n",
-    "CASE = \"CaseName\"  # <- results case-name prefix: results/<batch>/<CASE>_<dir>/...\n",
+    "project = pathlib.Path(\"/data/eng/consulting/NNN_CaseName\")\n",
+    "CASE = \"CaseName\"  # results/<batch>/<CASE>_<dir>/... and <CASE>_noBody_<dir>/...\n",
     "case_data = project / \"post_processing/pp_config/case_data\"\n",
     "results   = project / \"results\"\n",
     "dct_case = json.loads((case_data / \"global_data.json\").read_text())\n",
+    "from ruamel.yaml import YAML\n",
+    "yaml = YAML(typ=\"safe\")\n",
+    "\n",
     "batch = dct_case[\"analysis\"][\"batch_name\"]\n",
-    "H, L, V0 = float(dct_case[\"H\"]), float(dct_case[\"L\"]), float(dct_case[\"V0\"])\n",
-    "bodies = dct_case[\"analysis\"][\"body_names\"]\n",
+    "H  = float(dct_case[\"H\"]); L = float(dct_case[\"L\"]); V0 = float(dct_case[\"V0\"])\n",
     "cats = sorted(k.split(\"directions_cat\")[1] for k in dct_case[\"analysis\"] if k.startswith(\"directions_cat\"))\n",
     "dirs_by_cat = {c: [str(d) for d in dct_case[\"analysis\"][f\"directions_cat{c}\"]] for c in cats}\n",
+    "params_by_cat = {c: yaml.load((case_data / f\"params_cat{c}.yaml\").open()) for c in cats}\n",
+    "\n",
+    "# bodies: prefer the per-body force_coefficient keys (building_<body>) since that\n",
+    "# is where the per-body floor divisions live; fall back to global_data body_names\n",
+    "fc_keys = list(params_by_cat[cats[0]][\"force_coefficient\"])\n",
+    "if len(fc_keys) > 1 and all(k.startswith(\"building_\") for k in fc_keys):\n",
+    "    bodies = [k[len(\"building_\"):] for k in fc_keys]\n",
+    "else:\n",
+    "    bodies = list(dct_case[\"analysis\"][\"body_names\"])\n",
+    "\n",
     "simul_u_h, floor_heights = {}, {}\n",
     "for c in cats:\n",
-    "    params = yaml.load((case_data / f\"params_cat{c}.yaml\").open())\n",
+    "    params = params_by_cat[c]\n",
     "    cp0 = next(iter(params[\"pressure_coefficient\"].values()))\n",
     "    simul_u_h[c] = float(cp0[\"simul_U_H\"]); fluid_density = float(cp0.get(\"fluid_density\", 1.225))\n",
     "    fc0 = next(iter(params[\"force_coefficient\"].values()))\n",
@@ -76,14 +88,14 @@
     "        for b in bodies:\n",
     "            blk = params[\"force_coefficient\"].get(f\"building_{b}\") or fc0\n",
     "            floor_heights[b] = [float(z) for z in blk[\"bodies\"][0][\"sub_bodies\"][\"z_intervals\"]]\n",
-    "category_of = lambda d: next(c for c, ds in dirs_by_cat.items() if d in ds)\n",
     "directions = [d for c in cats for d in dirs_by_cat[c]]\n",
+    "category_of = lambda d: next(c for c, ds in dirs_by_cat.items() if d in ds)\n",
     "print(\"bodies\", bodies, \"| directions\", len(directions), \"| simul_u_h\", simul_u_h)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9bf2d14c",
+   "id": "d371f78e",
    "metadata": {},
    "source": [
     "## Pick body + direction, read the body pressure"
@@ -92,17 +104,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0bdc6db",
+   "id": "85374651",
    "metadata": {},
    "outputs": [],
    "source": [
-    "body = bodies[0]\n",
+    "body = next((b for b in bodies if b.lower() != \"base\"), bodies[0])\n",
+    "# body = \"base\"\n",
     "wind_dir = directions[0]\n",
     "mesh_path = project / f\"run/artifacts/lnas/{body}.lnas\"\n",
     "folder = results / batch / f\"{CASE}_{wind_dir}\" / \"000/probes/hist_series\" / f\"cp_analysis_{body}\"\n",
     "dbg = DebugWriter(pathlib.Path.cwd(), stage=f\"facade/{body}\", version=VERSION)\n",
     "\n",
     "def read_point_probe(h5_path, time_axis):\n",
+    "    \"\"\"Reference-pressure probe (points.point0.h5) -> PointsDataSource.\"\"\"\n",
     "    with h5py.File(h5_path, \"r\") as h:\n",
     "        grp = h[\"pressure\"]; keys = sorted(grp.keys(), key=lambda k: float(k[1:]))\n",
     "        arr = np.empty((1, len(keys)), dtype=np.float32)\n",
@@ -128,7 +142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7f5cd93",
+   "id": "c35c3299",
    "metadata": {},
    "source": [
     "## Render: iso view + per facade"
@@ -137,7 +151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4dc06831",
+   "id": "1da77bfd",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Problem (closes #198)

The consulting template's `static_response` dimensionalized per-floor Cf/Cm with
`base*height` (the `DimensionalData` reduced-coordinate scale), but
`per_floor_loads` normalizes the coefficients by `nominal_area`/`nominal_volume`
and the validated `cfdmod.building.dynamic` re-dimensionalizes with that same
reference. Using base*height under-reported **forces ~6x** and **moments ~42x**.

## Fix
- `F = cf * q * nominal_area`, `M = cm * q * nominal_volume`, `q = 0.5*rho*U_H^2`.
- Default body is now the first non-`base` body (the tower, not the podium).
- Body list derived from the per-body `building_<body>` force_coefficient keys,
  with a `global_data` body_names fallback.

## Proof
Regenerated a real tower case with the fix: base shear went from ~30-40 tf
(broken) to ~170-370 tf, per-floor peaks ~7-11 tf - same order as the v1-delivered
tower (~150-280 tf base, ~9-13 tf/floor). Executed clean (0 errors).