### PR TITLE
feat: H5 line-probe post-processing scripts

### DIFF
--- a/scripts/h5_line_to_csv.py
+++ b/scripts/h5_line_to_csv.py
@@ -1,0 +1,130 @@
+"""Convert a line-probe H5 file into the legacy CSV layout.
+
+The AeroSim solver now writes line probes as a single H5 file:
+
+    <line>.h5
+        Geometry      (N, 3) float  -- x, y, z of each probe point
+        Connectivity  (M,)   int    -- line connectivity (not exported)
+        ux / uy / uz / pressure     -- one group per field, each holding
+                                       one dataset per time step, named
+                                       "t<time>" and shaped (N,)
+
+The old post-processing tools expected instead a set of CSV files:
+
+    <line>.points.csv   idx,x,y,z                (one row per point)
+    <line>.ux.csv       time_step,0,1,2,...,N-1  (one row per time step,
+                                                  one column per point)
+
+and equivalently for uy, uz and pressure. This script reproduces that CSV
+layout from the H5 file so the legacy CSV-based scripts keep working
+unchanged.
+
+Example
+-------
+    python scripts/h5_line_to_csv.py \
+        --h5 "line.line_line_roof.h5" \
+        --out-dir ./csv_out \
+        --fields ux uy uz pressure
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+
+import h5py
+import numpy as np
+
+
+def _parse_time(key: str) -> float:
+    """Turn a time-step dataset name ("t2000.638062") into a float."""
+    return float(key.lstrip("t"))
+
+
+def _sorted_time_keys(group: h5py.Group) -> list[str]:
+    """Return the time-step dataset names of a field group, sorted by time."""
+    keys = list(group.keys())
+    return sorted(keys, key=_parse_time)
+
+
+def write_points_csv(geometry: np.ndarray, path: str) -> None:
+    """Write the point coordinates as idx,x,y,z (matches points.csv)."""
+    with open(path, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(["idx", "x", "y", "z"])
+        for idx, (x, y, z) in enumerate(geometry):
+            writer.writerow([idx, x, y, z])
+    print(f"[INFO] wrote {path}  ({geometry.shape[0]} points)")
+
+
+def write_field_csv(group: h5py.Group, n_points: int, path: str) -> None:
+    """Write one field as time_step,0,1,...,N-1 (matches the ux.csv layout).
+
+    Rows are time steps (sorted by time), columns are point indices. The
+    values are streamed one time step at a time to avoid loading the whole
+    field into memory at once.
+    """
+    time_keys = _sorted_time_keys(group)
+    header = ["time_step", *[str(i) for i in range(n_points)]]
+    with open(path, "w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        for key in time_keys:
+            values = group[key][:]
+            writer.writerow([_parse_time(key), *values.tolist()])
+    print(f"[INFO] wrote {path}  ({len(time_keys)} time steps x {n_points} points)")
+
+
+def convert(h5_path: str, out_dir: str, fields: list[str]) -> None:
+    """Convert every requested field of a line H5 file to CSV."""
+    os.makedirs(out_dir, exist_ok=True)
+    # Base name mirrors the H5 file (drop only the .h5 extension), so the
+    # output matches the historical "<line>.points.csv" / "<line>.ux.csv".
+    base = os.path.basename(h5_path)
+    if base.lower().endswith(".h5"):
+        base = base[:-3]
+
+    with h5py.File(h5_path, "r") as h5:
+        if "Geometry" not in h5:
+            raise KeyError(f"{h5_path}: no 'Geometry' dataset found")
+        geometry = h5["Geometry"][:]
+        n_points = geometry.shape[0]
+
+        write_points_csv(geometry, os.path.join(out_dir, f"{base}.points.csv"))
+
+        for field in fields:
+            if field not in h5:
+                print(f"[WARN] field '{field}' not in {h5_path}; skipping")
+                continue
+            group = h5[field]
+            if not isinstance(group, h5py.Group):
+                print(f"[WARN] '{field}' is not a time-step group; skipping")
+                continue
+            write_field_csv(group, n_points, os.path.join(out_dir, f"{base}.{field}.csv"))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--h5", required=True, help="path to the line-probe H5 file")
+    parser.add_argument(
+        "--out-dir",
+        default=".",
+        help="directory to write the CSV files into (default: current dir)",
+    )
+    parser.add_argument(
+        "--fields",
+        nargs="+",
+        default=["ux", "uy", "uz", "pressure"],
+        help="fields to export (default: ux uy uz pressure)",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    convert(args.h5, args.out_dir, args.fields)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/h5_line_to_csv.py
+++ b/scripts/h5_line_to_csv.py
@@ -19,22 +19,36 @@ and equivalently for uy, uz and pressure. This script reproduces that CSV
 layout from the H5 file so the legacy CSV-based scripts keep working
 unchanged.
 
-Example
--------
-    python scripts/h5_line_to_csv.py \
-        --h5 "line.line_line_roof.h5" \
-        --out-dir ./csv_out \
-        --fields ux uy uz pressure
+HOW TO USE: edit the CONFIG block right below, then run the file:
+
+    python scripts/h5_line_to_csv.py
 """
 
 from __future__ import annotations
 
