### PR TITLE
ci: add Dagger pipeline (lint + test + docs)

### DIFF
--- a/.dagger/.gitattributes
+++ b/.dagger/.gitattributes
@@ -1,0 +1,1 @@
+/sdk/** linguist-generated

--- a/.dagger/.gitignore
+++ b/.dagger/.gitignore
@@ -1,0 +1,4 @@
+/.venv
+/**/__pycache__
+/sdk
+/.env

--- a/.dagger/README.md
+++ b/.dagger/README.md
@@ -1,0 +1,54 @@
+# cfdmod CI (Dagger)
+
+cfdmod's CI is defined as code with [Dagger](https://dagger.io) (Apache-2.0).
+The same pipeline runs on your laptop and on any remote runner - there is no
+platform-specific YAML, and every step runs inside a container, so a green run
+locally is a green run everywhere.
+
+## One-time setup
+
+Install the Dagger CLI (Docker must be running):
+
+```bash
+curl -fsSL https://dl.dagger.io/dagger/install.sh | sh
+# then generate the SDK bindings for this module:
+dagger develop
+```
+
+`dagger develop` populates `.dagger/sdk/` (git-ignored) and reconciles the
+`engineVersion` in `dagger.json` with your installed CLI.
+
+## Running checks
+
+From the repository root, `--source=.` mounts the working tree:
+
+```bash
+dagger call --source=. check            # all checks, concurrently, with a summary
+dagger call --source=. lint             # a single check (also: test, docs)
+dagger call --source=. test
+```
+
+`check` runs the full pipeline:
+
+| Function | What it does                                                        |
+| -------- | ------------------------------------------------------------------- |
+| `lint`   | `ruff check` + `ruff format --check` (line length 99)               |
+| `test`   | `pytest` (unit + integration; the opt-in `perf` benchmarks excluded) |
+| `docs`   | Sphinx HTML build (nbsphinx renders the notebook pages)             |
+
+Everything runs inside one content-addressed base image: `python:3.12-slim`
+with the project synced via `uv sync --all-extras` (so the vtk / geometry /
+remesh extras are present for the full test suite and the docs extra for the
+Sphinx build). The `test` stage runs under `xvfb-run` to give the pyvista
+off-screen renders a virtual display.
+
+## How the CI server runs this
+
+This repo owns only its CI *definition* (the pipeline above). Scheduling,
+checkout, and running many repos' pipelines are the CI server's job (shared
+across repos), not this repo's. From the server's point of view the entrypoint
+is a single command run against a checkout:
+
+```bash
+dagger call --source=. check
+```

