### PR TITLE
release: v3.7.0

### DIFF
--- a/cfdmod/dynamics/__init__.py
+++ b/cfdmod/dynamics/__init__.py
@@ -44,6 +44,11 @@ __all__ = [
     "implied_strouhal",
     "spectral_peak",
     "check_vortex_shedding",
+    "wind_unit_vector",
+    "across_wind_width",
+    "across_wind_series",
+    "strouhal_by_direction",
+    "plot_strouhal_by_direction",
 ]
 
 from cfdmod.dynamics.cases import (
@@ -79,8 +84,13 @@ from cfdmod.dynamics.shedding import (
     STROUHAL_PHYSICAL_RANGE,
     STROUHAL_RECTANGULAR,
     SheddingCheck,
+    across_wind_series,
+    across_wind_width,
     check_vortex_shedding,
     implied_strouhal,
+    plot_strouhal_by_direction,
+    strouhal_by_direction,
+    wind_unit_vector,
     spectral_peak,
     vortex_shedding_frequency,
 )

--- a/cfdmod/dynamics/shedding.py
+++ b/cfdmod/dynamics/shedding.py
@@ -33,6 +33,11 @@ __all__ = [
     "implied_strouhal",
     "spectral_peak",
     "check_vortex_shedding",
+    "wind_unit_vector",
+    "across_wind_width",
+    "across_wind_series",
+    "strouhal_by_direction",
+    "plot_strouhal_by_direction",
 ]
 
 import numpy as np
@@ -197,3 +202,174 @@ def check_vortex_shedding(
         passed=bool(physical_range[0] <= st <= physical_range[1]),
         physical_range=physical_range,
     )
+
+
+def wind_unit_vector(direction_deg: float) -> np.ndarray:
+    """Unit vector the wind blows *towards*, in the model frame.
+
+    ``0 deg`` blows along ``+x``, ``90 deg`` along ``+y`` -- the convention the
+    per-floor ``cf_x`` / ``cf_y`` fields are written in, verified on a real case
+    by watching the facade stagnation patch move face to face as the direction
+    rotates. Check it on any new case before trusting a directional sweep.
+    """
+    a = np.deg2rad(float(direction_deg))
+    return np.array([np.cos(a), np.sin(a)])
+
+
+def across_wind_width(footprint_xy, direction_deg: float) -> float:
+    """Frontal width [m] of a plan footprint for one wind direction.
+
+    The width the wake spans: the span of the footprint projected onto the axis
+    perpendicular to the wind. Exact for any plan shape, so it does not assume a
+    rectangle -- for a rectangle ``a`` x ``b`` it reduces to
+    ``a*|sin| + b*|cos|``.
+
+    Args:
+        footprint_xy: ``(n, 2)`` plan coordinates. Use the *tower* footprint; a
+            podium or skirt would inflate the width and deflate the Strouhal
+            number.
+        direction_deg: Wind direction, see :func:`wind_unit_vector`.
+    """
+    pts = np.asarray(footprint_xy, dtype=np.float64)
+    if pts.ndim != 2 or pts.shape[1] != 2:
+        raise ValueError(f"footprint_xy must be (n, 2); got {pts.shape}")
+    if pts.shape[0] == 0:
+        raise ValueError("footprint_xy is empty")
+    d = wind_unit_vector(direction_deg)
+    across = pts[:, 0] * -d[1] + pts[:, 1] * d[0]  # projection on the across-wind axis
+    return float(across.max() - across.min())
+
+
+def across_wind_series(
+    load_source: DataSource, direction_deg: float, *, field_x: str = "cf_x", field_y: str = "cf_y"
+) -> np.ndarray:
+    """Global across-wind force history for one direction [same units as input].
+
+    Rotates the model-frame floor loads into the wind frame and sums over
+    floors: ``F_across = -Fx*sin(theta) + Fy*cos(theta)``. This is the component
+    the wake drives, and the one whose spectrum carries the shedding peak; at an
+    oblique direction neither ``cf_x`` nor ``cf_y`` is it on its own.
+    """
+    d = wind_unit_vector(direction_deg)
+    fx = np.asarray(load_source.fields.read(field_x), dtype=np.float64)
+    fy = np.asarray(load_source.fields.read(field_y), dtype=np.float64)
+    total_x = fx.sum(axis=0) if fx.ndim == 2 else fx
+    total_y = fy.sum(axis=0) if fy.ndim == 2 else fy
+    return -total_x * d[1] + total_y * d[0]
+
+
+def strouhal_by_direction(
+    load_by_direction: dict[float, DataSource],
+    footprint_xy,
+    *,
+    u_h_by_direction: dict[float, float] | float,
+    strouhal: float = STROUHAL_RECTANGULAR,
+    physical_range: tuple[float, float] = STROUHAL_PHYSICAL_RANGE,
+    sigma: float = 2.0,
+    min_cycles: float = 5.0,
+):
+    """Sweep the vortex-shedding check over every wind direction.
+
+    One row per direction: the frontal width, the observed across-wind spectral
+    peak, the frequency Strouhal predicts, and the Strouhal number the record
+    implies. Read as a *case quality* indicator - the implied number should sit
+    in a tight band around the nominal across all directions. A flat offset
+    points at the time axis; scatter points at a short record or a plan whose
+    shedding is not well defined at oblique angles.
+
+    Args:
+        load_by_direction: ``{direction_deg: floor-load source}``, each on a
+            physical (seconds) time axis and carrying ``cf_x`` / ``cf_y``.
+        footprint_xy: ``(n, 2)`` tower plan coordinates.
+        u_h_by_direction: Reference speed per direction, or one speed for all.
+
+    Returns:
+        A ``pandas.DataFrame`` sorted by direction.
+    """
+    import pandas as pd
+
+    rows = []
+    for direction in sorted(load_by_direction):
+        source = load_by_direction[direction]
+        u_h = u_h_by_direction if np.isscalar(u_h_by_direction) else u_h_by_direction[direction]
+        width = across_wind_width(footprint_xy, direction)
+        series = across_wind_series(source, direction)
+        dt = float(source.time.timestep_size)
+        freq, reduced = _reduced_spectrum(series, dt, sigma)
+        mask = (freq >= min_cycles / (series.size * dt)) & (freq <= 0.5 / dt)
+        observed = float(freq[mask][np.argmax(reduced[mask])])
+        st = implied_strouhal(observed, u_h, width)
+        rows.append(
+            {
+                "direction_deg": float(direction),
+                "across_wind_width_m": round(width, 2),
+                "u_h_ms": round(float(u_h), 3),
+                "expected_hz": round(vortex_shedding_frequency(u_h, width, strouhal=strouhal), 4),
+                "observed_hz": round(observed, 4),
+                "implied_strouhal": round(st, 4),
+                "passed": bool(physical_range[0] <= st <= physical_range[1]),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def plot_strouhal_by_direction(
+    table,
+    *,
+    strouhal: float = STROUHAL_RECTANGULAR,
+    physical_range: tuple[float, float] = STROUHAL_PHYSICAL_RANGE,
+    language: str = "en",
+    ax=None,
+):
+    """Implied Strouhal number against wind direction, with the physical band.
+
+    The figure is the case-quality read: points inside the shaded band and near
+    the nominal line mean the load record is dimensionally consistent for that
+    direction. A whole curve displaced from the band is the signature of a
+    mis-scaled time axis.
+    """
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FuncFormatter
+
+    if ax is None:
+        _fig, ax = plt.subplots(figsize=(9, 4.5), layout="constrained")
+    fig = ax.figure
+
+    txt = {
+        "en": (
+            "wind direction",
+            "implied Strouhal number",
+            "physical range",
+            f"nominal St = {strouhal:g}",
+            "measured",
+            "outside the range",
+        ),
+        "pt-br": (
+            "direcao do vento",
+            "numero de Strouhal implicito",
+            "faixa fisica",
+            f"St nominal = {strouhal:g}",
+            "medido",
+            "fora da faixa",
+        ),
+    }[language]
+
+    d = table["direction_deg"].to_numpy(float)
+    st = table["implied_strouhal"].to_numpy(float)
+    ok = table["passed"].to_numpy(bool)
+
+    ax.axhspan(physical_range[0], physical_range[1], color="#2F993A", alpha=0.12, label=txt[2])
+    ax.axhline(strouhal, color="#2F993A", linestyle="--", linewidth=1.5, label=txt[3])
+    ax.plot(d, st, "-", color="#E69F00", alpha=0.8, zorder=2)
+    ax.plot(d[ok], st[ok], "o", color="#E69F00", label=txt[4], zorder=3)
+    if (~ok).any():
+        ax.plot(d[~ok], st[~ok], "X", color="#A82D2D", markersize=10, label=txt[5], zorder=4)
+
+    ax.set_xlabel(txt[0])
+    ax.set_ylabel(txt[1])
+    ax.set_xticks(np.arange(0, d.max() + 1, 45))
+    ax.xaxis.set_major_formatter(FuncFormatter(lambda v, _: rf"${v:g}^\circ$"))
+    ax.set_ylim(0, max(float(st.max()) * 1.15, physical_range[1] * 1.15))
+    ax.grid(alpha=0.3)
+    ax.legend(loc="upper right", ncols=2, framealpha=0.9)
+    return fig, ax

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -1,5 +1,29 @@
 # Release Notes
 
+## 3.7.0
+
+Extends the vortex-shedding check into a directional sweep, so a case can be
+read for dimensional quality at a glance. Additive.
+
+### Strouhal by wind direction (`cfdmod.dynamics.strouhal_by_direction`)
+
+- `strouhal_by_direction()` runs the shedding check over every wind direction
+  and returns one row each: the frontal width, the observed across-wind spectral
+  peak, the frequency Strouhal predicts and the number the record implies.
+  `plot_strouhal_by_direction()` draws it against the physical band.
+- Read as a case-quality indicator: the implied number should sit in a tight
+  band around the nominal across all directions. A curve displaced as a whole
+  points at the time axis; scatter points at a short record or a plan whose
+  shedding is not well defined at oblique angles.
+- `across_wind_width()` gives the frontal width for any plan shape by projecting
+  the footprint onto the across-wind axis (for a rectangle it reduces to
+  `a*|sin| + b*|cos|`), and `across_wind_series()` rotates the model-frame floor
+  loads into the wind frame - at an oblique direction neither `cf_x` nor `cf_y`
+  is the across-wind component on its own.
+- `wind_unit_vector()` states the direction convention explicitly (0 deg blows
+  along +x, 90 deg along +y), since a silent frame swap would invert the whole
+  sweep.
+
 ## 3.6.0
 
 Adds the vortex-shedding cross-check on a dynamic load record. Additive: no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aerosim-cfdmod"
-version = "3.6.0"
+version = "3.7.0"
 description = "Tools for analysis of CFD cases"
 authors = [
     { name = "Waine Oliveira Jr", email = "waine@aerosim.io" },

--- a/tests/dynamics/test_shedding.py
+++ b/tests/dynamics/test_shedding.py
@@ -148,3 +148,166 @@ def test_zero_variance_series_is_rejected():
     src = _load(np.ones(2000), dt)
     with pytest.raises(ValueError, match="zero variance"):
         spectral_peak(src)
+
+
+# --- Directional sweep -------------------------------------------------------
+
+RECT = np.array([[-10.735, -18.45], [10.735, -18.45], [10.735, 18.45], [-10.735, 18.45]])
+A_X, B_Y = 21.47, 36.9
+
+
+def _directional_load(
+    deg: float, f_peak: float, dt: float, n_t: int, *, dt_axis: float | None = None
+) -> PointsDataSource:
+    """Load source whose tone sits on the across-wind axis of `deg`.
+
+    ``dt_axis`` re-labels the time axis without touching the samples - the shape
+    of a mis-scaled record, where the physics is right and only the seconds
+    attached to it are wrong.
+    """
+    t = np.arange(n_t) * dt
+    a = np.deg2rad(deg)
+    across = np.sin(2 * np.pi * f_peak * t)
+    rng = np.random.default_rng(int(deg))
+    series_x = -across * np.sin(a) + rng.standard_normal(n_t).cumsum() * 0.001
+    series_y = across * np.cos(a) + rng.standard_normal(n_t).cumsum() * 0.001
+    pts = np.column_stack([np.zeros(N_FLOORS), np.zeros(N_FLOORS), np.linspace(20, 80, N_FLOORS)])
+    return PointsDataSource(
+        time=TimeAxis(
+            initial_time=0.0, timestep_size=dt if dt_axis is None else dt_axis, n_timesteps=n_t
+        ),
+        topology=Topology.points(pts),
+        elements=ElementMeta(position=pts),
+        fields=MemoryFieldStore(
+            {
+                "cf_x": np.tile(series_x / N_FLOORS, (N_FLOORS, 1)),
+                "cf_y": np.tile(series_y / N_FLOORS, (N_FLOORS, 1)),
+                "cm_z": np.zeros((N_FLOORS, n_t)),
+            }
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_wind_vector_convention():
+    """0 deg blows along +x, 90 deg along +y - the frame cf_x / cf_y live in."""
+    from cfdmod.dynamics import wind_unit_vector
+
+    np.testing.assert_allclose(wind_unit_vector(0), [1.0, 0.0], atol=1e-12)
+    np.testing.assert_allclose(wind_unit_vector(90), [0.0, 1.0], atol=1e-12)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("deg", [0, 45, 90, 135, 180, 270])
+def test_across_wind_width_matches_the_rectangle_formula(deg):
+    """For a rectangle the projection reduces to a*|sin| + b*|cos|."""
+    from cfdmod.dynamics import across_wind_width
+
+    a = np.deg2rad(deg)
+    expected = A_X * abs(np.sin(a)) + B_Y * abs(np.cos(a))
+    assert across_wind_width(RECT, deg) == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.unit
+def test_across_wind_width_uses_the_wide_face_head_on():
+    from cfdmod.dynamics import across_wind_width
+
+    assert across_wind_width(RECT, 0) == pytest.approx(B_Y)
+    assert across_wind_width(RECT, 90) == pytest.approx(A_X)
+
+
+@pytest.mark.unit
+def test_across_wind_width_rejects_bad_footprints():
+    from cfdmod.dynamics import across_wind_width
+
+    with pytest.raises(ValueError, match=r"\(n, 2\)"):
+        across_wind_width(np.zeros((4, 3)), 0)
+    with pytest.raises(ValueError, match="empty"):
+        across_wind_width(np.zeros((0, 2)), 0)
+
+
+@pytest.mark.unit
+def test_across_wind_series_rotates_into_the_wind_frame():
+    """At 90 deg the across-wind component is -Fx, not Fy."""
+    from cfdmod.dynamics import across_wind_series
+
+    dt, n_t = 0.07, 512
+    fx = np.tile(np.linspace(1.0, 2.0, n_t), (N_FLOORS, 1))
+    fy = np.tile(np.linspace(-3.0, 3.0, n_t), (N_FLOORS, 1))
+    pts = np.column_stack([np.zeros(N_FLOORS), np.zeros(N_FLOORS), np.arange(N_FLOORS) * 10.0])
+    src = PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=dt, n_timesteps=n_t),
+        topology=Topology.points(pts),
+        elements=ElementMeta(position=pts),
+        fields=MemoryFieldStore({"cf_x": fx, "cf_y": fy, "cm_z": fx * 0}),
+    )
+
+    np.testing.assert_allclose(across_wind_series(src, 0), fy.sum(axis=0), atol=1e-9)
+    np.testing.assert_allclose(across_wind_series(src, 90), -fx.sum(axis=0), atol=1e-9)
+
+
+@pytest.mark.unit
+def test_strouhal_sweep_is_flat_for_a_dimensionally_consistent_case():
+    """A record that sheds at St*U/D in every direction reads back that St."""
+    from cfdmod.dynamics import across_wind_width, strouhal_by_direction
+
+    dt, n_t, st_true = 0.0705, 7955, 0.10
+    loads = {
+        float(deg): _directional_load(
+            deg,
+            vortex_shedding_frequency(U_H, across_wind_width(RECT, deg), strouhal=st_true),
+            dt,
+            n_t,
+        )
+        for deg in range(0, 360, 45)
+    }
+
+    table = strouhal_by_direction(loads, RECT, u_h_by_direction=U_H)
+
+    assert list(table["direction_deg"]) == sorted(table["direction_deg"])
+    assert table["passed"].all(), table
+    np.testing.assert_allclose(table["implied_strouhal"], st_true, rtol=0.12)
+    # the width really does vary with direction, so this was not trivially flat
+    assert table["across_wind_width_m"].max() / table["across_wind_width_m"].min() > 1.5
+
+
+@pytest.mark.unit
+def test_strouhal_sweep_flags_a_globally_compressed_record():
+    """A wrong time axis displaces the whole curve, not one point."""
+    from cfdmod.dynamics import across_wind_width, strouhal_by_direction
+
+    dt, n_t, st_true = 0.0705, 7955, 0.10
+    compression = 22.7 / 85.83
+    loads = {}
+    for deg in range(0, 360, 45):
+        f = vortex_shedding_frequency(U_H, across_wind_width(RECT, deg), strouhal=st_true)
+        # identical samples, only the seconds attached to them are wrong
+        loads[float(deg)] = _directional_load(deg, f, dt, n_t, dt_axis=dt * compression)
+
+    table = strouhal_by_direction(loads, RECT, u_h_by_direction=U_H)
+
+    assert not table["passed"].any(), table
+    np.testing.assert_allclose(table["implied_strouhal"], st_true / compression, rtol=0.12)
+
+
+@pytest.mark.unit
+def test_plot_strouhal_by_direction_marks_the_failures():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    from cfdmod.dynamics import plot_strouhal_by_direction
+
+    table = pd.DataFrame(
+        {
+            "direction_deg": [0.0, 90.0, 180.0],
+            "implied_strouhal": [0.10, 0.38, 0.11],
+            "passed": [True, False, True],
+        }
+    )
+    fig, ax = plot_strouhal_by_direction(table, language="pt-br")
+    labels = [t.get_text() for t in ax.get_legend().get_texts()]
+    assert any("fora da faixa" in lab for lab in labels), labels
+    plt.close(fig)

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "aerosim-cfdmod"
-version = "3.6.0"
+version = "3.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aerosim-lnas" },


### PR DESCRIPTION
Extends the vortex-shedding check into a directional sweep, so a case can be read for dimensional quality at a glance.

`strouhal_by_direction()` returns one row per wind direction — frontal width, observed across-wind spectral peak, the frequency Strouhal predicts, and the number the record implies — and `plot_strouhal_by_direction()` draws it against the physical band. The implied number should sit in a tight band around the nominal across all directions; a curve displaced as a whole points at the time axis, scatter points at a short record or a plan whose shedding is not well defined at oblique angles.

Two supporting pieces, both places this is easy to get wrong:

- `across_wind_width()` projects any plan footprint onto the across-wind axis (for a rectangle it reduces to `a*|sin| + b*|cos|`). Use the *tower* footprint — a podium would inflate the width and deflate the implied Strouhal number.
- `across_wind_series()` rotates the model-frame floor loads into the wind frame. At an oblique direction neither `cf_x` nor `cf_y` is the across-wind component on its own, so reading one of them directly would quietly measure the wrong spectrum.
- `wind_unit_vector()` states the convention (0 deg along +x, 90 deg along +y) rather than leaving it implicit; a frame swap would invert the entire sweep.

Tests cover the convention, the width against the closed-form rectangle result, the rotation at 0 and 90 deg, a dimensionally-consistent sweep reading back the planted Strouhal number across eight directions with a 1.9x width variation, and the compressed-record case where the samples are identical and only the seconds attached to them are wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)