### PR TITLE
fix(adapters): let the caller declare the DataSource kind on read

### DIFF
--- a/cfdmod/adapters/memory/storage.py
+++ b/cfdmod/adapters/memory/storage.py
@@ -42,10 +42,19 @@ class MemoryStorage:
     def __contains__(self, key: str) -> bool:
         return key in self._items
 
-    def read_data_source(self, key: str) -> DataSource:
+    def read_data_source(self, key: str, *, kind: str | None = None) -> DataSource:
         if key not in self._items:
             raise StorageKeyError(f"MemoryStorage has no data source under key {key!r}")
-        return self._items[key]
+        ds = self._items[key]
+        # RAM keeps the concrete type, so there is nothing to infer -- but the
+        # check still has to exist, or a caller passing ``kind`` would get a
+        # silent pass here and a hard failure against the h5 backend.
+        if kind is not None and ds.kind != kind:
+            raise ValueError(
+                f"MemoryStorage holds a {ds.kind!r} data source under key {key!r}, "
+                f"but {kind!r} was requested"
+            )
+        return ds
 
     def write_data_source(self, key: str, ds: DataSource) -> None:
         self._items[key] = ds

--- a/cfdmod/adapters/xdmf_h5/blob_storage.py
+++ b/cfdmod/adapters/xdmf_h5/blob_storage.py
@@ -53,7 +53,7 @@ class XdmfH5BlobStorage:
     def keys(self) -> Iterable[str]:
         return sorted(k[: -len(".h5")] for k in self._blobs.list_keys() if k.endswith(".h5"))
 
-    def read_data_source(self, key: str) -> DataSource:
+    def read_data_source(self, key: str, *, kind: str | None = None) -> DataSource:
         blob_key = f"{key}.h5"
         try:
             data = self._blobs.get_bytes(blob_key)
@@ -67,7 +67,7 @@ class XdmfH5BlobStorage:
             local_path = root / f"{key}.h5"
             local_path.parent.mkdir(parents=True, exist_ok=True)
             local_path.write_bytes(data)
-            ds = XdmfH5Storage(root).read_data_source(key)
+            ds = XdmfH5Storage(root).read_data_source(key, kind=kind)
             # Materialise fields into RAM so the DataSource does not outlive
             # the temp file it was lazily reading from.
             arrays = {name: ds.fields.read(name) for name in ds.fields.keys()}

--- a/cfdmod/adapters/xdmf_h5/storage.py
+++ b/cfdmod/adapters/xdmf_h5/storage.py
@@ -21,9 +21,10 @@ Layouts handled:
 
 The file at ``<root>/<key>.h5`` together with the optional sidecar
 ``<root>/<key>.xdmf`` is the storage unit. ``read_data_source`` returns
-a :class:`SurfaceDataSource` or :class:`PointsDataSource`; the kind is
-inferred from the ``key`` filename prefix (``bodies.``/``cp_t.``/...
--> surface, ``points.`` -> points). ``write_data_source`` rewrites the
+a :class:`SurfaceDataSource` or :class:`PointsDataSource`. Pass ``kind``
+to say which; the byte layout does not record it, so without it the
+adapter falls back to guessing from the filename stem (``points.*`` ->
+points, anything else -> surface). ``write_data_source`` rewrites the
 file from scratch using the existing ``cfdmod.io.xdmf`` helpers, so the
 output format is exactly what the v2 pipeline produces.
 """
@@ -68,13 +69,25 @@ _RESERVED_GROUP_DATASETS = frozenset({"Triangles", "Geometry", "Connectivity"})
 _BARE_STATS_GROUP = "stats"
 
 
+# Kinds this byte layout can represent. Volume and modes sources have no
+# /Triangles + /Geometry form here, so asking for one is an error rather than
+# something to approximate with a surface.
+_READABLE_KINDS = frozenset({"surface", "points"})
+
+
 def _kind_from_key(key: str) -> str:
-    """Infer DataSource kind from the filename stem.
+    """Guess the DataSource kind from the filename stem.
 
     A ``points.*`` stem is read as a points (probe) source; every other
     stem defaults to surface, which is the most common case (``bodies.*``,
-    ``cp_t.*``, ``stats.*``, ...). The prefix is the only signal -- a probe
-    file must therefore be named ``points.*`` to be read back as points.
+    ``cp_t.*``, ``stats.*``, ...).
+
+    This is a *fallback*, used only when the caller did not say what it
+    expects. The on-disk layout does not record the kind, so the filename is
+    the only signal available -- which means a probe file not named
+    ``points.*`` would read back as a surface. Callers that know the kind
+    (a template declares one per input) should pass it to
+    :meth:`XdmfH5Storage.read_data_source` instead of relying on this.
     """
     stem = pathlib.Path(key).name
     if stem.startswith("points."):
