### PR TITLE
fix(examples): static-load deliverables in labelled SI units (kN / kN.m)

### DIFF
--- a/examples/consulting_template/02_static_loads.ipynb
+++ b/examples/consulting_template/02_static_loads.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "f61da048",
+   "id": "78d2472c",
    "metadata": {},
    "source": [
     "# 02 - Static wind loads\n",
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd6d3da4",
+   "id": "6afdcd08",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,13 +47,14 @@
     "import logging\n",
     "logging.getLogger(\"cfdmod\").setLevel(logging.WARNING)\n",
     "plot_config.apply_style()\n",
-    "TF = 1.0 / 9806.65  # N -> tonne-force\n",
+    "KN = 1.0e-3   # N -> kN. Deliverables are SI: forces in kN, moments in kN.m\n",
+    "MNM = 1.0e-6  # N.m -> MN.m (used only for the global-loads summary table)\n",
     "VERSION = \"v3\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f1416efd",
+   "id": "3bce0f4a",
    "metadata": {},
    "source": [
     "## Case config (read inline)"
@@ -62,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5817f912",
+   "id": "36c91e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +78,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5508108",
+   "id": "137a769d",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +127,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c92dc0db",
+   "id": "5e745ae2",
    "metadata": {},
    "source": [
     "## Pick a body + tiny glue (kept visible)\n",
@@ -141,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7bee91c",
+   "id": "770e9add",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad0914eb",
+   "id": "8cdfd1a5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +204,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4cd3f5c8",
+   "id": "a8b0648e",
    "metadata": {},
    "source": [
     "## Solve every direction (the loop, right here)\n",
@@ -217,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b02d5691",
+   "id": "35c20dbe",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -249,7 +250,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9496ae4d",
+   "id": "e32354c9",
    "metadata": {},
    "source": [
     "## Directional global envelope (base loads per direction)"
@@ -258,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f204155c",
+   "id": "80db09e3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,17 +280,26 @@
     "    rows_f.append(rf); rows_m.append(rm)\n",
     "stats = {\"forces_static\": pd.DataFrame(rows_f), \"moments_static\": pd.DataFrame(rows_m)}\n",
     "\n",
-    "fig, _ = plot_global_stats_per_direction({0.0: stats}, unit_conversion=TF,\n",
-    "                                          unit_name=\"tf\", variable_types=[\"static\"], xticks=45)\n",
+    "fig, _ = plot_global_stats_per_direction({0.0: stats}, unit_conversion=KN,\n",
+    "                                          unit_name=\"kN\", variable_types=[\"static\"], xticks=45)\n",
     "dbg.savefig(fig, \"global_envelope.png\", deliverable=True)\n",
     "plt.show()\n",
-    "export_global_stats_per_direction_csv(dbg.deliverable_path(\"global_stats.csv\"), stats)\n",
-    "stats[\"forces_static\"].round(2)"
+    "\n",
+    "# clearly-labelled global summary: forces in kN, moments in MN.m, per direction\n",
+    "summary = pd.DataFrame({\"direction_deg\": stats[\"forces_static\"][\"direction\"]})\n",
+    "for comp in (\"x\", \"y\"):\n",
+    "    for s in (\"min\", \"max\", \"mean\"):\n",
+    "        summary[f\"F{comp}_{s}_kN\"] = (stats[\"forces_static\"][f\"{s}_{comp}\"] * KN).round(1)\n",
+    "for comp in (\"x\", \"y\", \"z\"):\n",
+    "    for s in (\"min\", \"max\", \"mean\"):\n",
+    "        summary[f\"M{comp}_{s}_MNm\"] = (stats[\"moments_static\"][f\"{s}_{comp}\"] * MNM).round(2)\n",
+    "dbg.save_csv(summary, \"global_loads_summary.csv\", deliverable=True)\n",
+    "summary"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "cc4ddfe5",
+   "id": "9305b8e5",
    "metadata": {},
    "source": [
     "## Per-direction floor-by-floor Fx / Fy / Mz\n",
@@ -301,19 +311,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1194a99c",
+   "id": "58e851c5",
    "metadata": {},
    "outputs": [],
    "source": [
     "n_floors = next(iter(responses.values())).n_elements\n",
     "vals_by_dir = {d: {s: get_stats_forces_effective(responses[d], s) for s in (\"min\", \"max\", \"mean\")}\n",
     "               for d in sorted(responses)}\n",
-    "x_lims = floor_load_xlims(vals_by_dir.values(), unit_conversion=TF)\n",
-    "print(\"shared floor-load x-limits (tf):\", x_lims)\n",
+    "x_lims = floor_load_xlims(vals_by_dir.values(), unit_conversion=KN)\n",
+    "print(\"shared floor-load x-limits (kN):\", x_lims)\n",
     "\n",
     "for d, vals in vals_by_dir.items():\n",
     "    fig, _ = plot_floor_by_floor_mean_peaks(vals_plot=vals, vals_labels=(\"Fx\", \"Fy\", \"Mz\"),\n",
-    "                                            wind_dir=d, unit_conversion=TF, unit_name=\"tf\",\n",
+    "                                            wind_dir=d, unit_conversion=KN, unit_name=\"kN\",\n",
     "                                            y_abs=(0, n_floors + 1), x_lims=x_lims)\n",
     "    dbg.savefig(fig, f\"floor_loads/wind_{d:g}.png\", deliverable=True)\n",
     "    plt.show()"
@@ -321,7 +331,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd0f4735",
+   "id": "4df3a192",
    "metadata": {},
    "source": [
     "## Per-direction peak-load tables (+ Eberick xlsx when the storey table aligns)"
@@ -330,14 +340,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "323e1d44",
+   "id": "b47d3b32",
    "metadata": {},
    "outputs": [],
    "source": [
-    "tables = effective_peak_loads_per_direction(filter_by_xi(cont, 0.0))\n",
+    "# peak per-floor loads in SI: Fx/Fy in kN, Mz in kN.m (rows = floor bands, cols = wind dir)\n",
+    "tables = effective_peak_loads_per_direction(filter_by_xi(cont, 0.0), unit_conversion=KN)\n",
     "n_bands = len(next(iter(tables.values())))\n",
     "for name, df in tables.items():\n",
-    "    dbg.save_csv(df.round(4), f\"peak_loads_{name}.csv\", deliverable=True)\n",
+    "    dbg.save_csv(df.round(2), f\"peak_loads_{name}.csv\", deliverable=True)\n",
     "\n",
     "alt_path = case_data / f\"alturas_{body}.csv\"\n",
     "if not alt_path.exists():\n",
@@ -351,6 +362,20 @@
     "else:\n",
     "    got = len(pd.read_csv(alt_path)) if alt_path.exists() else \"no file\"\n",
     "    print(f\"[eberick] storey table ({got}) != {n_bands} floor bands; wrote peak_loads_*.csv only\")\n",
+    "\n",
+    "# self-describing units note next to the deliverables\n",
+    "units_txt = (\n",
+    "    \"Static-load deliverable units (SI)\\n\"\n",
+    "    \"  peak_loads_Fx.csv, peak_loads_Fy.csv : per-floor peak lateral force [kN]\\n\"\n",
+    "    \"  peak_loads_Mz.csv                    : per-floor peak torsion [kN.m]\\n\"\n",
+    "    \"    rows = floor bands (bottom -> top), columns = wind direction [deg]\\n\"\n",
+    "    \"  global_loads_summary.csv             : per-direction base loads; F*_kN in [kN], M*_MNm in [MN.m]\\n\"\n",
+    "    \"  eberick_loads.xlsx                   : per-floor peak loads [kN] / [kN.m]\\n\"\n",
+    "    \"  figures (*.png)                      : forces [kN], moments [kN.m]\\n\"\n",
+    "    \"Conversions: 1 tf = 9.80665 kN; 1 kN = 1e-3 MN; moments 1 kN.m = 1e-3 MN.m\\n\"\n",
+    ")\n",
+    "dbg.deliverable_path(\"UNITS.txt\").write_text(units_txt)\n",
+    "print(units_txt)\n",
     "print(\"deliverables ->\", dbg.deliverables_dir)\n",
     "tables[\"Fx\"].round(2)"
    ]


### PR DESCRIPTION
The static deliverables mixed units - global_stats.csv in newtons, peak_loads_*.csv in tonne-force - and neither file stated its unit, so downstream consumers could not tell kN from tf from a coefficient. Now everything is consistent, labelled SI: peak_loads and figures in kN/kN.m, a new global_loads_summary.csv with explicit unit-suffixed columns (forces kN, moments MN.m) replacing the unlabelled global_stats.csv, plus a UNITS.txt documenting all units.