### PR TITLE
fix(altimetry): keep optional extras out of the base import path

### DIFF
--- a/cfdmod/altimetry/cli.py
+++ b/cfdmod/altimetry/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pathlib
 
-import trimesh
 import typer
 
 from cfdmod.altimetry import AltimetryProbe, AltimetrySection, Shed
@@ -14,6 +13,23 @@ from cfdmod.altimetry.plots import plot_altimetry_profiles
 app = typer.Typer(name="altimetry", help="Altimetry section profile commands")
 
 
+def _load_trimesh():
+    """Import trimesh on demand, naming the extra when it is absent.
+
+    Importing at module scope would make the whole `cfdmod` CLI -- including
+    `cfdmod run`, which has nothing to do with altimetry -- unusable on an
+    install that did not opt into the optional `geometry` extra.
+    """
+    try:
+        import trimesh
+    except ImportError as exc:
+        raise ImportError(
+            "cfdmod altimetry requires the optional 'geometry' extras. "
+            "Install with: pip install aerosim-cfdmod[geometry]"
+        ) from exc
+    return trimesh
+
+
 @app.command()
 def main(
     csv: pathlib.Path = typer.Option(..., "--csv", help="Probe CSV table"),
@@ -21,6 +37,7 @@ def main(
     output: pathlib.Path = typer.Option(..., "--output", help="Output directory"),
 ) -> None:
     """Build altimetry section figures from probe + surface inputs."""
+    trimesh = _load_trimesh()
     surface_mesh: trimesh.Trimesh = trimesh.load_mesh(surface.as_posix())
 
     probes = AltimetryProbe.from_csv(csv)

--- a/cfdmod/altimetry/plots.py
+++ b/cfdmod/altimetry/plots.py
@@ -1,9 +1,16 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import matplotlib.pyplot as plt
 import numpy as np
-import trimesh
 from matplotlib.figure import Figure
 
 from cfdmod.altimetry import AltimetrySection
+
+if TYPE_CHECKING:
+    # Annotation only; see the note in cfdmod/altimetry/section.py.
+    import trimesh
 
 __all__ = [
     "plot_surface",

--- a/cfdmod/altimetry/section.py
+++ b/cfdmod/altimetry/section.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
-import trimesh
 
 from cfdmod.altimetry import SectionVertices, Shed
+
+if TYPE_CHECKING:
+    # Annotation only: slice_surface calls .section() on whatever it is handed,
+    # so importing the optional `geometry` extra at runtime is not needed here.
+    import trimesh
 
 __all__ = ["AltimetrySection"]
 

--- a/cfdmod/snapshot/__init__.py
+++ b/cfdmod/snapshot/__init__.py
@@ -23,6 +23,14 @@ __all__ = [
     "get_mesh_center",
 ]
 
+try:
+    import pyvista as _pyvista  # noqa: F401
+except ImportError as _exc:  # pragma: no cover - depends on the install
+    raise ImportError(
+        "cfdmod.snapshot requires the optional 'snapshot' extras. "
+        "Install with: pip install aerosim-cfdmod[snapshot]"
+    ) from _exc
+
 from cfdmod.snapshot.config import (
     ImageConfig,
     CropConfig,

--- a/tests/altimetry/test_altimetry.py
+++ b/tests/altimetry/test_altimetry.py
@@ -2,11 +2,16 @@ import pathlib
 
 import numpy as np
 import pytest
-import trimesh
 
-from cfdmod.altimetry import AltimetryProbe, AltimetrySection, Shed
-from cfdmod.altimetry.figure import savefig_to_file
-from cfdmod.altimetry.plots import plot_altimetry_profiles, plot_profiles, plot_surface
+trimesh = pytest.importorskip("trimesh")
+
+from cfdmod.altimetry import AltimetryProbe, AltimetrySection, Shed  # noqa: E402
+from cfdmod.altimetry.figure import savefig_to_file  # noqa: E402
+from cfdmod.altimetry.plots import (  # noqa: E402
+    plot_altimetry_profiles,
+    plot_profiles,
+    plot_surface,
+)
 
 pytestmark = pytest.mark.unit
 

--- a/tests/io/test_probe_vtm.py
+++ b/tests/io/test_probe_vtm.py
@@ -2,7 +2,14 @@ import pathlib
 
 import pytest
 
-from cfdmod.io.vtk.probe_vtm import create_line, get_array_from_filter, probe_over_line, read_vtm
+pytest.importorskip("vtkmodules")
+
+from cfdmod.io.vtk.probe_vtm import (  # noqa: E402
+    create_line,
+    get_array_from_filter,
+    probe_over_line,
+    read_vtm,
+)
 
 pytestmark = pytest.mark.integration
 

--- a/tests/io/test_write_vtk.py
+++ b/tests/io/test_write_vtk.py
@@ -4,9 +4,15 @@ import numpy as np
 import pandas as pd
 import pytest
 from lnas import LnasGeometry
-from vtkmodules.util.numpy_support import vtk_to_numpy  # type: ignore
 
-from cfdmod.io.vtk.write_vtk import create_polydata_for_cell_data, write_polydata
+pytest.importorskip("vtkmodules")
+
+from vtkmodules.util.numpy_support import vtk_to_numpy  # type: ignore  # noqa: E402
+
+from cfdmod.io.vtk.write_vtk import (  # noqa: E402
+    create_polydata_for_cell_data,
+    write_polydata,
+)
 
 pytestmark = pytest.mark.unit
 

--- a/tests/s1/test_profile.py
+++ b/tests/s1/test_profile.py
@@ -3,9 +3,16 @@ import pathlib
 import numpy as np
 import pytest
 
-from cfdmod.io.vtk.probe_vtm import create_line, get_array_from_filter, probe_over_line, read_vtm
-from cfdmod.s1.probe import S1Probe
-from cfdmod.s1.profile import Profile
+pytest.importorskip("vtkmodules")
+
+from cfdmod.io.vtk.probe_vtm import (  # noqa: E402
+    create_line,
+    get_array_from_filter,
+    probe_over_line,
+    read_vtm,
+)
+from cfdmod.s1.probe import S1Probe  # noqa: E402
+from cfdmod.s1.profile import Profile  # noqa: E402
 
 
 @pytest.mark.parametrize("numPoints", [2, 10, 100, 1000])

--- a/tests/test_lean_install.py
+++ b/tests/test_lean_install.py
@@ -1,0 +1,129 @@
+"""Guard that a base install -- no optional extras -- can still import and run.
+
+`aerosim-cfdmod` declares trimesh, vtk/pyvista, pytables and fast-simplification
+as extras precisely so the library installs lean. That promise is only real if
+nothing on a base install's import path reaches one of them at module scope.
+
+It broke once: the `cfdmod` console script imported the altimetry sub-app
+eagerly, which imported trimesh, so `cfdmod run` -- which has nothing to do with
+altimetry -- died on any install that had not opted into `[geometry]`. These
+tests reproduce that condition on purpose (the extras are installed in CI, so
+they are masked out here rather than merely absent).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Every optional extra declared in pyproject.toml.
+OPTIONAL_EXTRAS = (
+    "trimesh",
+    "vtk",
+    "vtkmodules",
+    "pyvista",
+    "tables",
+    "fast_simplification",
+)
+
+
+class _BlockExtras:
+    """meta_path finder that makes the named top-level packages look absent."""
+
+    def __init__(self, blocked: frozenset[str]) -> None:
+        self.blocked = blocked
+
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".", 1)[0] in self.blocked:
+            raise ImportError(f"{fullname} is masked by test_lean_install")
+        return None
+
+
+@contextlib.contextmanager
+def extras_absent():
+    """Run the body as if none of the optional extras were installed.
+
+    Purges cfdmod and the extras from ``sys.modules`` so imports inside the body
+    genuinely re-execute, then restores the interpreter state so the rest of the
+    session is unaffected.
+    """
+    saved = dict(sys.modules)
+    blocked = frozenset(OPTIONAL_EXTRAS)
+    for name in list(sys.modules):
+        root = name.split(".", 1)[0]
+        if root == "cfdmod" or root in blocked:
+            del sys.modules[name]
+    finder = _BlockExtras(blocked)
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+        sys.modules.clear()
+        sys.modules.update(saved)
+
+
+def test_cli_builds_without_optional_extras():
+    """`cfdmod --help` must work on a base install.
+
+    Asserts the whole command tree resolves, not just that the import survived:
+    `run` and `status` are the v3 entry points, and `altimetry` must still be
+    listed rather than silently disappearing when its extra is missing.
+    """
+    with extras_absent():
+        main = importlib.import_module("cfdmod.__main__")
+        commands = {c.name for c in main.app.registered_commands}
+        groups = {g.name for g in main.app.registered_groups}
+
+    assert {"run", "status"} <= commands
+    assert {"altimetry", "loft", "roughness", "regroup", "dynamics"} <= groups
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        "cfdmod",
+        "cfdmod.altimetry",
+        "cfdmod.altimetry.cli",
+        "cfdmod.altimetry.plots",
+        "cfdmod.core",
+        "cfdmod.io",
+        "cfdmod.recipes",
+    ],
+)
+def test_module_imports_without_optional_extras(module):
+    with extras_absent():
+        importlib.import_module(module)
+
+
+def test_altimetry_names_the_missing_extra():
+    """A base install that actually runs altimetry gets an actionable error."""
+    with extras_absent():
+        cli = importlib.import_module("cfdmod.altimetry.cli")
+        with pytest.raises(ImportError, match=r"aerosim-cfdmod\[geometry\]"):
+            cli._load_trimesh()
+
+
+@pytest.mark.parametrize(
+    ("do_import", "extra"),
+    [
+        (lambda: importlib.import_module("cfdmod.snapshot"), "snapshot"),
+        (lambda: importlib.import_module("cfdmod.io").read_vtm, "vtk"),
+    ],
+    ids=["snapshot", "vtk"],
+)
+def test_extras_only_features_name_their_extra(do_import, extra):
+    """Reaching an extras-only feature must say which extra to install.
+
+    These two are *allowed* to need an extra -- unlike the CLI above, they are
+    the feature the extra exists for. What is not allowed is a bare
+    ``No module named 'pyvista'`` that leaves the caller guessing.
+    """
+    with extras_absent():
+        with pytest.raises(ImportError, match=rf"aerosim-cfdmod\[{extra}\]"):
+            do_import()


### PR DESCRIPTION
Closes #218.

## The defect

`cfdmod/__main__.py` imported `cfdmod.altimetry.cli` eagerly, which imported `trimesh` at module scope. `trimesh` is the optional `[geometry]` extra, so on a base install the whole console script died - `cfdmod run`, `cfdmod status` and all - before printing anything.

```
$ cfdmod --help
ModuleNotFoundError: No module named 'trimesh'
```

Separately, four test modules imported `trimesh` / `vtkmodules` at module scope. Collection errors abort the entire run, so a contributor who did `uv sync` (dev group, no extras) and then `pytest` executed **zero tests**. CI never caught it because Dagger syncs `--all-extras`.

## The fix

Fixed at the leaf, not at the CLI, so nothing above altimetry has to know the extra exists:

- `section.py`, `plots.py` - `trimesh` was only ever used to annotate a parameter, so it moves under `TYPE_CHECKING`. `slice_surface` calls `.section()` on whatever it is handed; there was no runtime use to relocate.
- `cli.py` - genuinely calls `trimesh.load_mesh`, so the import moves into the command body and re-raises naming the extra, mirroring `cfdmod/io/__init__.py`.
- `cfdmod/snapshot/__init__.py` - same guard. It is *allowed* to need `[snapshot]`, but a bare `No module named 'pyvista'` left the caller guessing.

Registering the sub-app lazily was the alternative and is worse: it would drop `altimetry` out of `--help` entirely on a base install. As it stands the command is listed, and only running it without the extra fails, with an actionable message.

- Four test modules get `pytest.importorskip`, matching `tests/remesh/test_functions.py` and `tests/snapshot/test_config.py`.
- `tests/test_lean_install.py` is the regression guard. The extras are installed in CI, so it masks them out of `sys.modules` with a `meta_path` finder rather than relying on their absence, then asserts the CLI command tree builds, that the modules a base install reaches import, and that the two extras-only features name their extra.

## Verified

`cfdmod --help` now lists all seven commands with no extras installed.

| | before | after |
|---|---|---|
| `uv sync` + `uv run pytest` | collection aborted, 0 tests run | **765 collected, 765 passed** (10 skipped on absent extras) |
| `uv sync --all-extras` + `uv run pytest` | 783 passed | **785 passed** |

- `uv run ruff check cfdmod tests` and `ruff format --check` clean.
- **Adversarial sweep, not just the modules I suspected**: walked every package under `cfdmod` with all six extras blocked by a `meta_path` finder. Before this change the sweep also flagged `cfdmod.altimetry`; after it, the only two that fail are `cfdmod.io.vtk` and `cfdmod.snapshot`, which is correct - they are the features the extras exist for, they are not on any base-install import path, and both now raise a message naming the extra.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered here. No docs or rendered docstrings changed.