@@ -150,7 +163,12 @@ class XdmfH5Storage:
 
     # --- Read --------------------------------------------------------------
 
-    def read_data_source(self, key: str) -> DataSource:
+    def read_data_source(self, key: str, *, kind: str | None = None) -> DataSource:
+        if kind is not None and kind not in _READABLE_KINDS:
+            raise ValueError(
+                f"XdmfH5Storage cannot read a {kind!r} data source; this byte layout "
+                f"represents {sorted(_READABLE_KINDS)} only"
+            )
         h5_path = self.h5_path(key)
         if not h5_path.exists():
             raise StorageKeyError(
@@ -208,8 +226,10 @@ class XdmfH5Storage:
                         )
                         field_groups[field_name] = f"{name}/{stat_name}"
 
-        # Topology + ElementMeta
-        kind = _kind_from_key(key)
+        # Topology + ElementMeta. The declared kind wins; the filename stem is
+        # only consulted when the caller did not say.
+        if kind is None:
+            kind = _kind_from_key(key)
         if kind == "points":
             topology = Topology.points(vertices)
         else:

--- a/cfdmod/core/pipeline_yaml.py
+++ b/cfdmod/core/pipeline_yaml.py
@@ -81,6 +81,7 @@ __all__ = [
     "FreshnessConfig",
 ]
 
+import inspect
 import pathlib
 from typing import Callable, Literal
 