-import argparse
 import csv
 import os
 
 import h5py
 import numpy as np
+
+# =============================================================================
+# CONFIG -- edit these values, then just run the file.
+# =============================================================================
+
+# Input line-probe H5 file.
+H5_PATH = r"/home/waine/Downloads/line.line_line_roof.h5"
+
+# Directory to write the CSV files into.
+OUT_DIR = r"/home/waine/Downloads/h5_postpro_out"
+
+# Fields to export. A field that is absent from the H5 is skipped with a
+# warning (e.g. some line probes have no "pressure").
+FIELDS = ["ux", "uy", "uz", "pressure"]
+
+# =============================================================================
+# End of CONFIG. You normally do not need to edit below this line.
+# =============================================================================
 
 
 def _parse_time(key: str) -> float:
@@ -104,26 +118,8 @@ def convert(h5_path: str, out_dir: str, fields: list[str]) -> None:
             write_field_csv(group, n_points, os.path.join(out_dir, f"{base}.{field}.csv"))
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--h5", required=True, help="path to the line-probe H5 file")
-    parser.add_argument(
-        "--out-dir",
-        default=".",
-        help="directory to write the CSV files into (default: current dir)",
-    )
-    parser.add_argument(
-        "--fields",
-        nargs="+",
-        default=["ux", "uy", "uz", "pressure"],
-        help="fields to export (default: ux uy uz pressure)",
-    )
-    return parser
-
-
 def main() -> None:
-    args = build_parser().parse_args()
-    convert(args.h5, args.out_dir, args.fields)
+    convert(H5_PATH, OUT_DIR, FIELDS)
 
 
 if __name__ == "__main__":

--- a/scripts/velocity_profile_from_h5.py
+++ b/scripts/velocity_profile_from_h5.py
@@ -9,25 +9,18 @@ tool. It does the same thing the old CSV script did:
   4. optionally overlay a scaled experimental velocity profile,
   5. save the comparison figure (and the modified experimental CSV).
 
-The only change is the input: instead of reading
+The only change from the original is the input: instead of reading
+<line>.points.csv and <line>.ux.csv, it reads the coordinates from the
+"Geometry" dataset and the velocity component from the matching field group
+("ux") of a single line H5 file.
 
-    <line>.points.csv   and   <line>.ux.csv
+HOW TO USE: edit the CONFIG block right below, then run the file:
 