--- a/.dagger/pyproject.toml
+++ b/.dagger/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "cfdmod-ci"
+version = "0.0.0"
+requires-python = ">=3.11"
+dependencies = ["dagger-io"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cfdmod_ci"]

--- a/.dagger/src/cfdmod_ci/__init__.py
+++ b/.dagger/src/cfdmod_ci/__init__.py
@@ -1,0 +1,125 @@
+"""cfdmod CI pipeline, defined as code with Dagger.
+
+The exact same pipeline runs on a laptop and on any remote runner - there is no
+platform-specific YAML. Everything executes inside containers, so a green run
+locally means a green run everywhere.
+
+Quick start (see ``.dagger/README.md`` for details)::
+
+    dagger call --source=. check          # all checks, concurrently
+    dagger call --source=. lint stdout    # a single check
+
+The checks mirror the tooling cfdmod actually uses: ruff lint + format check,
+the pytest suite (unit + integration; the opt-in ``perf`` benchmarks are
+excluded, matching the project's default ``-m 'not perf'``), and the Sphinx
+docs build. Everything runs inside a single content-addressed base image, so
+each check reuses the same ``uv sync``.
+"""
+
+import asyncio
+from typing import Annotated
+
+import dagger
+from dagger import Doc, dag, function, object_type
+
+PYTHON_IMAGE = "python:3.12-slim-bookworm"
+
+# System packages for the base image:
+#   git/curl/ca-certificates - uv sync + source metadata
+#   pandoc                    - nbsphinx converts the docs notebooks
+#   libgl1/libglx-mesa0/...   - vtk + pyvista need OpenGL to import/render
+#   xvfb                      - off-screen virtual display for the pyvista
+#                               mesh-field render tests (headless host)
+BASE_APT = [
+    "git",
+    "curl",
+    "ca-certificates",
+    "make",
+    "pandoc",
+    "libgl1",
+    "libglx-mesa0",
+    "libxrender1",
+    "libxext6",
+    "libglib2.0-0",
+    "xvfb",
+    "xauth",
+]
+
+# name -> the coroutine attribute on ``Cfdmod`` that runs it, for ``check``.
+CHECKS = ["lint", "test", "docs"]
+
+
+@object_type
+class Cfdmod:
+    """CI pipeline for the aerosim-cfdmod library."""
+
+    source: Annotated[dagger.Directory, Doc("The cfdmod repository root")]
+
+    def base(self) -> dagger.Container:
+        """Python container with the project and all extras synced via uv.
+
+        Layers are content-addressed, so every check reuses this build. All
+        optional extras are installed so the full test suite (vtk, geometry,
+        remesh) collects and runs, and the docs extra is present for the
+        Sphinx build.
+        """
+        uv_cache = dag.cache_volume("cfdmod-uv-cache")
+        apt = "apt-get update && apt-get install -y --no-install-recommends " + " ".join(BASE_APT)
+        return (
+            dag.container()
+            .from_(PYTHON_IMAGE)
+            .with_exec(["sh", "-c", apt])
+            .with_exec(["pip", "install", "--no-cache-dir", "uv"])
+            .with_env_variable("UV_LINK_MODE", "copy")
+            .with_mounted_cache("/root/.cache/uv", uv_cache)
+            .with_directory("/src", self.source)
+            .with_workdir("/src")
+            .with_exec(["uv", "sync", "--all-extras"])
+        )
+
+    @function
+    async def lint(self) -> str:
+        """ruff static analysis and format check (line length 99)."""
+        return await (
+            self.base()
+            .with_exec(["uv", "run", "ruff", "check", "."])
+            .with_exec(["uv", "run", "ruff", "format", "--check", "."])
+            .stdout()
+        )
+
+    @function
+    async def test(self) -> str:
+        """Run the pytest suite (unit + integration; perf excluded by default).
+
+        Wrapped in ``xvfb-run`` so the pyvista off-screen renders have a
+        virtual display on the headless CI host.
+        """
+        return await self.base().with_exec(["xvfb-run", "-a", "uv", "run", "pytest"]).stdout()
+
+    @function
+    async def docs(self) -> str:
+        """Build the Sphinx HTML docs (nbsphinx renders the notebook pages)."""
+        return await self.base().with_exec(["sh", "-c", "cd docs && uv run make html"]).stdout()
+
+    @function
+    async def check(self) -> str:
+        """Run every check concurrently and report a pass/fail summary.
+
+        Raises if any check fails, so this is the single command a runner calls.
+        """
+        results = await asyncio.gather(
+            *(getattr(self, name)() for name in CHECKS),
+            return_exceptions=True,
+        )
+        lines: list[str] = []
+        failed = False
+        for name, result in zip(CHECKS, results):
+            if isinstance(result, BaseException):
+                failed = True
+                lines.append(f"FAIL  {name}\n{result}")
+            else:
+                lines.append(f"ok    {name}")
+        report = "\n".join(lines)
+        if failed:
+            raise RuntimeError("CI checks failed:\n" + report)
+        return "All checks passed:\n" + report

--- a/dagger.json
+++ b/dagger.json
@@ -1,0 +1,9 @@
+{
+  "name": "cfdmod",
+  "engineVersion": "v0.21.7",
+  "sdk": {
+    "source": "python"
+  },
+  "source": ".dagger",
+  "disableDefaultFunctionCaching": true
+}


### PR DESCRIPTION
Adds Dagger-based CI to cfdmod, mirroring the nassu/aerosim org pattern: CI defined as code (Python SDK, engine v0.21.7), same pipeline on a laptop and on the shared CI runner, no platform-specific YAML.

## What runs

`dagger call --source=. check` runs three stages concurrently in one content-addressed base image (`python:3.12-slim`, `uv sync --all-extras`, plus pandoc + GL libs + xvfb):

| stage | command |
| ----- | ------- |
| `lint` | `ruff check` + `ruff format --check` (line length 99) |
| `test` | `pytest` (unit + integration; opt-in `perf` excluded), under `xvfb-run` |
| `docs` | Sphinx HTML build (nbsphinx notebook pages) |

Scoped to the tooling cfdmod actually configures (no mypy/bandit/schema stages, unlike nassu, since those aren't set up here).

## Validation

`dagger call --source=. check` was run end-to-end in a clean container:

```
All checks passed:
ok    lint
ok    test
ok    docs
```

The clean-container run surfaced no issues in the library itself; the only fixes were to the CI harness (base image needed `make` and `xauth`; the module file needed formatting). See `.dagger/README.md` for setup and how the CI server invokes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)