@@ -721,6 +722,24 @@ def _step_params(
     return params_cls.model_validate(raw)
 
 
+def _accepts_kind(storage: Storage) -> bool:
+    """Whether ``storage.read_data_source`` takes the ``kind`` keyword.
+
+    ``Storage`` is a structural protocol, so a consumer's adapter written
+    against the older two-argument signature is still a valid ``Storage``.
+    Probing the signature once keeps those working, and -- unlike catching
+    ``TypeError`` around the call -- cannot mistake a genuine ``TypeError``
+    raised *inside* the adapter for an old signature.
+    """
+    try:
+        params = inspect.signature(storage.read_data_source).parameters
+    except (TypeError, ValueError):  # builtins / C extensions have no signature
+        return False
+    if "kind" in params:
+        return True
+    return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
 def run_template(
     template: PipelineTemplate,
     *,
@@ -771,6 +790,7 @@ def run_template(
 
     # 1. Load inputs (all, or -- under skip_fresh -- only those the stale
     #    outputs depend on).
+    accepts_kind = _accepts_kind(storage)
     bindings: dict[str, DataSource] = {}
     for name, spec in template.inputs.items():
         if needed_inputs is not None and name not in needed_inputs:
@@ -779,10 +799,23 @@ def run_template(
         # the storage key so the adapter can map it to its on-disk
         # layout.
         key = _resolve_key(template.root, spec.path)
-        ds = storage.read_data_source(key)
-        # Honor the declared kind: the H5 adapter infers surface-vs-points
-        # from the filename, so a misnamed/misdeclared input would flow in
-        # as the wrong kind silently. Assert the loaded kind matches.
+        # Pass the declared kind down rather than letting the adapter guess.
+        # The h5 layout does not record it, so without this the backend falls
+        # back to the filename stem and a probe file not named ``points.*``
+        # loads as a surface.
+        try:
+            if accepts_kind:
+                ds = storage.read_data_source(key, kind=spec.kind)
+            else:
+                ds = storage.read_data_source(key)
+        except ValueError as exc:
+            raise TemplateError(
+                f"input {name!r} declares kind {spec.kind!r}, which the storage "
+                f"backend cannot read from {spec.path!r}: {exc}"
+            ) from exc
+        # Invariant check. With the kind passed explicitly this should be
+        # unreachable; it stays so a backend that ignores the keyword cannot
+        # feed the pipeline the wrong kind silently.
         if ds.kind != spec.kind:
             raise TemplateError(
                 f"input {name!r} declares kind {spec.kind!r} but the source at "

--- a/cfdmod/core/protocols.py
+++ b/cfdmod/core/protocols.py
@@ -144,12 +144,26 @@ class Storage(Protocol):
     :class:`XdmfH5Storage`. No code path differs between the two.
     """
 
-    def read_data_source(self, key: str) -> "DataSource":
+    def read_data_source(self, key: str, *, kind: "str | None" = None) -> "DataSource":
         """Read a complete :class:`DataSource` by logical key.
 
         ``key`` is a string identifier. The memory backend treats it
         as a dict key; the h5 backend resolves it to an
         ``<key>.h5`` + ``<key>.xdmf`` pair under its root directory.
+
+        Args:
+            key: The logical key to read.
+            kind: The :class:`DataSource` kind the caller expects. ``None``
+                (the default) leaves the adapter to infer it however it
+                can -- which for a byte layout that does not record the
+                kind means guessing from the key. Pass it whenever the
+                caller knows: a template declares ``kind:`` per input, and
+                a filename is not a reliable carrier of that information.
+
+        Raises:
+            ValueError: When ``kind`` is given and this backend cannot
+                produce it from what it has stored. An adapter must not
+                silently return a different kind than the one requested.
         """
         ...
 

--- a/tests/adapters/test_declared_kind.py
+++ b/tests/adapters/test_declared_kind.py
@@ -1,0 +1,162 @@
+"""A caller that knows the DataSource kind must be able to say so.
+
+The XDMF+H5 byte layout does not record whether a file is a surface or a
+points source, so the adapter used to guess from the filename stem: anything
+not named ``points.*`` read back as a surface. That is a convention a human
+can follow and a caller generating filenames from an id cannot -- and a
+template already declares ``kind:`` per input, so the information was there
+and being thrown away.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+from cfdmod.core import ElementMeta, PointsDataSource, SurfaceDataSource, TimeAxis, Topology
+from cfdmod.core.errors import TemplateError
+from cfdmod.core.pipeline_yaml import PipelineTemplate, run_template
+
+pytestmark = pytest.mark.unit
+
+
+def _points() -> PointsDataSource:
+    coords = np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 2.0]])
+    return PointsDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.5, n_timesteps=3),
+        topology=Topology.points(coords),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"pressure": np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])}),
+    )
+
+
+def _surface() -> SurfaceDataSource:
+    verts = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=np.float64)
+    tris = np.array([[0, 1, 2]], dtype=np.int32)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.5, n_timesteps=3),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore({"pressure": np.array([[1.0, 2.0, 3.0]])}),
+    )
+
+
+def test_h5_infers_points_only_from_the_filename(tmp_path):
+    """The defect, pinned: without a declared kind the stem is all there is."""
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source("probe_17", _points())
+
+    assert storage.read_data_source("probe_17").kind == "surface"
+
+
+def test_h5_declared_kind_beats_the_filename(tmp_path):
+    """...and declaring it fixes exactly that."""
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source("probe_17", _points())
+
+    back = storage.read_data_source("probe_17", kind="points")
+    assert back.kind == "points"
+    assert back.topology.cell_type == "point"
+    np.testing.assert_allclose(back.fields.read("pressure"), [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+
+def test_h5_declared_surface_under_a_points_name(tmp_path):
+    """The mirror case: a surface whose stem happens to start with points."""
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source("points.actually_a_surface", _surface())
+
+    assert storage.read_data_source("points.actually_a_surface").kind == "points"
+    back = storage.read_data_source("points.actually_a_surface", kind="surface")
+    assert back.kind == "surface"
+    assert back.topology.cell_type == "triangle"
+
+
+@pytest.mark.parametrize("kind", ["volume", "modes"])
+def test_h5_rejects_a_kind_it_cannot_represent(tmp_path, kind):
+    """Better a refusal than a surface handed back under another name."""
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source("thing", _surface())
+
+    with pytest.raises(ValueError, match="cannot read"):
+        storage.read_data_source("thing", kind=kind)
+
+
+def test_memory_storage_validates_the_declared_kind():
+    """Both backends must agree, or a test passing on memory means nothing."""
+    storage = MemoryStorage()
+    storage.write_data_source("probe", _points())
+
+    assert storage.read_data_source("probe", kind="points").kind == "points"
+    with pytest.raises(ValueError, match="but 'surface' was requested"):
+        storage.read_data_source("probe", kind="surface")
+
+
+def test_run_template_passes_the_declared_kind_down(tmp_path):
+    """The end-to-end case the issue is about.
+
+    A points input under a filename that carries no ``points.`` prefix used to
+    fail the kind assertion; declaring the kind is now enough.
+    """
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source("probe_17", _points())
+
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "kind_passthrough",
+            "root": str(tmp_path),
+            "inputs": {"p_ref": {"kind": "points", "path": "probe_17", "field": "pressure"}},
+            "pipeline": [],
+            "outputs": {},
+        }
+    )
+    bindings = run_template(template, storage=storage)
+    assert bindings["p_ref"].kind == "points"
+
+
+def test_run_template_reports_an_unreadable_declared_kind(tmp_path):
+    storage = XdmfH5Storage(tmp_path, write_xdmf=False)
+    storage.write_data_source("thing", _surface())
+
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "bad_kind",
+            "root": str(tmp_path),
+            "inputs": {"v": {"kind": "volume", "path": "thing"}},
+            "pipeline": [],
+            "outputs": {},
+        }
+    )
+    with pytest.raises(TemplateError, match="cannot read"):
+        run_template(template, storage=storage)
+
+
+def test_run_template_tolerates_a_backend_without_the_keyword():
+    """``Storage`` is structural: an adapter on the old signature still works."""
+
+    class LegacyStorage:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def read_data_source(self, key):  # no ``kind`` keyword, on purpose
+            return self._inner.read_data_source(key)
+
+        def write_data_source(self, key, ds):
+            self._inner.write_data_source(key, ds)
+
+        def keys(self):
+            return self._inner.keys()
+
+    inner = MemoryStorage()
+    inner.write_data_source("probe", _points())
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "legacy",
+            "inputs": {"p_ref": {"kind": "points", "path": "probe"}},
+            "pipeline": [],
+            "outputs": {},
+        }
+    )
+    bindings = run_template(template, storage=LegacyStorage(inner))
+    assert bindings["p_ref"].kind == "points"