-it reads the coordinates from the "Geometry" dataset and the velocity
-component from the matching field group ("ux") of a single line H5 file.
-
-Example (matches the original defaults: U_inf=3.5, B=40, ux)
-------------------------------------------------------------
-    python scripts/velocity_profile_from_h5.py \
-        --h5 "line.line_line_roof.h5" \
-        --u-infinity 3.5 --height-scale 40 \
-        --experimental velocity_profile_at_x_position_roof_AR1.csv \
-        --out-dir ./out
+    python scripts/velocity_profile_from_h5.py
 """
 
 from __future__ import annotations
 
-import argparse
 import os
 
 import h5py
@@ -36,9 +29,40 @@ import numpy as np
 import pandas as pd
 from matplotlib.ticker import FuncFormatter
 
+# =============================================================================
+# CONFIG -- edit these values, then just run the file.
+# =============================================================================
 
-def _parse_time(key: str) -> float:
-    return float(key.lstrip("t"))
+# Input line-probe H5 file.
+H5_PATH = r"/home/waine/Downloads/line.line_line_roof.h5"
+
+# Velocity component to average ("ux", "uy" or "uz").
+COMPONENT = "ux"
+
+# Reference velocity used to normalise the mean profile.
+U_INFINITY = 3.5
+
+# Length B used to normalise the height z.
+HEIGHT_SCALE = 40.0
+
+# Where to write the outputs (figure + modified experimental CSV).
+OUT_DIR = r"/home/waine/Downloads/h5_postpro_out"
+
+# Optional experimental profile CSV to overlay. Set to None to skip the
+# overlay and plot only the simulation curve.
+EXPERIMENTAL_CSV = None
+# EXPERIMENTAL_CSV = r"/home/waine/Downloads/velocity_profile_at_x_position_roof_AR1.csv"
+
+# Experimental scaling (only used when EXPERIMENTAL_CSV is set), matching the
+# original script: divide U by EXP_DIV_X, divide Y by EXP_DIV_Y, and keep only
+# points with Y <= EXP_Y_MAX (after dropping the first point).
+EXP_DIV_X = 1.3
+EXP_DIV_Y = 1.2
+EXP_Y_MAX = 6.0
+
+# =============================================================================
+# End of CONFIG. You normally do not need to edit below this line.
+# =============================================================================
 
 
 def mean_component_profile(h5_path: str, component: str) -> tuple[np.ndarray, np.ndarray]:
@@ -145,68 +169,29 @@ def make_plot(
     print(f"[INFO] plot saved: {out_png}")
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--h5", required=True, help="path to the line-probe H5 file")
-    parser.add_argument(
-        "--component",
-        default="ux",
-        help="velocity component field to average (default: ux)",
-    )
-    parser.add_argument(
-        "--u-infinity",
-        type=float,
-        default=3.5,
-        help="reference velocity used to normalise the mean profile (default: 3.5)",
-    )
-    parser.add_argument(
-        "--height-scale",
-        type=float,
-        default=40.0,
-        help="length B used to normalise the height z (default: 40)",
-    )
-    parser.add_argument(
-        "--experimental",
-        default=None,
-        help="optional experimental profile CSV to overlay",
-    )
-    parser.add_argument("--exp-div-x", type=float, default=1.3, help="experimental U scale divisor")
-    parser.add_argument("--exp-div-y", type=float, default=1.2, help="experimental Y scale divisor")
-    parser.add_argument("--exp-y-max", type=float, default=6.0, help="max experimental Y kept")
-    parser.add_argument(
-        "--out-dir",
-        default=".",
-        help="directory to write outputs into (default: current dir)",
-    )
-    return parser
-
-
 def main() -> None:
-    args = build_parser().parse_args()
-    os.makedirs(args.out_dir, exist_ok=True)
+    os.makedirs(OUT_DIR, exist_ok=True)
 
-    base = os.path.basename(args.h5)
+    base = os.path.basename(H5_PATH)
     if base.lower().endswith(".h5"):
         base = base[:-3]
 
-    z, mean_u = mean_component_profile(args.h5, args.component)
+    z, mean_u = mean_component_profile(H5_PATH, COMPONENT)
     print(
-        f"[INFO] {args.component}: {z.shape[0]} points, "
-        f"mean range [{(mean_u / args.u_infinity).min():.3f}, "
-        f"{(mean_u / args.u_infinity).max():.3f}] (normalised)"
+        f"[INFO] {COMPONENT}: {z.shape[0]} points, "
+        f"mean range [{(mean_u / U_INFINITY).min():.3f}, "
+        f"{(mean_u / U_INFINITY).max():.3f}] (normalised)"
     )
 
     experimental = None
-    if args.experimental:
-        experimental = load_experimental(
-            args.experimental, args.exp_div_x, args.exp_div_y, args.exp_y_max
-        )
-        exp_out = os.path.join(args.out_dir, f"modified_experimental_{base}.csv")
+    if EXPERIMENTAL_CSV:
+        experimental = load_experimental(EXPERIMENTAL_CSV, EXP_DIV_X, EXP_DIV_Y, EXP_Y_MAX)
+        exp_out = os.path.join(OUT_DIR, f"modified_experimental_{base}.csv")
         experimental.to_csv(exp_out, index=False)
         print(f"[INFO] modified experimental data saved: {exp_out}")
 
-    out_png = os.path.join(args.out_dir, f"velocity_profile_comparison_{base}.png")
-    make_plot(z, mean_u, args.u_infinity, args.height_scale, experimental, out_png)
+    out_png = os.path.join(OUT_DIR, f"velocity_profile_comparison_{base}.png")
+    make_plot(z, mean_u, U_INFINITY, HEIGHT_SCALE, experimental, out_png)
 
 
 if __name__ == "__main__":

--- a/scripts/velocity_profile_from_h5.py
+++ b/scripts/velocity_profile_from_h5.py
@@ -1,0 +1,213 @@
+"""Velocity-profile comparison, migrated from CSV to H5 input.
+
+This is the H5-native version of the legacy "ExpAndSim_roof.py" post-processing
+tool. It does the same thing the old CSV script did:
+
+  1. read a line probe (point coordinates + a velocity component time series),
+  2. average the velocity component over all time steps at each point,
+  3. normalise the mean velocity by U_infinity and the height by B,
+  4. optionally overlay a scaled experimental velocity profile,
+  5. save the comparison figure (and the modified experimental CSV).
+
+The only change is the input: instead of reading
+
+    <line>.points.csv   and   <line>.ux.csv
+
+it reads the coordinates from the "Geometry" dataset and the velocity
+component from the matching field group ("ux") of a single line H5 file.
+
+Example (matches the original defaults: U_inf=3.5, B=40, ux)
+------------------------------------------------------------
+    python scripts/velocity_profile_from_h5.py \
+        --h5 "line.line_line_roof.h5" \
+        --u-infinity 3.5 --height-scale 40 \
+        --experimental velocity_profile_at_x_position_roof_AR1.csv \
+        --out-dir ./out
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import h5py
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from matplotlib.ticker import FuncFormatter
+
+
+def _parse_time(key: str) -> float:
+    return float(key.lstrip("t"))
+
+
+def mean_component_profile(h5_path: str, component: str) -> tuple[np.ndarray, np.ndarray]:
+    """Return (z, time-mean component) along the line probe.
+
+    The mean is accumulated one time step at a time so the full time series
+    never has to sit in memory at once (a line H5 can hold thousands of
+    steps). This reproduces pandas' ``ux.mean(axis=0)`` from the old script.
+    """
+    with h5py.File(h5_path, "r") as h5:
+        if "Geometry" not in h5:
+            raise KeyError(f"{h5_path}: no 'Geometry' dataset found")
+        if component not in h5:
+            raise KeyError(f"{h5_path}: no '{component}' field group found")
+
+        z = h5["Geometry"][:, 2].astype(np.float64)
+
+        group = h5[component]
+        time_keys = list(group.keys())
+        if not time_keys:
+            raise ValueError(f"{h5_path}: field '{component}' has no time steps")
+
+        accum = np.zeros(z.shape[0], dtype=np.float64)
+        for key in time_keys:
+            accum += group[key][:]
+        mean_values = accum / len(time_keys)
+
+    return z, mean_values
+
+
+def load_experimental(path: str, div_x: float, div_y: float, y_max: float) -> pd.DataFrame:
+    """Load and scale the experimental profile, matching the old script.
+
+    Steps preserved from the original: drop the first point, keep only
+    y <= ``y_max``, then divide U by ``div_x`` and Y by ``div_y``.
+    """
+    data = pd.read_csv(path)
+    y = data["Y (normalized)"]
+    u = data["U_normalized"]
+
+    # Drop the first point (original behaviour).
+    y = y[1:]
+    u = u[1:]
+
+    # Keep the near-ground portion of the profile.
+    valid = y <= y_max
+    y = y[valid]
+    u = u[valid]
+
+    # Apply the profile scaling factors.
+    y = y / div_y
+    u = u / div_x
+
+    return pd.DataFrame({"Y (normalized)": y, "U_normalized": u})
+
+
+def make_plot(
+    z: np.ndarray,
+    mean_u: np.ndarray,
+    u_infinity: float,
+    height_scale: float,
+    experimental: pd.DataFrame | None,
+    out_png: str,
+) -> None:
+    mean_u_norm = mean_u / u_infinity
+    z_norm = z / height_scale
+
+    # Sort by height so the simulated line plots cleanly.
+    order = np.argsort(z_norm)
+    z_norm = z_norm[order]
+    mean_u_norm = mean_u_norm[order]
+
+    fig, ax = plt.subplots(figsize=(5, 6))
+
+    if experimental is not None:
+        ax.plot(
+            experimental["U_normalized"],
+            experimental["Y (normalized)"],
+            label="Experimental Data (U)",
+            color="r",
+            marker="o",
+        )
+
+    ax.plot(
+        mean_u_norm,
+        z_norm,
+        label="Simulation Data (U)",
+        color="b",
+        linestyle="--",
+    )
+
+    ax.set_title("Comparison of Experimental and Simulation Velocity Profiles", fontsize=14)
+    ax.set_xlabel(r"$\overline{u_x} / U_\infty$", fontsize=16)
+    ax.set_ylabel(f"Normalized Y (z / {height_scale:g})", fontsize=16)
+    ax.legend(loc="upper right", fontsize=12)
+    ax.grid(True)
+
+    ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: f"{v:.1f}"))
+    ax.set_xticks(np.linspace(mean_u_norm.min(), mean_u_norm.max(), 5))
+
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=300)
+    plt.close(fig)
+    print(f"[INFO] plot saved: {out_png}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--h5", required=True, help="path to the line-probe H5 file")
+    parser.add_argument(
+        "--component",
+        default="ux",
+        help="velocity component field to average (default: ux)",
+    )
+    parser.add_argument(
+        "--u-infinity",
+        type=float,
+        default=3.5,
+        help="reference velocity used to normalise the mean profile (default: 3.5)",
+    )
+    parser.add_argument(
+        "--height-scale",
+        type=float,
+        default=40.0,
+        help="length B used to normalise the height z (default: 40)",
+    )
+    parser.add_argument(
+        "--experimental",
+        default=None,
+        help="optional experimental profile CSV to overlay",
+    )
+    parser.add_argument("--exp-div-x", type=float, default=1.3, help="experimental U scale divisor")
+    parser.add_argument("--exp-div-y", type=float, default=1.2, help="experimental Y scale divisor")
+    parser.add_argument("--exp-y-max", type=float, default=6.0, help="max experimental Y kept")
+    parser.add_argument(
+        "--out-dir",
+        default=".",
+        help="directory to write outputs into (default: current dir)",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    base = os.path.basename(args.h5)
+    if base.lower().endswith(".h5"):
+        base = base[:-3]
+
+    z, mean_u = mean_component_profile(args.h5, args.component)
+    print(
+        f"[INFO] {args.component}: {z.shape[0]} points, "
+        f"mean range [{(mean_u / args.u_infinity).min():.3f}, "
+        f"{(mean_u / args.u_infinity).max():.3f}] (normalised)"
+    )
+
+    experimental = None
+    if args.experimental:
+        experimental = load_experimental(
+            args.experimental, args.exp_div_x, args.exp_div_y, args.exp_y_max
+        )
+        exp_out = os.path.join(args.out_dir, f"modified_experimental_{base}.csv")
+        experimental.to_csv(exp_out, index=False)
+        print(f"[INFO] modified experimental data saved: {exp_out}")
+
+    out_png = os.path.join(args.out_dir, f"velocity_profile_comparison_{base}.png")
+    make_plot(z, mean_u, args.u_infinity, args.height_scale, experimental, out_png)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The solver now emits line probes as a single H5 file (`Geometry` + `ux`/`uy`/`uz`/`pressure` time-step groups) instead of the old per-field CSVs. This adds two scripts under `scripts/` to keep the existing line-probe post-processing working against H5 input.

### `scripts/h5_line_to_csv.py`
Converts a line-probe H5 back into the legacy CSV layout so any existing CSV-based tool keeps working unchanged:
- `<line>.points.csv` -> `idx,x,y,z`
- `<line>.ux.csv` (and `uy`/`uz`/`pressure`) -> `time_step,0,1,...,N-1` (one row per time step, one column per point)

Streams one time step at a time (files hold thousands of steps) and skips fields absent from a given H5 with a warning.

### `scripts/velocity_profile_from_h5.py`
H5-native port of the legacy `ExpAndSim_roof` velocity-profile comparison. Reads coordinates from `Geometry` and the velocity component from its field group, time-averages the component per point, normalises velocity by `U_infinity` and height by `B`, optionally overlays a scaled experimental profile, and saves the comparison figure plus the modified experimental CSV. Defaults match the original (`U_inf=3.5`, `B=40`, `ux`).

## Verification

Run against the roof and line10 line fixtures:
- Post-processing produced the expected boundary-layer profile (0 at the wall, growing with height).
- H5-direct time-mean matches the CSV round-trip time-mean exactly (max abs diff `0.0`, `allclose` True).
- Missing-field handling (line10 has no `pressure`) skips with a warning, no crash.
- `ruff check` passes on both scripts.

Generated data artifacts are written to a user-specified output directory and are intentionally not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)