### PR TITLE
fix(examples): inflow notebook falls back to an available inlet run

### DIFF
--- a/examples/consulting_template/01_inflow.ipynb
+++ b/examples/consulting_template/01_inflow.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a4583b4d",
+   "id": "eba8c5c0",
    "metadata": {},
    "source": [
     "# 01 - Inlet profile validation\n",
@@ -18,7 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "abf004be",
+   "id": "86251364",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec51e5d6",
+   "id": "00b92e40",
    "metadata": {},
    "source": [
     "## 1. Directional design speed (NBR + EU)\n",
@@ -65,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67b5eabc",
+   "id": "8be864d3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d8e13d04",
+   "id": "3984af19",
    "metadata": {},
    "source": [
     "## 2. ABL profile validation (nassu-free probe read)\n",
@@ -103,7 +103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e42b2d51",
+   "id": "092f2161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,15 +130,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d83605e",
+   "id": "a780a67b",
    "metadata": {},
    "outputs": [],
    "source": [
     "REP = {\"0\": (\"000.0\", \"0\", \"I\"), \"3\": (\"022.5\", \"III\", \"III\")}\n",
     "\n",
+    "# inlet (no-body) runs actually on disk; fall back to one of these if the\n",
+    "# representative direction for a category was not simulated\n",
+    "avail = sorted(p.name.split(\"_noBody_\")[1] for p in (results / batch).glob(f\"{CASE}_noBody_*\"))\n",
+    "print(\"available inlet runs:\", avail)\n",
+    "\n",
     "measured_u_ref = {}\n",
     "for c in cats:\n",
     "    rep_dir, cat_eu, cat_nbr = REP.get(c, (dct_case[\"analysis\"][f\"directions_cat{c}\"][0], \"III\", \"III\"))\n",
+    "    if rep_dir not in avail and avail:\n",
+    "        print(f\"[cat{c}] rep dir {rep_dir} not simulated; using {avail[0]}\")\n",
+    "        rep_dir = avail[0]\n",
     "    try:\n",
     "        inflow, folder = build_inflow(rep_dir)\n",
     "        prof = ir.detect_profiles(inflow, min_points=3)[0]\n",
@@ -160,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "612c46da",
+   "id": "ccd7c4b8",
    "metadata": {},
    "source": [
     "## Handoff to the load notebooks (`_shared.json`)"
@@ -169,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3e41ca7",
+   "id": "3342fce3",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
If the REP representative ABL direction for a terrain category was not simulated, 01_inflow now uses an available `<CASE>_noBody_<dir>` run on disk rather than skipping the ABL validation and its deliverable figures.