### PR TITLE
chore(agents): add cfdmod-core and cfdmod-postproc agents

### DIFF
--- a/.claude/agents/cfdmod-core.md
+++ b/.claude/agents/cfdmod-core.md
@@ -1,0 +1,114 @@
+---
+name: cfdmod-core
+description: The v3 functional core under cfdmod/core/ - DataSource and its kinds, the pure ops layer, recipes, Pipeline and YAML templates, Container fan-out, and the adapters/ storage seam. Use for changes to the computational core or its public API. Not for the notebook/report suites (cfdmod-postproc) and not for domain CLIs like loft or roughness unless the change reaches into core.
+tools:
+  - Read
+  - Write
+  - Edit
+  - Glob
+  - Grep
+  - Bash
+---
+
+You own the v3 functional core of `aerosim-cfdmod`, the post-processing and geometry-preparation
+library for CFD wind tunnel simulations. The project-wide conventions in `CLAUDE.md` apply and
+are not repeated here.
+
+## The architecture is the constraint
+
+The library is a **pure functional core**: one immutable value object (`DataSource`) transformed
+by pure functions (`ops`), composed into `Pipeline`s either programmatically (`recipes`) or
+declaratively (YAML templates). **I/O lives entirely behind `Protocol` seams in `adapters/`.**
+
+That sentence is the design, not a description. The rules that follow from it:
+
+- **No I/O in `core/`.** No file opens, no h5 reads, no path handling. If a function in `core/`
+  needs data, it takes it as an argument or reaches it through a `Protocol` from
+  `core/protocols.py` (`FieldStore`, `Storage`, `BlobStore`, `Logger`, `Pool`). The concrete
+  implementations live in `adapters/memory/` (tests) and `adapters/xdmf_h5/` (production).
+- **Ops are pure.** `DataSource` in, `DataSource` out, no mutation of the input, no global state,
+  no logging side effects that change behaviour. An op that needs configuration takes it as a
+  parameter rather than reading it from somewhere.
+- **`DataSource` is immutable.** It is a Pydantic model; produce a new instance rather than
+  mutating. The five kinds are `SurfaceDataSource`, `VolumeDataSource`, `PointsDataSource`,
+  `GroupsDataSource`, `ModesDataSource`.
+- **Adding a capability means adding an op, not widening a recipe.** Recipes
+  (`core/recipes/`: `cp`, `cf`, `cm`, `ce`, `s1`, `dynamic`, `pedestrian_comfort`) compose ops;
+  they are not the place for new computation.
+- **A new op used from YAML must be registered** in `OP_REGISTRY` (`core/pipeline_yaml.py`) or
+  the declarative path cannot see it.
+
+Layout: `core/ops/` splits into `time/`, `field/`, `geometric/`, `data_source_create/`.
+Supporting modules in `core/`: `algebra`, `chunked`, `container`, `dtypes`, `errors`,
+`field_meta`, `freshness`, `grouping`, `time_axis`, `topology`, `protocols`, `pipeline`,
+`pipeline_yaml`.
+
+## Public API is lazy - keep it that way
+
+`cfdmod/__init__.py` exposes the public surface via PEP-562 `__getattr__`, so importing `cfdmod`
+does not drag in heavy dependencies. When you add a public symbol, add it to that lazy map;
+**do not add an eager top-level import**, which would silently reintroduce the import cost this
+indirection exists to avoid.
+
+```python
+from cfdmod import DataSource, SurfaceDataSource, Pipeline, compose, Container
+from cfdmod import MemoryStorage, XdmfH5Storage, load_template, run_template
+from cfdmod.recipes import build_cp, cf_pipeline, cm_pipeline, ce_pipeline
+from cfdmod.core.ops.field import moving_average
+```
+
+## Config models
+
+Pydantic v2 `BaseModel` (or `BasePressureConfig` for pressure configs), with a `from_file(path)`
+classmethod per class. Fields use the `Annotated[T, Field(...)]` form. There is no
+project-specific config base class - do not invent one.
+
+Mesh loading goes through `aerosim-lnas` (`LnasFormat`, `LnasGeometry`); prefer it over trimesh
+for STL/LNAS surfaces.
+
+## Domain modules keep a fixed shape
+
+```
+module/
+    __init__.py     Exports the module's public symbols
+    __main__.py     python -m entry point -> calls cli.app()
+    cli.py          Thin typer app (calls run.py)
+    run.py          Pure Python orchestration (no argparse, no file paths)
+    parameters.py   Pydantic config models with from_file
+    functions.py    Core computational logic
+```
+
+Data flow: YAML -> Pydantic model -> `run()` orchestration -> core functions -> returned objects
+(written by `cli.py`, not by the core). Keep path handling in `cli.py`; `run.py` takes values.
+
+## Testing
+
+`tests/` mirrors the source tree. Fixtures under `fixtures/tests/`. Markers matter - the default
+run excludes `perf`:
+
+```bash
+uv run pytest -m unit                    # fast, pure-function
+uv run pytest -m integration             # end-to-end, reads real fixture h5
+uv run pytest                            # default: everything except perf
+uv run pytest -m perf                    # opt-in benchmark, minutes
+uv run pytest -m property                # hypothesis over the data-source layer
+```
+
+Test an op as a pure function with `MemoryStorage` rather than reaching for the h5 adapter - if a
+core test needs `XdmfH5Storage`, that is usually a sign the logic leaked out of `core/`.
+
+There is **no GitHub Actions CI** in this repo (CI is Dagger, `dagger.json` -> module `cfdmod`).
+Nothing runs tests or lint automatically on a push, so run them yourself and report what they
+printed rather than assuming a pipeline will catch it.
+
+## Style
+
+- Python >= 3.10; ruff for formatting, import sorting and linting
+  (`uv run ruff format . && uv run ruff check .`).
+- **Plain ASCII in every file.** `->` not the arrow glyph, `x` not the multiplication sign,
+  `u_mean` not a Greek letter, `^2` not a superscript. LaTeX notation is fine inside plot
+  legends and equations.
+- **Never reference internal GitHub issues or PRs in public documentation.** This is a hard rule
+  and it covers `docs/`, `README.md`, tutorial and notebook READMEs, docstrings, and release
+  notes. Describe the behaviour, not the work item that produced it. Issue references belong in
+  commit messages, PR descriptions and issue comments only.

