### PR TITLE
release: v3.6.0

### DIFF
--- a/cfdmod/dynamics/__init__.py
+++ b/cfdmod/dynamics/__init__.py
@@ -37,6 +37,13 @@ __all__ = [
     "EberickUnits",
     "aggregate_to_building",
     "NodalModel",
+    "STROUHAL_RECTANGULAR",
+    "STROUHAL_PHYSICAL_RANGE",
+    "SheddingCheck",
+    "vortex_shedding_frequency",
+    "implied_strouhal",
+    "spectral_peak",
+    "check_vortex_shedding",
 ]
 
 from cfdmod.dynamics.cases import (
@@ -67,6 +74,15 @@ from cfdmod.dynamics.imports import (
     read_eberick,
     read_tqs_portels,
     read_tqs_portico,
+)
+from cfdmod.dynamics.shedding import (
+    STROUHAL_PHYSICAL_RANGE,
+    STROUHAL_RECTANGULAR,
+    SheddingCheck,
+    check_vortex_shedding,
+    implied_strouhal,
+    spectral_peak,
+    vortex_shedding_frequency,
 )
 from cfdmod.dynamics.structural import (
     BuildingStructuralData,

--- a/cfdmod/dynamics/plotting.py
+++ b/cfdmod/dynamics/plotting.py
@@ -69,6 +69,7 @@ def plot_force_spectrum(
     fields: tuple[str, str, str] = ("cf_x", "cf_y", "cm_z"),
     plot_mz: bool = True,
     sigma: float = 2,
+    shedding_hz: float | None = None,
     ax=None,
 ):
     """Reduced power spectral density of the global (floor-summed) load.
@@ -79,6 +80,10 @@ def plot_force_spectrum(
         natural_frequencies_hz: Modal natural frequencies (Hz) drawn as
             vertical markers.
         fields: The three load fields, in ``(FX, FY, MZ)`` order.
+        shedding_hz: Expected vortex-shedding frequency (Hz), drawn as a dashed
+            marker. The across-wind peak should sit on it; when it does not, the
+            time axis is the first thing to doubt. See
+            :func:`cfdmod.dynamics.vortex_shedding_frequency`.
     """
     dt = float(load_source.time.timestep_size)
     if ax is None:
@@ -98,6 +103,15 @@ def plot_force_spectrum(
 
     for f in np.atleast_1d(np.asarray(natural_frequencies_hz, dtype=np.float64)):
         ax.loglog([f, f], [1e-5, 1e1], color="orange", alpha=0.2)
+
+    if shedding_hz is not None:
+        ax.axvline(
+            shedding_hz,
+            color="#2F993A",
+            linestyle="--",
+            linewidth=1.5,
+            label=f"$f_s$ = {shedding_hz:.3f} Hz",
+        )
 
     ax.set_ylim(1e-4, 1e1)
     ax.set_xlim(1e-3, 3)

--- a/cfdmod/dynamics/shedding.py
+++ b/cfdmod/dynamics/shedding.py
@@ -1,0 +1,199 @@
+"""Vortex-shedding cross-check on a building's across-wind load record.
+
+A dimensional sanity check that needs no configuration file to agree with: a
+bluff prismatic body sheds at a Strouhal number that is a property of its
+cross-section, roughly ``0.06 - 0.15`` for rectangular plans. So the dominant
+peak of the across-wind load spectrum has a *predictable* frequency::
+
+    f_shedding = St * U_H / D
+
+with ``D`` the across-wind face width. Turn that around and the spectrum
+implies a Strouhal number:
+
+    St_implied = f_peak * D / U_H
+
+If ``St_implied`` lands outside the physical band, the load record is not
+telling the truth about time -- and the usual cause is a mis-scaled time axis,
+which nothing else downstream can detect because every array shape, unit and
+range stays plausible (see :class:`cfdmod.dynamics.DimensionalData`). This
+caught a real deliverable whose record had been compressed 3.8x: its across-wind
+peak implied ``St = 0.38``.
+
+The check is cheap and independent of the case config, so run it on every
+dynamic stage before trusting the response.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "STROUHAL_RECTANGULAR",
+    "STROUHAL_PHYSICAL_RANGE",
+    "SheddingCheck",
+    "vortex_shedding_frequency",
+    "implied_strouhal",
+    "spectral_peak",
+    "check_vortex_shedding",
+]
+
+import numpy as np
+import scipy.signal
+from pydantic import BaseModel, ConfigDict
+from scipy.ndimage import gaussian_filter
+
+from cfdmod.core.data_source import DataSource
+
+# Nominal Strouhal number for a rectangular tall-building plan. Published values
+# for rectangular prisms in turbulent boundary-layer flow sit around 0.06-0.15
+# depending on side ratio and turbulence; 0.10 is the usual first estimate.
+STROUHAL_RECTANGULAR = 0.10
+
+# Outside this band a bluff rectangular section is not what produced the peak.
+STROUHAL_PHYSICAL_RANGE = (0.05, 0.25)
+
+
+class SheddingCheck(BaseModel):
+    """Outcome of :func:`check_vortex_shedding`.
+
+    Attributes:
+        expected_hz: ``strouhal * u_h / width``.
+        observed_hz: Frequency of the dominant peak of the reduced across-wind
+            load spectrum ``f * S(f)``.
+        implied_strouhal: ``observed_hz * width / u_h`` -- the dimensionless
+            number the record actually implies.
+        frequency_ratio: ``observed_hz / expected_hz``.
+        passed: Whether ``implied_strouhal`` is inside ``physical_range``.
+        physical_range: The band tested against.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    expected_hz: float
+    observed_hz: float
+    implied_strouhal: float
+    frequency_ratio: float
+    passed: bool
+    physical_range: tuple[float, float]
+
+    def summary(self) -> str:
+        verdict = "OK" if self.passed else "OUT OF RANGE"
+        return (
+            f"vortex shedding: expected {self.expected_hz:.4f} Hz, observed "
+            f"{self.observed_hz:.4f} Hz ({self.frequency_ratio:.2f}x) -> implied "
+            f"St = {self.implied_strouhal:.3f} [{verdict}; physical band "
+            f"{self.physical_range[0]:g}-{self.physical_range[1]:g}]"
+        )
+
+    def raise_if_failed(self) -> "SheddingCheck":
+        """Turn the check into an assertion, for a notebook that must not proceed."""
+        if not self.passed:
+            raise ValueError(
+                self.summary() + ". A record whose implied Strouhal number is not "
+                "physical usually has a mis-scaled time axis; check the "
+                "characteristic length the time axis was de-normalised with."
+            )
+        return self
+
+
+def vortex_shedding_frequency(
+    u_h: float, across_wind_width: float, *, strouhal: float = STROUHAL_RECTANGULAR
+) -> float:
+    """``St * U_H / D`` [Hz].
+
+    Args:
+        u_h: Reference wind speed at building height [m/s].
+        across_wind_width: Width of the face normal to the wind [m] -- the
+            dimension the wake spans, not necessarily the plan ``base``.
+        strouhal: Strouhal number; defaults to the rectangular-plan estimate.
+    """
+    if u_h <= 0 or across_wind_width <= 0:
+        raise ValueError(
+            f"u_h and across_wind_width must be positive; got {u_h!r}, {across_wind_width!r}"
+        )
+    return float(strouhal) * float(u_h) / float(across_wind_width)
+
+
+def implied_strouhal(peak_hz: float, u_h: float, across_wind_width: float) -> float:
+    """``f_peak * D / U_H`` -- the Strouhal number a measured peak implies."""
+    if u_h <= 0:
+        raise ValueError(f"u_h must be positive; got {u_h!r}")
+    return float(peak_hz) * float(across_wind_width) / float(u_h)
+
+
+def _reduced_spectrum(
+    series: np.ndarray, dt: float, sigma: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """``(freq, f * S(f) / var)`` -- the reduced spectrum the deliverable plots."""
+    freq, psd = scipy.signal.periodogram(series, 1.0 / dt, scaling="density")
+    var = float(np.var(series))
+    if var <= 0:
+        raise ValueError("load series has zero variance; nothing to find a peak in")
+    return freq, gaussian_filter(psd * freq / var, sigma=sigma)
+
+
+def spectral_peak(
+    load_source: DataSource,
+    *,
+    field: str = "cf_y",
+    band: tuple[float, float] | None = None,
+    sigma: float = 2.0,
+    min_cycles: float = 5.0,
+) -> float:
+    """Frequency [Hz] of the dominant peak of the reduced global-load spectrum.
+
+    The load is summed over floors first (the global across-wind force is what
+    sheds), then reduced to ``f * S(f)``, whose maximum is the shedding peak for
+    a bluff body.
+
+    ``band`` restricts the search; by default it spans everything the record can
+    actually resolve -- from ``min_cycles`` cycles over the record length up to
+    Nyquist. Leaving it open is deliberate: narrowing the search around the
+    expected frequency would let the check confirm itself.
+    """
+    arr = np.asarray(load_source.fields.read(field), dtype=np.float64)
+    series = arr.sum(axis=0) if arr.ndim == 2 else arr
+    dt = float(load_source.time.timestep_size)
+    freq, reduced = _reduced_spectrum(series, dt, sigma)
+
+    lo, hi = band if band is not None else (min_cycles / (len(series) * dt), 0.5 / dt)
+    mask = (freq >= lo) & (freq <= hi)
+    if not mask.any():
+        raise ValueError(f"no spectral bins inside band {lo:g}-{hi:g} Hz")
+    return float(freq[mask][np.argmax(reduced[mask])])
+
+
+def check_vortex_shedding(
+    load_source: DataSource,
+    *,
+    u_h: float,
+    across_wind_width: float,
+    field: str = "cf_y",
+    strouhal: float = STROUHAL_RECTANGULAR,
+    physical_range: tuple[float, float] = STROUHAL_PHYSICAL_RANGE,
+    band: tuple[float, float] | None = None,
+    sigma: float = 2.0,
+) -> SheddingCheck:
+    """Cross-check a load record's time axis against vortex-shedding physics.
+
+    Args:
+        load_source: Floor-load source with a **physical** time axis (seconds).
+        u_h: Reference wind speed the loads are referenced at [m/s].
+        across_wind_width: Width of the face normal to this wind direction [m].
+        field: Across-wind load field. ``"cf_y"`` for wind along x.
+        strouhal / physical_range: The nominal value and the acceptance band.
+        band / sigma: Passed to :func:`spectral_peak`.
+
+    Returns:
+        A :class:`SheddingCheck`. Call ``.summary()`` to report it or
+        ``.raise_if_failed()`` to stop a notebook that must not continue.
+    """
+    expected = vortex_shedding_frequency(u_h, across_wind_width, strouhal=strouhal)
+    observed = spectral_peak(load_source, field=field, band=band, sigma=sigma)
+    st = implied_strouhal(observed, u_h, across_wind_width)
+    return SheddingCheck(
+        expected_hz=expected,
+        observed_hz=observed,
+        implied_strouhal=st,
+        frequency_ratio=observed / expected,
+        passed=bool(physical_range[0] <= st <= physical_range[1]),
+        physical_range=physical_range,
+    )

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -1,5 +1,33 @@
 # Release Notes
 
+## 3.6.0
+
+Adds the vortex-shedding cross-check on a dynamic load record. Additive: no
+public symbol is removed or changed in signature.
+
+### Vortex-shedding check (`cfdmod.dynamics.check_vortex_shedding`)
+
+- A bluff prismatic body sheds at a Strouhal number that is a property of its
+  cross-section, so the dominant peak of the across-wind load spectrum has a
+  predictable frequency, `f = St * U_H / D`. Inverted, a load record *implies* a
+  Strouhal number, and one outside the physical band (roughly 0.05-0.25 for
+  rectangular plans) means the record is not telling the truth about time.
+- This is the one statement about a dynamic record that does not depend on the
+  case configuration agreeing with itself, which is what makes it useful: a
+  mis-scaled time axis leaves every shape, unit and range plausible and is
+  otherwise undetectable downstream. On a real deliverable whose record had been
+  compressed 3.8x, the across-wind peak implied `St = 0.38`.
+- `check_vortex_shedding()` returns a `SheddingCheck` with the expected and
+  observed frequencies, the implied Strouhal number and a verdict;
+  `.summary()` formats it for a report and `.raise_if_failed()` turns it into an
+  assertion. `vortex_shedding_frequency()`, `implied_strouhal()` and
+  `spectral_peak()` are exposed for use on their own.
+- The default peak search spans everything the record resolves rather than a
+  band around the prediction - a centred search would let the check confirm
+  itself.
+- `plot_force_spectrum()` gains `shedding_hz`, drawing the expected frequency
+  alongside the natural-frequency markers, so the figure carries the check.
+
 ## 3.5.0
 
 Correctness and performance work on the building dynamic-response path. The

--- a/docs/source/use_cases/building/index.md
+++ b/docs/source/use_cases/building/index.md
@@ -145,6 +145,13 @@ is solved as a **modal single-degree-of-freedom (SDOF) system** per mode
    the closed-form piecewise-linear (Nigam-Jennings) recurrence, exact for a
    load interpolated linearly between samples.
 
+   Before trusting the response, cross-check the load record against
+   vortex-shedding physics with
+   {func}`~cfdmod.dynamics.check_vortex_shedding`: the across-wind spectral peak
+   must imply a physical Strouhal number for the plan section. It is the only
+   check on the record that does not depend on the case configuration agreeing
+   with itself.
+
    The load must arrive on a **physical** time axis. The pressure stage writes
    a dimensionless time normalised by its own characteristic length, and that
    same length -- not the base dimension used by the force normalisation --

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerosim-cfdmod"
-version = "3.5.0"
+version = "3.6.0"
 description = "Tools for analysis of CFD cases"
 authors = [
     { name = "Waine Oliveira Jr", email = "waine@aerosim.io" },

--- a/tests/dynamics/test_plotting.py
+++ b/tests/dynamics/test_plotting.py
@@ -259,3 +259,23 @@ def test_plot_global_stats_per_direction_reports_the_missing_frame():
     stats = {"forces_static_eq": _stats_df(), "moments_static_eq": _stats_df()}
     with pytest.raises(KeyError, match="forces_static"):
         plotting.plot_global_stats_per_direction({0.02: stats}, variable_types=["static", "hfpi"])
+
+
+def test_plot_force_spectrum_marks_the_shedding_frequency():
+    """The expected shedding line is what makes the spectrum figure a check."""
+    dt, n_t, n_floors = 0.07, 2048, 3
+    rng = np.random.default_rng(4)
+    pts = np.column_stack([np.zeros(n_floors), np.zeros(n_floors), np.linspace(10, 60, n_floors)])
+    fields = {k: rng.standard_normal((n_floors, n_t)) for k in ("cf_x", "cf_y", "cm_z")}
+    src = PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=dt, n_timesteps=n_t),
+        topology=Topology.points(pts),
+        elements=ElementMeta(position=pts),
+        fields=MemoryFieldStore(fields),
+    )
+
+    fig, ax = plotting.plot_force_spectrum(src, [0.21, 0.26], shedding_hz=0.076)
+
+    labels = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert any("0.076" in lab for lab in labels), labels
+    plt.close(fig)

--- a/tests/dynamics/test_shedding.py
+++ b/tests/dynamics/test_shedding.py
@@ -1,0 +1,150 @@
+"""The vortex-shedding cross-check on a load record's time axis.
+
+The check exists because a mis-scaled time axis is invisible to everything else:
+shapes, units and ranges all stay plausible. Strouhal similarity is the one
+statement about the record that does not depend on the case configuration, so it
+is what catches it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core import ElementMeta, PointsDataSource, TimeAxis, Topology
+from cfdmod.dynamics import (
+    STROUHAL_RECTANGULAR,
+    check_vortex_shedding,
+    implied_strouhal,
+    spectral_peak,
+    vortex_shedding_frequency,
+)
+
+N_FLOORS = 4
+
+# The real case this came from: 86 m tower, 36.9 m across-wind face, 27.86 m/s.
+U_H = 27.859
+WIDTH = 36.9
+
+
+def _load(series: np.ndarray, dt: float) -> PointsDataSource:
+    """Spread a global across-wind series over floors as a load source."""
+    per_floor = np.outer(np.linspace(0.5, 1.5, N_FLOORS), series)
+    per_floor /= N_FLOORS  # so the floor sum reproduces `series`
+    pts = np.column_stack(
+        [np.zeros(N_FLOORS), np.zeros(N_FLOORS), np.linspace(20.0, 80.0, N_FLOORS)]
+    )
+    fields = {"cf_x": per_floor * 0.3, "cf_y": per_floor, "cm_z": per_floor * 0.1}
+    return PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=dt, n_timesteps=series.size),
+        topology=Topology.points(pts),
+        elements=ElementMeta(position=pts),
+        fields=MemoryFieldStore(fields),
+    )
+
+
+def _shedding_like(f_peak: float, dt: float, n_t: int, seed: int = 0) -> np.ndarray:
+    """Narrow-band across-wind force: a tone at ``f_peak`` over broadband noise."""
+    rng = np.random.default_rng(seed)
+    t = np.arange(n_t) * dt
+    background = rng.standard_normal(n_t).cumsum() * 0.002
+    return np.sin(2 * np.pi * f_peak * t) + background
+
+
+@pytest.mark.unit
+def test_shedding_frequency_formula():
+    assert vortex_shedding_frequency(U_H, WIDTH) == pytest.approx(
+        STROUHAL_RECTANGULAR * U_H / WIDTH
+    )
+    assert vortex_shedding_frequency(30.0, 20.0, strouhal=0.15) == pytest.approx(0.225)
+
+
+@pytest.mark.unit
+def test_implied_strouhal_is_the_inverse():
+    f = vortex_shedding_frequency(U_H, WIDTH, strouhal=0.12)
+    assert implied_strouhal(f, U_H, WIDTH) == pytest.approx(0.12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad", [0.0, -1.0])
+def test_rejects_non_physical_inputs(bad):
+    with pytest.raises(ValueError):
+        vortex_shedding_frequency(bad, WIDTH)
+    with pytest.raises(ValueError):
+        vortex_shedding_frequency(U_H, bad)
+    with pytest.raises(ValueError):
+        implied_strouhal(0.1, bad, WIDTH)
+
+
+@pytest.mark.unit
+def test_spectral_peak_finds_the_planted_tone():
+    dt, n_t, f_peak = 0.07, 8000, 0.076
+    src = _load(_shedding_like(f_peak, dt, n_t), dt)
+    assert spectral_peak(src) == pytest.approx(f_peak, rel=0.1)
+
+
+@pytest.mark.unit
+def test_a_physically_scaled_record_passes():
+    """Peak where Strouhal says it should be -> implied St back at the nominal."""
+    dt, n_t = 0.0705, 7955  # the real record's physical dt and length
+    src = _load(_shedding_like(vortex_shedding_frequency(U_H, WIDTH), dt, n_t), dt)
+
+    result = check_vortex_shedding(src, u_h=U_H, across_wind_width=WIDTH)
+
+    assert result.passed, result.summary()
+    assert result.implied_strouhal == pytest.approx(STROUHAL_RECTANGULAR, rel=0.15)
+    assert result.frequency_ratio == pytest.approx(1.0, rel=0.15)
+    result.raise_if_failed()
+
+
+@pytest.mark.unit
+def test_a_time_compressed_record_is_caught():
+    """The real defect: the time axis de-normalised with the wrong length.
+
+    The record is identical; only ``dt`` is wrong, compressed by B/H = 0.264 as
+    it was on the issued deliverable. Every shape, unit and range still looks
+    fine - and the implied Strouhal number comes out at ~0.38, which no bluff
+    rectangular section produces.
+    """
+    dt_physical, n_t = 0.0705, 7955
+    compression = 22.7 / 85.83  # base / characteristic length
+    series = _shedding_like(vortex_shedding_frequency(U_H, WIDTH), dt_physical, n_t)
+
+    good = check_vortex_shedding(_load(series, dt_physical), u_h=U_H, across_wind_width=WIDTH)
+    bad = check_vortex_shedding(
+        _load(series, dt_physical * compression), u_h=U_H, across_wind_width=WIDTH
+    )
+
+    assert good.passed
+    assert not bad.passed, bad.summary()
+    assert bad.implied_strouhal / good.implied_strouhal == pytest.approx(1 / compression, rel=0.05)
+    assert bad.implied_strouhal > 0.3
+    with pytest.raises(ValueError, match="mis-scaled time axis"):
+        bad.raise_if_failed()
+
+
+@pytest.mark.unit
+def test_search_band_is_open_by_default_and_restrictable():
+    """The default search must not be centred on the expected value.
+
+    A band centred on the prediction would let the check confirm itself, so the
+    default spans everything the record resolves. Narrowing it is opt-in.
+    """
+    dt, n_t = 0.07, 8000
+    src = _load(_shedding_like(0.30, dt, n_t), dt)  # peak far from St*U/D = 0.0755
+
+    wide = check_vortex_shedding(src, u_h=U_H, across_wind_width=WIDTH)
+    assert not wide.passed
+    assert wide.observed_hz == pytest.approx(0.30, rel=0.1)
+
+    narrow = spectral_peak(src, band=(0.05, 0.12))
+    assert 0.05 <= narrow <= 0.12
+
+
+@pytest.mark.unit
+def test_zero_variance_series_is_rejected():
+    dt = 0.07
+    src = _load(np.ones(2000), dt)
+    with pytest.raises(ValueError, match="zero variance"):
+        spectral_peak(src)

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "aerosim-cfdmod"
-version = "3.5.0"
+version = "3.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aerosim-lnas" },


### PR DESCRIPTION
Adds the vortex-shedding cross-check on a dynamic load record.

## Why

A mis-scaled time axis leaves every array shape, unit and range plausible, so nothing downstream can detect it. What is needed is a check that does not depend on the case configuration agreeing with itself.

Strouhal similarity is that check. A bluff prismatic body sheds at a St that is a property of its cross-section, so the dominant peak of the across-wind load spectrum has a predictable frequency `f = St * U_H / D`. Inverted, a load record *implies* a Strouhal number, and one outside the physical band for rectangular plans (roughly 0.05-0.25) means the record is not telling the truth about time.

This is what diagnosed the compressed record behind the 3.5.0 fix: the across-wind peak implied `St = 0.38`, which no rectangular section produces.

## What

- `check_vortex_shedding()` -> `SheddingCheck` with expected and observed frequency, the implied Strouhal number, the ratio and a verdict. `.summary()` formats it for a report; `.raise_if_failed()` turns it into an assertion for a notebook that must not continue.
- `vortex_shedding_frequency()`, `implied_strouhal()` and `spectral_peak()` are exposed for use on their own.
- The default peak search spans everything the record resolves, not a window around the prediction - a centred search would let the check confirm itself. There is a test for that.
- `plot_force_spectrum()` gains `shedding_hz`, so the spectrum figure carries the check rather than merely illustrating it.

## Tests

`tests/dynamics/test_shedding.py`: the formula and its inverse, input validation, peak recovery from a planted tone, a physically-scaled record passing, the **time-compressed record being caught** (the real defect, reproduced at B/H = 0.264 with only `dt` changed), the open-by-default search band, and the zero-variance guard. Plus a plotting test that the shedding marker is drawn.

Full suite green (`tests/core`, `tests/building`, `tests/dynamics`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)