### PR DESCRIPTION
Closes #225.

## The defect

`XdmfH5Storage` decided surface-vs-points from the filename stem. A probe file not named `points.*` read back as a surface. The template declares the kind, but `run_template` could only compare after loading and raise - it had no channel to tell the adapter what to load. So a correctly declared template pointed at a correctly formed file failed on naming alone, which a caller generating filenames from an id cannot fix.

## The fix

`read_data_source(key, *, kind=None)` on the `Storage` protocol and all three adapters. `kind=None` keeps the old inference, so this is additive.

- **`XdmfH5Storage`** uses the declared kind; `_kind_from_key` is now only the fallback. Asking for `volume` or `modes` raises, rather than handing back a surface under another name.
- **`MemoryStorage`** validates `kind` against what it holds. Without this a test passing on memory would say nothing about the h5 path.
- **`XdmfH5BlobStorage`** forwards it.
- **`run_template`** passes `spec.kind` down.

`Storage` is a structural protocol, so a consumer's adapter written against the two-argument signature is still valid. Handled by probing `inspect.signature` once per run, **not** by catching `TypeError` around the call - that would mistake a genuine `TypeError` raised inside an adapter for an old signature, and silently retry with the wrong arguments. There is a test with a deliberately old-signature adapter.

The existing post-load `ds.kind != spec.kind` assertion stays. With the kind passed explicitly it is unreachable, which makes it a real invariant rather than the only line of defence.

## Also

The module docstring claimed the kind came from `bodies.` / `cp_t.` / `stats.` / `points.` prefixes. Checked: only `points.` was ever load-bearing. The rest are convention, and documenting them as behaviour was misleading. Corrected.

## Tests

`tests/adapters/test_declared_kind.py`. It pins the old behaviour as well as the new one - `test_h5_infers_points_only_from_the_filename` asserts that *without* a declared kind a points source under a plain name still reads as a surface, so the fallback is documented by a test rather than left implicit. Plus the mirror case (a surface under a `points.` name), the refusal on unrepresentable kinds, the memory-backend agreement, the end-to-end `run_template` path, and the legacy-adapter compatibility case.

## Verified

- `uv run pytest` with `--all-extras`: **798 collected, all passed**, exit 0.
- `uv run ruff check` / `format --check` clean.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered. Docstrings changed but no `docs/` page.