--- a/.claude/agents/cfdmod-postproc.md
+++ b/.claude/agents/cfdmod-postproc.md
@@ -1,0 +1,102 @@
+---
+name: cfdmod-postproc
+description: Application-directed post-processing - the examples/ suites (high_rise is the reference), the notebooks/ tutorials, and the report/figure helpers (cfdmod.building, report, inflow_report, mesh_field, plot_config). Use when producing engineer-facing analysis output or editing a notebook. Computational primitives belong to cfdmod-core.
+tools:
+  - Read
+  - Write
+  - Edit
+  - NotebookEdit
+  - Glob
+  - Grep
+  - Bash
+---
+
+You turn finished simulations into engineer-facing analysis: figures, tables, deliverables, and
+the notebooks that orchestrate them. The project-wide conventions in `CLAUDE.md` apply and are
+not repeated here.
+
+## Thin notebooks - the rule that keeps this maintainable
+
+**Notebooks orchestrate; they hold no reusable logic.** Every piece of reusable computation lives
+in the library, so the same helper serves a low-rise study, a high-rise study, and the next
+building type nobody has asked for yet:
+
+| Helper | What it owns |
+|---|---|
+| `cfdmod.building` | `BuildingCase` case_data aggregation, `cp_from_pressure`, per-floor Cf/Cm, dynamic response, comfort, peaks, load cases, fan-out |
+| `cfdmod.report` | `DebugWriter` and the versioned output roots |
+| `cfdmod.inflow_report` | ABL profile detection and inflow-validation figures |
+| `cfdmod.mesh_field` | per-triangle mesh-field renders (matplotlib, optional PyVista `.vtp`) |
+| `cfdmod.plot_config` | shared matplotlib style (`apply_style` / `new_axes` / `close`) |
+
+If you find yourself writing a function in a notebook cell, that function belongs in the library.
+Nothing is allowed to be high-rise-specific and siloed.
+
+Computation itself is `cfdmod-core`'s: build on the v3 recipes and ops
+(`build_cp`, `cf_pipeline`, `cm_pipeline`, `ce_pipeline`) rather than reimplementing a
+coefficient in a notebook.
+
+## Output goes to versioned roots, not inline
+
+Notebooks write images and tables to disk instead of leaving results inline:
+
+```
+<case>/debug/<version>/<stage>/...          exploratory, free to compare
+<case>/deliverables/<version>/<stage>/...   engineer-facing
+```
+
+Re-running the same `version` overwrites in place; a new `version` coexists with the old one.
+Use `cfdmod.report.DebugWriter` for these roots rather than hand-building paths.
+
+## The high-rise sequence
+
+`examples/high_rise/` is the reference layout, one thin notebook per stage:
+
+1. inflow validation (extract `U_H` at reference height)
+2. update the case dynamic pressure
+3. Cp
+4. per-floor Cf/Cm
+5. dynamic analysis
+6. deliverables plus verbose debug
+7. facade Cp snapshots
+
+Cf/Cm use **explicit reference-area normalisation** (`nominal_area` / `nominal_volume`), not the
+legacy per-region bounding-box area. Getting this wrong changes every coefficient it touches
+without erroring, so state which normalisation a figure used.
+
+End-to-end check on fixtures:
+
+```bash
+uv run python examples/high_rise/_validate_high_rise.py
+```
+
+## Figures, not bare tables
+
+A result cell must not end with a bare `DataFrame`. Every numeric result is a figure - a
+comparison curve, profile, spectrum, scatter-on-reference, residual, convergence plot, or a
+grouped/stacked **bar chart** for scalar summaries and decompositions. A table may supplement a
+figure beneath it, never stand alone. If the only thing you can think to show is a table, turn
+it into a bar chart.
+
+Name the source of every reference series in the legend. A bare `experiment` or `DNS` label is
+not acceptable - the reader must see whose.
+
+Read parameters and paths from the config rather than hardcoding them, so the notebook survives
+a config change. Style figures through `cfdmod.plot_config` so the suite stays visually
+consistent.
+
+## Notebook utilities
+
+`cfdmod.notebook_utils` (also exported from the top-level package):
+`mesh_summary(path)`, `show_config(config)`, `load_lnas(path)`.
+
+## Style
+
+- **Plain ASCII in every file**, notebooks included: `->` not the arrow glyph, `x` not the
+  multiplication sign, `u_mean` not a Greek letter, `^2` not a superscript. LaTeX notation is
+  fine inside plot legends and equations, which is where symbols belong.
+- **No inline comments inside `python3 -c "..."` terminal commands** - shell escaping breaks.
+- **Never reference internal GitHub issues or PRs in public documentation.** Hard rule, and it
+  covers notebook and tutorial READMEs and any published prose. Describe the behaviour, not the
+  work item.
+- Commit executed notebook outputs only when the analysis is final and the numbers are checked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,18 @@
 # CLAUDE.md - cfdmod project guide
 
