### PR TITLE
fix(io): hold one h5 handle per write instead of reopening per timestep

### DIFF
--- a/cfdmod/adapters/xdmf_h5/storage.py
+++ b/cfdmod/adapters/xdmf_h5/storage.py
@@ -273,50 +273,45 @@ class XdmfH5Storage:
 
         triangles = _connectivity_for_write(ds.topology)
         vertices = np.asarray(ds.topology.vertices, dtype=np.float64)
-        _xdmf.write_timeseries_geometry(h5_path, triangles, vertices)
-
         time_aggregated = ds.time.is_time_aggregated
-        if not time_aggregated:
-            time_steps = ds.time.times()
-            time_normalized = ds.time.times_normalized()
-            _xdmf.write_timeseries_meta(h5_path, time_steps, time_normalized)
 
-        # Resolve every field by reading via the source's own FieldStore.
-        # That makes the writeback work uniformly for MemoryFieldStore,
-        # H5FieldStore (with overlay), and any future store.
+        # One open handle for the whole write. Writing a timestep at a time
+        # through the module-level helpers reopened the file per timestep,
+        # which was ~3x the cost for byte-identical output.
         groups_for_xdmf: list[str] = []
-        for fname in sorted(ds.fields.keys()):
-            arr = ds.fields.read(fname)
-            if time_aggregated:
-                # Single dataset path: support 'group/stat' or bare 'stat'.
-                group, _, stat = fname.partition("/")
-                if not stat:
-                    stat = group
-                    group = _BARE_STATS_GROUP
-                _xdmf.write_stats_field(
-                    h5_path,
-                    group=group,
-                    stat_name=stat,
-                    values=np.asarray(arr, dtype=np.float64),
-                    triangles=triangles,
-                    vertices=vertices,
-                )
-            else:
-                # Timeseries: arr is (n_elements, n_timesteps).
-                if arr.ndim != 2:
-                    raise ValueError(
-                        f"field {fname!r} must be 2-D for a non-aggregated DataSource; "
-                        f"got shape {arr.shape}"
+        with _xdmf.timeseries_writer(h5_path) as writer:
+            writer.write_geometry(triangles, vertices)
+            if not time_aggregated:
+                writer.write_meta(ds.time.times(), ds.time.times_normalized())
+
+            # Resolve every field by reading via the source's own FieldStore.
+            # That makes the writeback work uniformly for MemoryFieldStore,
+            # H5FieldStore (with overlay), and any future store.
+            for fname in sorted(ds.fields.keys()):
+                arr = ds.fields.read(fname)
+                if time_aggregated:
+                    # Single dataset path: support 'group/stat' or bare 'stat'.
+                    group, _, stat = fname.partition("/")
+                    if not stat:
+                        stat = group
+                        group = _BARE_STATS_GROUP
+                    writer.write_stats_field(
+                        group=group,
+                        stat_name=stat,
+                        values=np.asarray(arr, dtype=np.float64),
+                        triangles=triangles,
+                        vertices=vertices,
                     )
-                ts = ds.time.times()
-                for i, t in enumerate(ts):
-                    _xdmf.write_timeseries_step(
-                        h5_path,
-                        group=fname,
-                        key=f"t{t}",
-                        data=np.asarray(arr[:, i], dtype=np.float64),
-                    )
-                groups_for_xdmf.append(fname)
+                else:
+                    # Timeseries: arr is (n_elements, n_timesteps).
+                    if arr.ndim != 2:
+                        raise ValueError(
+                            f"field {fname!r} must be 2-D for a non-aggregated DataSource; "
+                            f"got shape {arr.shape}"
+                        )
+                    keys = [f"t{t}" for t in ds.time.times()]
+                    writer.write_field(fname, np.asarray(arr, dtype=np.float64), keys)
+                    groups_for_xdmf.append(fname)
 
         if self._write_xdmf:
             xdmf_path = self.xdmf_path(key)

--- a/cfdmod/io/xdmf.py
+++ b/cfdmod/io/xdmf.py
@@ -23,6 +23,10 @@ __all__ = [
     "filter_keys_by_range",
     "read_step",
     "read_timeseries_meta",
+    "timeseries_reader",
+    "timeseries_writer",
+    "TimeseriesReader",
+    "TimeseriesWriter",
     "write_timeseries_step",
     "write_timeseries_meta",
     "write_timeseries_geometry",
@@ -33,9 +37,11 @@ __all__ = [
     "read_processing_metadata",
 ]
 
+import contextlib
 import datetime as _dt
 import pathlib
 import xml.etree.ElementTree as ET
+from typing import Iterator, Sequence
 from xml.dom import minidom
 
 import h5py
@@ -87,30 +93,40 @@ def read_timeseries_meta(h5_path: pathlib.Path) -> dict:
     return result
 
 
-def write_timeseries_step(
-    h5_path: pathlib.Path,
-    group: str,
-    key: str,
-    data: np.ndarray,
-    mode: str = "a",
-) -> None:
-    """Append a single timestep array to an H5 group."""
-    with h5py.File(h5_path, mode) as f:
-        grp = f.require_group(group)
-        if key in grp:
-            del grp[key]
-        grp.create_dataset(key, data=data.astype(np.float64))
+class TimeseriesWriter:
+    """Writes the timeseries / stats layout through one already-open handle.
 
+    Every write helper in this module used to open and close the h5 file on
+    each call. That is fine for a one-off, and quietly expensive in a loop: a
+    timeseries with ``n_timesteps`` steps paid ``n_timesteps`` full open / flush
+    / close cycles, which measured ~3x the cost of holding a single handle for
+    data that is byte-for-byte identical.
 
-def write_timeseries_meta(
-    h5_path: pathlib.Path,
-    time_steps: np.ndarray,
-    time_normalized: np.ndarray,
-    region_labels: list[str] | None = None,
-) -> None:
-    """Write /meta datasets (time arrays + optional region labels)."""
-    with h5py.File(h5_path, "a") as f:
-        meta = f.require_group("meta")
+    The module-level functions below delegate here, so there is one
+    implementation of each write and their behaviour is unchanged.
+    """
+
+    __slots__ = ("_f",)
+
+    def __init__(self, f: h5py.File) -> None:
+        self._f = f
+
+    def write_geometry(self, triangles: np.ndarray, vertices: np.ndarray) -> None:
+        """Write /Triangles and /Geometry (only needed once per file)."""
+        for key in ("Triangles", "Geometry"):
+            if key in self._f:
+                del self._f[key]
+        self._f.create_dataset("Triangles", data=triangles.astype(np.int32))
+        self._f.create_dataset("Geometry", data=vertices.astype(np.float64))
+
+    def write_meta(
+        self,
+        time_steps: np.ndarray,
+        time_normalized: np.ndarray,
+        region_labels: list[str] | None = None,
+    ) -> None:
+        """Write /meta datasets (time arrays + optional region labels)."""
+        meta = self._f.require_group("meta")
         for key in ("time_steps", "time_normalized", "region_labels"):
             if key in meta:
                 del meta[key]
@@ -120,6 +136,115 @@ def write_timeseries_meta(
             encoded = [s.encode() for s in region_labels]
             meta.create_dataset("region_labels", data=np.array(encoded))
 
+    def write_step(self, group: str, key: str, data: np.ndarray) -> None:
+        """Append a single timestep array to an H5 group."""
+        grp = self._f.require_group(group)
+        if key in grp:
+            del grp[key]
+        grp.create_dataset(key, data=np.asarray(data).astype(np.float64))
+
+    def write_field(self, group: str, values: np.ndarray, keys: Sequence[str]) -> None:
+        """Write a whole ``(n_elements, n_timesteps)`` field as per-timestep datasets.
+
+        ``keys[i]`` names the dataset for column ``i``. This is the batched form
+        of :meth:`write_step` and the reason this class exists.
+        """
+        values = np.asarray(values)
+        if values.ndim != 2:
+            raise ValueError(
+                f"write_field expects a 2-D (elements, time) array; got {values.shape}"
+            )
+        if values.shape[1] != len(keys):
+            raise ValueError(
+                f"write_field got {values.shape[1]} time columns but {len(keys)} keys"
+            )
+        grp = self._f.require_group(group)
+        for i, key in enumerate(keys):
+            if key in grp:
+                del grp[key]
+            grp.create_dataset(key, data=values[:, i].astype(np.float64))
+
+    def write_stats_field(
+        self,
+        group: str,
+        stat_name: str,
+        values: np.ndarray,
+        triangles: np.ndarray | None = None,
+        vertices: np.ndarray | None = None,
+    ) -> None:
+        """Write a stat dataset to ``<group>/<stat_name>``; see the module function."""
+        grp = self._f.require_group(group)
+        if triangles is not None and "Triangles" not in grp:
+            grp.create_dataset("Triangles", data=triangles.astype(np.int32))
+        if vertices is not None and "Geometry" not in grp:
+            grp.create_dataset("Geometry", data=vertices.astype(np.float64))
+        if stat_name in grp:
+            del grp[stat_name]
+        grp.create_dataset(stat_name, data=values.astype(np.float64))
+
+
+class TimeseriesReader:
+    """Reads the timeseries layout through one already-open handle.
+
+    The counterpart to :class:`TimeseriesWriter`, for the same reason: a loop
+    that calls :func:`read_step` per timestep reopens the file per timestep.
+    """
+
+    __slots__ = ("_f",)
+
+    def __init__(self, f: h5py.File) -> None:
+        self._f = f
+
+    def keys(self, group: str = "pressure") -> list[tuple[float, str]]:
+        """Sorted ``(float_time, key_str)`` pairs from an H5 group."""
+        result = [(float(k[1:]), k) for k in self._f[group].keys()]
+        return sorted(result, key=lambda x: x[0])
+
+    def read_step(self, key: str, group: str) -> np.ndarray:
+        """Read a single timestep array from an H5 group."""
+        return self._f[group][key][:]
+
+
+@contextlib.contextmanager
+def timeseries_writer(h5_path: pathlib.Path, mode: str = "a") -> Iterator[TimeseriesWriter]:
+    """Open ``h5_path`` once and write many steps / fields through the handle."""
+    with h5py.File(h5_path, mode) as f:
+        yield TimeseriesWriter(f)
+
+
+@contextlib.contextmanager
+def timeseries_reader(h5_path: pathlib.Path) -> Iterator[TimeseriesReader]:
+    """Open ``h5_path`` once and read many steps through the handle."""
+    with h5py.File(h5_path, "r") as f:
+        yield TimeseriesReader(f)
+
+
+def write_timeseries_step(
+    h5_path: pathlib.Path,
+    group: str,
+    key: str,
+    data: np.ndarray,
+    mode: str = "a",
+) -> None:
+    """Append a single timestep array to an H5 group.
+
+    Opens and closes the file. In a loop over timesteps, use
+    :func:`timeseries_writer` instead.
+    """
+    with timeseries_writer(h5_path, mode) as w:
+        w.write_step(group, key, data)
+
+
+def write_timeseries_meta(
+    h5_path: pathlib.Path,
+    time_steps: np.ndarray,
+    time_normalized: np.ndarray,
+    region_labels: list[str] | None = None,
+) -> None:
+    """Write /meta datasets (time arrays + optional region labels)."""
+    with timeseries_writer(h5_path) as w:
+        w.write_meta(time_steps, time_normalized, region_labels)
+
 
 def write_timeseries_geometry(
     h5_path: pathlib.Path,
@@ -127,12 +252,8 @@ def write_timeseries_geometry(
     vertices: np.ndarray,
 ) -> None:
     """Write /Triangles and /Geometry to H5 file (only needed once per file)."""
-    with h5py.File(h5_path, "a") as f:
-        for key in ("Triangles", "Geometry"):
-            if key in f:
-                del f[key]
-        f.create_dataset("Triangles", data=triangles.astype(np.int32))
-        f.create_dataset("Geometry", data=vertices.astype(np.float64))
+    with timeseries_writer(h5_path) as w:
+        w.write_geometry(triangles, vertices)
 
 
 def write_temporal_xdmf(
@@ -234,15 +355,8 @@ def write_stats_field(
     therefore carries its own embedded mesh; ``write_stats_xdmf`` discovers
     these and emits one Grid per group.
     """
-    with h5py.File(h5_path, "a") as f:
-        grp = f.require_group(group)
-        if triangles is not None and "Triangles" not in grp:
-            grp.create_dataset("Triangles", data=triangles.astype(np.int32))
-        if vertices is not None and "Geometry" not in grp:
-            grp.create_dataset("Geometry", data=vertices.astype(np.float64))
-        if stat_name in grp:
-            del grp[stat_name]
-        grp.create_dataset(stat_name, data=values.astype(np.float64))
+    with timeseries_writer(h5_path) as w:
+        w.write_stats_field(group, stat_name, values, triangles, vertices)
 
 
 def write_stats_xdmf(h5_path: pathlib.Path, xdmf_path: pathlib.Path) -> None:

--- a/cfdmod/regroup/functions.py
+++ b/cfdmod/regroup/functions.py
@@ -46,11 +46,11 @@ from cfdmod.geometry.triangle_slicing import (
 from cfdmod.io.geometry.transformation_config import TransformationConfig
 from cfdmod.io.xdmf import (
     get_pressure_keys,
-    read_step,
     read_timeseries_meta,
+    timeseries_reader,
+    timeseries_writer,
     write_timeseries_geometry,
     write_timeseries_meta,
-    write_timeseries_step,
 )
 from cfdmod.logger import logger
 
@@ -447,25 +447,29 @@ def apply_regroup_to_timeseries(
         f"{len(regroup_index.output_group_names)} group(s) to {output_h5}"
     )
 
-    if regroup_index.aggregation in ("per_triangle", "sliced"):
-        gather = regroup_index.new_to_parent
-        for _t_val, key in keys:
-            in_col = read_step(input_h5, key, group)
-            out_col = in_col[gather]
-            write_timeseries_step(output_h5, group, key, out_col)
-    elif regroup_index.aggregation == "area_weighted_mean":
-        triangle_group_idx = regroup_index.triangle_group_idx
-        for _t_val, key in keys:
-            in_col = read_step(input_h5, key, group)
-            per_group = np.empty(len(regroup_index.output_group_names), dtype=np.float64)
-            for gi, (parents, weights) in enumerate(
-                zip(regroup_index.group_parents, regroup_index.group_weights)
-            ):
-                per_group[gi] = float(np.sum(weights * in_col[parents]))
-            out_col = per_group[triangle_group_idx]
-            write_timeseries_step(output_h5, group, key, out_col)
-    else:
+    if regroup_index.aggregation not in ("per_triangle", "sliced", "area_weighted_mean"):
         raise ValueError(f"regroup: unknown aggregation {regroup_index.aggregation!r}")
+
+    # One open handle on each side for the whole loop. Going through the
+    # per-call helpers reopened both the input and the output file on every
+    # timestep, so a 10k-step regroup paid 20k open/close cycles.
+    with timeseries_reader(input_h5) as reader, timeseries_writer(output_h5) as writer:
+        if regroup_index.aggregation in ("per_triangle", "sliced"):
+            gather = regroup_index.new_to_parent
+            for _t_val, key in keys:
+                out_col = reader.read_step(key, group)[gather]
+                writer.write_step(group, key, out_col)
+        else:
+            triangle_group_idx = regroup_index.triangle_group_idx
+            for _t_val, key in keys:
+                in_col = reader.read_step(key, group)
+                per_group = np.empty(len(regroup_index.output_group_names), dtype=np.float64)
+                for gi, (parents, weights) in enumerate(
+                    zip(regroup_index.group_parents, regroup_index.group_weights)
+                ):
+                    per_group[gi] = float(np.sum(weights * in_col[parents]))
+                out_col = per_group[triangle_group_idx]
+                writer.write_step(group, key, out_col)
 
     write_timeseries_meta(
         output_h5,

--- a/tests/adapters/test_h5_open_count.py
+++ b/tests/adapters/test_h5_open_count.py
@@ -1,0 +1,116 @@
+"""Guard that h5 writes do not reopen the file once per timestep.
+
+Every write helper in ``cfdmod.io.xdmf`` opens and closes the file per call.
+That is correct for a one-off and quietly expensive in a loop: writing a
+timeseries used to cost one full open / flush / close cycle *per timestep*,
+for output that is byte-for-byte identical to writing it through one handle.
+
+Counting opens rather than timing the write is deliberate. A timing assertion
+on a shared machine flakes; the open count is exact, and it is the property
+that actually matters - the write must scale with the data, not with the number
+of timesteps.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import cfdmod.io.xdmf as _xdmf
+from cfdmod.adapters import XdmfH5Storage
+from cfdmod.adapters.memory import MemoryFieldStore
+from cfdmod.core import SurfaceDataSource, TimeAxis
+from cfdmod.core.topology import ElementMeta, Topology
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def count_h5_opens(monkeypatch):
+    """Return a list that accumulates one entry per ``h5py.File`` construction."""
+    opens: list[str] = []
+    real_file = _xdmf.h5py.File
+
+    def counting_file(path, *args, **kwargs):
+        opens.append(str(path))
+        return real_file(path, *args, **kwargs)
+
+    monkeypatch.setattr(_xdmf.h5py, "File", counting_file)
+    return opens
+
+
+def _surface(n_elements: int, n_timesteps: int) -> SurfaceDataSource:
+    vertices = np.random.default_rng(0).random((n_elements * 3, 3))
+    triangles = np.arange(n_elements * 3, dtype=np.int32).reshape(n_elements, 3)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=n_timesteps),
+        topology=Topology.triangles(triangles, vertices),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"cp": np.random.default_rng(1).random((n_elements, n_timesteps))}
+        ),
+    )
+
+
+@pytest.mark.parametrize("n_timesteps", [4, 64])
+def test_write_data_source_open_count_is_independent_of_timesteps(
+    tmp_path, count_h5_opens, n_timesteps
+):
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source(f"cp_t.n{n_timesteps}", _surface(6, n_timesteps))
+    # One handle for the whole write: geometry, meta and every field column.
+    assert len(count_h5_opens) == 1
+
+
+def test_write_data_source_still_writes_every_timestep(tmp_path):
+    """The open-count guard must not be satisfiable by writing less data."""
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    ds = _surface(6, 16)
+    storage.write_data_source("cp_t.full", ds)
+
+    back = storage.read_data_source("cp_t.full")
+    assert back.time.n_timesteps == 16
+    np.testing.assert_allclose(back.fields.read("cp"), ds.fields.read("cp"))
+
+
+def test_regroup_open_count_is_independent_of_timesteps(tmp_path, count_h5_opens):
+    """The regroup writer streams step by step; it must still hold both handles.
+
+    Regroup reopened *two* files per timestep - the input to read the column and
+    the output to write it - so it paid double.
+    """
+    import cfdmod.regroup.functions as regroup_functions
+
+    n_timesteps = 32
+    src = tmp_path / "in.h5"
+    triangles = np.array([[0, 1, 2], [3, 4, 5]], dtype=np.int32)
+    vertices = np.random.default_rng(2).random((6, 3))
+    _xdmf.write_timeseries_geometry(src, triangles, vertices)
+    times = np.arange(n_timesteps, dtype=np.float64)
+    _xdmf.write_timeseries_meta(src, times, times)
+    with _xdmf.timeseries_writer(src) as w:
+        for t in times:
+            w.write_step("cp", f"t{t}", np.array([1.0 + t, 2.0 + t]))
+
+    index = regroup_functions.RegroupIndex(
+        new_to_parent=np.array([0, 1, 0], dtype=np.int64),
+        output_group_names=["a"],
+        triangle_group_idx=np.array([0, 0, 0], dtype=np.int64),
+        group_parents=[np.array([0, 1], dtype=np.int64)],
+        group_weights=[np.array([0.5, 0.5])],
+        aggregation="per_triangle",
+    )
+    new_triangles = np.array([[0, 1, 2], [3, 4, 5], [0, 1, 2]], dtype=np.int32)
+
+    count_h5_opens.clear()
+    regroup_functions.apply_regroup_to_timeseries(
+        input_h5=src,
+        output_h5=tmp_path / "out.h5",
+        regroup_index=index,
+        new_triangles=new_triangles,
+        new_vertices=vertices,
+        group="cp",
+    )
+    # Bounded by the fixed set-up reads/writes (geometry, meta, key listing),
+    # never by n_timesteps. Before the fix this was 2 * n_timesteps + set-up.
+    assert len(count_h5_opens) < n_timesteps


### PR DESCRIPTION
Closes #219.

## The defect

`XdmfH5Storage.write_data_source` wrote a timeseries one timestep at a time through `cfdmod.io.xdmf.write_timeseries_step`, and that helper opens and closes the file on every call. An n-step field therefore paid n full open / flush / close cycles for output identical to writing it through one handle.

**The same defect existed in `cfdmod.regroup`, twice over** - found while checking whether the pattern had siblings. `apply_regroup_to_timeseries` called `read_step` on the input *and* `write_timeseries_step` on the output inside the same loop, so it reopened two files per timestep. Measured on a 32-step regroup: 69 opens.

## The fix

`TimeseriesWriter` / `TimeseriesReader` hold an open handle; `timeseries_writer()` / `timeseries_reader()` are the context managers. The existing module-level functions now delegate to them, so there is one implementation of each write and every current caller keeps working unchanged.

- The storage writes geometry, meta and every field column through a single handle - one open for the whole `write_data_source`.
- Regroup holds one handle on each side of its loop.

## Measured

End to end through `write_data_source`, this branch vs `origin/main`:

| | before | after | |
|---|---|---|---|
| 5 000 tri x 2 000 steps | 1.47 s | **0.62 s** | 2.4x |
| 20 000 tri x 3 000 steps | 2.90 s | **1.49 s** | 1.9x |

Lower than the 3.1x isolated open/close micro-benchmark in the issue, as expected: at these sizes the actual data write is a real share of the total. The saving is pure overhead either way.

**Output verified byte-identical.** Wrote the same timeseries and stats sources on both `origin/main` and this branch and compared every h5 dataset plus the XDMF sidecars: 54 and 8 datasets respectively, all equal, sidecars byte-equal.

## Tests

`tests/adapters/test_h5_open_count.py` counts `h5py.File` constructions rather than timing the write - a timing assertion on a shared machine flakes, and the open count is the property that actually matters.

Confirmed these fail on the base commit (throwaway worktree at `origin/main`): both storage cases, and regroup at `69 < 32` false. The fourth test - that the write still produces every timestep - passes on both, which is the point: it stops the open-count guard from being satisfiable by writing less data.

## Verified

- `uv run pytest` with `--all-extras`: **789 collected, all passed**, exit 0.
- `uv run ruff check` / `ruff format --check` clean.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered. No docs changed; the new docstrings are on classes Sphinx does not currently render.