### PR TITLE
fix(examples): static-load deliverables in tonne-force (tf)

### DIFF
--- a/examples/consulting_template/02_static_loads.ipynb
+++ b/examples/consulting_template/02_static_loads.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "78d2472c",
+   "id": "50620c0a",
    "metadata": {},
    "source": [
     "# 02 - Static wind loads\n",
@@ -16,7 +16,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6afdcd08",
+   "id": "261506fa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,14 +47,13 @@
     "import logging\n",
     "logging.getLogger(\"cfdmod\").setLevel(logging.WARNING)\n",
     "plot_config.apply_style()\n",
-    "KN = 1.0e-3   # N -> kN. Deliverables are SI: forces in kN, moments in kN.m\n",
-    "MNM = 1.0e-6  # N.m -> MN.m (used only for the global-loads summary table)\n",
+    "TF = 1.0 / 9806.65   # N -> tf (tonne-force). Deliverables in tf and tf.m\n",
     "VERSION = \"v3\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3bce0f4a",
+   "id": "5fc946fe",
    "metadata": {},
    "source": [
     "## Case config (read inline)"
@@ -63,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36c91e62",
+   "id": "4535b549",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137a769d",
+   "id": "ee5f9e15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5e745ae2",
+   "id": "719b313a",
    "metadata": {},
    "source": [
     "## Pick a body + tiny glue (kept visible)\n",
@@ -142,7 +141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "770e9add",
+   "id": "87d331b5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8cdfd1a5",
+   "id": "da2426ff",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8b0648e",
+   "id": "d5b81466",
    "metadata": {},
    "source": [
     "## Solve every direction (the loop, right here)\n",
@@ -218,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35c20dbe",
+   "id": "e9b36b66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e32354c9",
+   "id": "fd52b622",
    "metadata": {},
    "source": [
     "## Directional global envelope (base loads per direction)"
@@ -259,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80db09e3",
+   "id": "9d43e74a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,26 +279,26 @@
     "    rows_f.append(rf); rows_m.append(rm)\n",
     "stats = {\"forces_static\": pd.DataFrame(rows_f), \"moments_static\": pd.DataFrame(rows_m)}\n",
     "\n",
-    "fig, _ = plot_global_stats_per_direction({0.0: stats}, unit_conversion=KN,\n",
-    "                                          unit_name=\"kN\", variable_types=[\"static\"], xticks=45)\n",
+    "fig, _ = plot_global_stats_per_direction({0.0: stats}, unit_conversion=TF,\n",
+    "                                          unit_name=\"tf\", variable_types=[\"static\"], xticks=45)\n",
     "dbg.savefig(fig, \"global_envelope.png\", deliverable=True)\n",
     "plt.show()\n",
     "\n",
-    "# clearly-labelled global summary: forces in kN, moments in MN.m, per direction\n",
+    "# clearly-labelled global summary: forces in tf, moments in tf.m, per direction\n",
     "summary = pd.DataFrame({\"direction_deg\": stats[\"forces_static\"][\"direction\"]})\n",
     "for comp in (\"x\", \"y\"):\n",
     "    for s in (\"min\", \"max\", \"mean\"):\n",
-    "        summary[f\"F{comp}_{s}_kN\"] = (stats[\"forces_static\"][f\"{s}_{comp}\"] * KN).round(1)\n",
+    "        summary[f\"F{comp}_{s}_tf\"] = (stats[\"forces_static\"][f\"{s}_{comp}\"] * TF).round(1)\n",
     "for comp in (\"x\", \"y\", \"z\"):\n",
     "    for s in (\"min\", \"max\", \"mean\"):\n",
-    "        summary[f\"M{comp}_{s}_MNm\"] = (stats[\"moments_static\"][f\"{s}_{comp}\"] * MNM).round(2)\n",
+    "        summary[f\"M{comp}_{s}_tfm\"] = (stats[\"moments_static\"][f\"{s}_{comp}\"] * TF).round(1)\n",
     "dbg.save_csv(summary, \"global_loads_summary.csv\", deliverable=True)\n",
     "summary"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9305b8e5",
+   "id": "2e18b1ed",
    "metadata": {},
    "source": [
     "## Per-direction floor-by-floor Fx / Fy / Mz\n",
@@ -311,19 +310,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58e851c5",
+   "id": "789be89d",
    "metadata": {},
    "outputs": [],
    "source": [
     "n_floors = next(iter(responses.values())).n_elements\n",
     "vals_by_dir = {d: {s: get_stats_forces_effective(responses[d], s) for s in (\"min\", \"max\", \"mean\")}\n",
     "               for d in sorted(responses)}\n",
-    "x_lims = floor_load_xlims(vals_by_dir.values(), unit_conversion=KN)\n",
-    "print(\"shared floor-load x-limits (kN):\", x_lims)\n",
+    "x_lims = floor_load_xlims(vals_by_dir.values(), unit_conversion=TF)\n",
+    "print(\"shared floor-load x-limits (tf):\", x_lims)\n",
     "\n",
     "for d, vals in vals_by_dir.items():\n",
     "    fig, _ = plot_floor_by_floor_mean_peaks(vals_plot=vals, vals_labels=(\"Fx\", \"Fy\", \"Mz\"),\n",
-    "                                            wind_dir=d, unit_conversion=KN, unit_name=\"kN\",\n",
+    "                                            wind_dir=d, unit_conversion=TF, unit_name=\"tf\",\n",
     "                                            y_abs=(0, n_floors + 1), x_lims=x_lims)\n",
     "    dbg.savefig(fig, f\"floor_loads/wind_{d:g}.png\", deliverable=True)\n",
     "    plt.show()"
@@ -331,7 +330,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4df3a192",
+   "id": "0f6c3209",
    "metadata": {},
    "source": [
     "## Per-direction peak-load tables (+ Eberick xlsx when the storey table aligns)"
@@ -340,15 +339,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b47d3b32",
+   "id": "a3a0d72f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# peak per-floor loads in SI: Fx/Fy in kN, Mz in kN.m (rows = floor bands, cols = wind dir)\n",
-    "tables = effective_peak_loads_per_direction(filter_by_xi(cont, 0.0), unit_conversion=KN)\n",
+    "# peak per-floor loads in tf: Fx/Fy in tf, Mz in tf.m (rows = floor bands, cols = wind dir)\n",
+    "tables = effective_peak_loads_per_direction(filter_by_xi(cont, 0.0), unit_conversion=TF)\n",
     "n_bands = len(next(iter(tables.values())))\n",
     "for name, df in tables.items():\n",
-    "    dbg.save_csv(df.round(2), f\"peak_loads_{name}.csv\", deliverable=True)\n",
+    "    dbg.save_csv(df.round(3), f\"peak_loads_{name}.csv\", deliverable=True)\n",
     "\n",
     "alt_path = case_data / f\"alturas_{body}.csv\"\n",
     "if not alt_path.exists():\n",
@@ -365,14 +364,14 @@
     "\n",
     "# self-describing units note next to the deliverables\n",
     "units_txt = (\n",
-    "    \"Static-load deliverable units (SI)\\n\"\n",
-    "    \"  peak_loads_Fx.csv, peak_loads_Fy.csv : per-floor peak lateral force [kN]\\n\"\n",
-    "    \"  peak_loads_Mz.csv                    : per-floor peak torsion [kN.m]\\n\"\n",
+    "    \"Static-load deliverable units (tonne-force)\\n\"\n",
+    "    \"  peak_loads_Fx.csv, peak_loads_Fy.csv : per-floor peak lateral force [tf]\\n\"\n",
+    "    \"  peak_loads_Mz.csv                    : per-floor peak torsion [tf.m]\\n\"\n",
     "    \"    rows = floor bands (bottom -> top), columns = wind direction [deg]\\n\"\n",
-    "    \"  global_loads_summary.csv             : per-direction base loads; F*_kN in [kN], M*_MNm in [MN.m]\\n\"\n",
-    "    \"  eberick_loads.xlsx                   : per-floor peak loads [kN] / [kN.m]\\n\"\n",
-    "    \"  figures (*.png)                      : forces [kN], moments [kN.m]\\n\"\n",
-    "    \"Conversions: 1 tf = 9.80665 kN; 1 kN = 1e-3 MN; moments 1 kN.m = 1e-3 MN.m\\n\"\n",
+    "    \"  global_loads_summary.csv             : per-direction base loads; F*_tf in [tf], M*_tfm in [tf.m]\\n\"\n",
+    "    \"  eberick_loads.xlsx                   : per-floor peak loads [tf] / [tf.m]\\n\"\n",
+    "    \"  figures (*.png)                      : forces [tf], moments [tf.m]\\n\"\n",
+    "    \"Conversions: 1 tf = 9.80665 kN = 9.80665e-3 MN; 1 tf.m = 9.80665e-3 MN.m\\n\"\n",
     ")\n",
     "dbg.deliverable_path(\"UNITS.txt\").write_text(units_txt)\n",
     "print(units_txt)\n",


### PR DESCRIPTION
Switches the static-load deliverables to tonne-force (tf / tf.m) throughout - figures, peak_loads_*.csv, global_loads_summary.csv (F*_tf, M*_tfm), eberick_loads.xlsx - matching the tf convention used across the consulting reports, replacing the mixed kN/MN.m from #201. Keeps the labelled summary, UNITS.txt, and the axis/styling fixes.