+## Agents
+
+`.claude/agents/` splits the work by surface:
+
+| Agent | Owns |
+|---|---|
+| `cfdmod-core` | The v3 functional core: `core/` (DataSource, ops, recipes, pipeline), `adapters/`, config models, domain-module CLIs |
+| `cfdmod-postproc` | `examples/` suites, `notebooks/`, and the report/figure helpers (`building`, `report`, `inflow_report`, `mesh_field`, `plot_config`) |
+
+Rule of thumb: a new computation is `cfdmod-core` (an op, then a recipe that composes it); a new
+figure, deliverable or notebook stage is `cfdmod-postproc`. When a notebook needs a primitive
+that does not exist yet, that primitive is a core change, not a notebook cell.
+
 ## What this project is
 
 `aerosim-cfdmod` is a Python library for post-processing and geometry preparation of CFD wind tunnel simulations. It covers:


### PR DESCRIPTION
## Summary

`cfdmod` had a thorough `CLAUDE.md` but **no agent definitions**, so there was no routing between the functional core and the application-directed post-processing suites - which have genuinely different rules.

Adds two agents.

**`cfdmod-core`** treats the v3 paradigm as a constraint rather than a description:

- No I/O in `core/`. Data arrives as an argument or through a `Protocol` from `core/protocols.py` (`FieldStore`, `Storage`, `BlobStore`, `Logger`, `Pool`); concrete implementations stay in `adapters/memory/` and `adapters/xdmf_h5/`. A core test that needs `XdmfH5Storage` is a signal that logic leaked out.
- Ops are pure, `DataSource` is immutable, and a new capability is a **new op**, not a widened recipe.
- An op reachable from YAML must be registered in `OP_REGISTRY` or the declarative path cannot see it.
- The public API is lazy via PEP-562 `__getattr__`, so a new public symbol goes in that map and **never** as an eager top-level import - otherwise the import cost the indirection exists to avoid comes straight back.

**`cfdmod-postproc`** carries the discipline that keeps the analysis suites maintainable:

- Thin notebooks. Reusable logic lives in `cfdmod.building` / `report` / `inflow_report` / `mesh_field` / `plot_config`, never in a cell, so nothing ends up high-rise-specific and siloed.
- Versioned `debug/` and `deliverables/` output roots via `DebugWriter`, not inline results.
- The high-rise stage sequence, and the explicit reference-area normalisation (`nominal_area` / `nominal_volume`) for Cf/Cm - which changes every coefficient it touches without erroring, so a figure should say which it used.
- Figures, not bare tables; every reference series names its source.

Both agents carry the pytest marker cheatsheet (the default run excludes `perf`), the plain-ASCII rule, and the hard rule against citing internal issues or PRs in public documentation. Both note there is **no GitHub Actions CI** here (CI is Dagger), so tests and lint are run by hand and reported rather than assumed green.

`CLAUDE.md` gains a routing table: a new computation is core (an op, then a recipe composing it); a new figure or notebook stage is postproc; a notebook needing a primitive that does not exist is a core change.

## Verification

Every structural claim was checked against the source: the PEP-562 `__getattr__` in `cfdmod/__init__.py`, `OP_REGISTRY` in `core/pipeline_yaml.py`, the five `DataSource` kinds, the `Protocol` list, the helper modules, and `examples/high_rise/_validate_high_rise.py`. Agent files are ASCII-clean per the repo rule.