### PR TITLE
feat(core): run templates over time windows, sized from a memory budget

### DIFF
--- a/cfdmod/__main__.py
+++ b/cfdmod/__main__.py
@@ -22,6 +22,36 @@ app.add_typer(
 )
 
 
+_SIZE_SUFFIXES = {"K": 1 << 10, "M": 1 << 20, "G": 1 << 30, "T": 1 << 40}
+
+
+def _parse_size(text: str | None) -> int | None:
+    """Parse ``4G`` / ``512M`` / ``2000000`` into bytes.
+
+    Asking an engineer for a byte count is asking them to do arithmetic at the
+    shell; asking for ``4G`` is not.
+    """
+    if text is None:
+        return None
+    raw = text.strip().upper().removesuffix("B")
+    if not raw:
+        raise ValueError(f"could not parse memory budget {text!r}")
+    multiplier = _SIZE_SUFFIXES.get(raw[-1:])
+    if multiplier is not None:
+        raw = raw[:-1]
+    else:
+        multiplier = 1
+    try:
+        value = float(raw)
+    except ValueError as exc:
+        raise ValueError(
+            f"could not parse memory budget {text!r}; expected e.g. 4G, 512M, or a byte count"
+        ) from exc
+    if value <= 0:
+        raise ValueError(f"memory budget must be positive; got {text!r}")
+    return int(value * multiplier)
+
+
 @app.command("run")
 def run(
     template: pathlib.Path = typer.Argument(..., help="Path to a v3 pipeline YAML template."),
@@ -40,15 +70,42 @@ def run(
         "--digest",
         help="Override the input-digest strategy: size_mtime | content | backend.",
     ),
+    chunk_size: int | None = typer.Option(
+        None,
+        "--chunk-size",
+        help="Timesteps per window. Bounds peak memory on a time-chunkable template.",
+    ),
+    memory_budget: str | None = typer.Option(
+        None,
+        "--memory-budget",
+        help="RAM the run may spend on time-resolved arrays (e.g. 4G, 512M). "
+        "The window size is derived from it; mutually exclusive with --chunk-size.",
+    ),
 ) -> None:
     """Execute a v3 pipeline template (cfdmod.core.pipeline_yaml).
 
     The template declares its own inputs, pipeline steps, and outputs;
     this command just loads the YAML and runs it via XdmfH5Storage.
     """
+    if chunk_size is not None and memory_budget is not None:
+        typer.echo("error: pass --chunk-size or --memory-budget, not both", err=True)
+        raise typer.Exit(code=1)
+    try:
+        budget_bytes = _parse_size(memory_budget)
+    except ValueError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
     try:
         bindings = run_yaml(
-            template, output_root=output_root, skip_fresh=skip_fresh, digest=digest
+            template,
+            output_root=output_root,
+            skip_fresh=skip_fresh,
+            digest=digest,
+            chunk_size=chunk_size,
+            memory_budget=budget_bytes,
+            # Say what the run decided. A silent cap reads as "processed
+            # everything comfortably" when it did not.
+            on_plan=lambda plan: typer.echo(plan.describe()),
         )
     except (KeyError, ValueError, FileNotFoundError, ValidationError) as exc:
         # These are user/config errors (bad template, missing file, typo'd

--- a/cfdmod/adapters/memory/storage.py
+++ b/cfdmod/adapters/memory/storage.py
@@ -80,19 +80,45 @@ class MemoryStorage:
         self._signatures[key] = signature
 
 
+# Rows of a field hashed at a time. Bounds the float64 upcast + tobytes copy
+# to roughly this many bytes instead of the whole field twice over.
+_HASH_BLOCK_BYTES = 8 << 20
+
+
+def _update_blockwise(h, arr: np.ndarray, dtype) -> None:
+    """Feed ``arr`` to ``h`` as ``dtype`` bytes, a row block at a time.
+
+    Hashing ``np.ascontiguousarray(arr, dtype).tobytes()`` in one go costs two
+    full copies of the array -- the upcast and the bytes -- so digesting a
+    64 MB float32 field peaked at 256 MB. Since the array is walked in
+    C order, concatenating row blocks yields exactly the same byte sequence,
+    so this is byte-identical to the whole-array form and existing signatures
+    keep matching. Only the peak changes.
+    """
+    arr = np.asarray(arr)
+    if arr.size == 0:
+        return
+    itemsize = np.dtype(dtype).itemsize
+    row_bytes = max(1, int(np.prod(arr.shape[1:], dtype=np.int64))) * itemsize
+    rows_per_block = max(1, _HASH_BLOCK_BYTES // max(1, row_bytes))
+    for start in range(0, arr.shape[0], rows_per_block):
+        block = np.ascontiguousarray(arr[start : start + rows_per_block], dtype=dtype)
+        h.update(block.tobytes())
+
+
 def _data_source_content_hash(ds: DataSource) -> str:
     """Stable hash of a data source's kind, topology, time axis, and fields."""
     h = hashlib.blake2b(digest_size=32)
     h.update(ds.kind.encode("utf-8"))
     if ds.topology is not None:
-        h.update(np.ascontiguousarray(ds.topology.vertices, dtype=np.float64).tobytes())
+        _update_blockwise(h, ds.topology.vertices, np.float64)
         conn = ds.topology.connectivity
         if conn is not None:
-            h.update(np.ascontiguousarray(conn, dtype=np.int64).tobytes())
+            _update_blockwise(h, conn, np.int64)
     h.update(str(ds.time.n_timesteps).encode("utf-8"))
     for name in sorted(ds.fields.keys()):
-        arr = np.ascontiguousarray(ds.fields.read(name), dtype=np.float64)
+        arr = np.asarray(ds.fields.read(name))
         h.update(name.encode("utf-8"))
         h.update(str(arr.shape).encode("utf-8"))
-        h.update(arr.tobytes())
+        _update_blockwise(h, arr, np.float64)
     return h.hexdigest()

--- a/cfdmod/core/memory.py
+++ b/cfdmod/core/memory.py
@@ -1,0 +1,222 @@
+"""Turn a RAM budget into a time-chunk size.
+
+:mod:`cfdmod.core.chunked` can stream a time-preserving pipeline over windows of
+the time axis so peak memory is ``O(n_elements * chunk)`` rather than
+``O(n_elements * n_timesteps)``. It needs a ``chunk_size`` in timesteps, and
+that is the wrong question to put to a caller: nobody knows what 4096 timesteps
+costs. "I have 8 GB" is answerable.
+
+The arithmetic is deliberately simple, and deliberately an estimate:
+
+    one time column   = n_elements * itemsize          bytes
+    live at any time  = n_live_arrays columns          (input + intermediates)
+    chunk_size        = budget / (n_elements * itemsize * n_live_arrays)
+
+``n_live_arrays`` is the count of time-resolved arrays alive at the widest point
+of the pipeline. It is not knowable exactly -- numpy temporaries inside an op,
+copies an adapter makes on read -- so this is a *lower bound on the cost* and
+therefore an upper bound on a safe chunk size. Leave headroom in the budget
+rather than trusting the estimate to the byte; :data:`DEFAULT_SAFETY_FACTOR`
+applies some by default.
+
+Nothing here allocates or measures. It is arithmetic over shapes, so it is
+cheap enough to call before deciding whether to run at all.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "ChunkPlan",
+    "DEFAULT_SAFETY_FACTOR",
+    "bytes_per_timestep",
+    "estimate_peak_bytes",
+    "plan_chunking",
+    "suggest_chunk_size",
+]
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from cfdmod.core.dtypes import FIELD_DTYPE
+
+DEFAULT_SAFETY_FACTOR = 0.8
+"""Fraction of the stated budget the planner will actually spend.
+
+The estimate counts whole arrays and cannot see numpy's temporaries, so
+spending the budget exactly is how a run that was "planned to fit" does not.
+"""
+
+
+@dataclass(frozen=True)
+class ChunkPlan:
+    """A chunk size plus everything needed to explain it.
+
+    Returning this rather than a bare int is the point: when a run picks
+    ``chunk_size=1`` the immediate question is why, and a plain integer cannot
+    answer it.
+
+    Attributes:
+        chunk_size: Timesteps per window. Equal to ``n_timesteps`` when the
+            whole series fits, in which case chunking is a no-op.
+        n_timesteps: The full time axis length this was planned against.
+        n_elements: Elements on the source.
+        n_live_arrays: How many time-resolved arrays the plan assumed are
+            simultaneously live.
+        itemsize: Bytes per value.
+        estimated_peak_bytes: What one window is expected to cost.
+        budget_bytes: The budget the plan was derived from, or ``None`` when
+            the chunk size was given directly.
+        clamped: True when the arithmetic asked for something outside
+            ``[1, n_timesteps]`` and the plan was pinned to the bound. A
+            ``clamped`` plan at ``chunk_size == 1`` means the budget does not
+            actually fit a single timestep and the run will exceed it.
+    """
+
+    chunk_size: int
+    n_timesteps: int
+    n_elements: int
+    n_live_arrays: int
+    itemsize: int
+    estimated_peak_bytes: int
+    budget_bytes: int | None = None
+    clamped: bool = False
+
+    @property
+    def is_chunked(self) -> bool:
+        """Whether this plan actually splits the time axis."""
+        return 0 < self.chunk_size < self.n_timesteps
+
+    @property
+    def exceeds_budget(self) -> bool:
+        """True when even one timestep does not fit the budget."""
+        return self.budget_bytes is not None and self.estimated_peak_bytes > self.budget_bytes
+
+    def describe(self) -> str:
+        """One line for a log or a CLI, in units a human reads."""
+        peak_mb = self.estimated_peak_bytes / 1e6
+        if not self.is_chunked:
+            return (
+                f"time chunking: off (whole series of {self.n_timesteps} steps in one pass, "
+                f"est. peak {peak_mb:.0f} MB)"
+            )
+        n_windows = -(-self.n_timesteps // self.chunk_size)
+        note = " -- BUDGET EXCEEDED, one timestep does not fit" if self.exceeds_budget else ""
+        return (
+            f"time chunking: {self.chunk_size} steps x {n_windows} windows "
+            f"({self.n_elements} elements, {self.n_live_arrays} live arrays, "
+            f"est. peak {peak_mb:.0f} MB){note}"
+        )
+
+
+def _itemsize(dtype) -> int:
+    return int(np.dtype(dtype).itemsize)
+
+
+def bytes_per_timestep(
+    n_elements: int,
+    *,
+    n_live_arrays: int = 1,
+    dtype=FIELD_DTYPE,
+) -> int:
+    """Bytes one timestep occupies across every simultaneously live array."""
+    if n_elements < 0:
+        raise ValueError(f"n_elements must be non-negative; got {n_elements}")
+    if n_live_arrays < 1:
+        raise ValueError(f"n_live_arrays must be at least 1; got {n_live_arrays}")
+    return int(n_elements) * _itemsize(dtype) * int(n_live_arrays)
+
+
+def estimate_peak_bytes(
+    n_elements: int,
+    chunk_size: int,
+    *,
+    n_live_arrays: int = 1,
+    dtype=FIELD_DTYPE,
+) -> int:
+    """Estimated peak bytes held while processing one window of ``chunk_size`` steps."""
+    if chunk_size < 0:
+        raise ValueError(f"chunk_size must be non-negative; got {chunk_size}")
+    return bytes_per_timestep(n_elements, n_live_arrays=n_live_arrays, dtype=dtype) * int(
+        chunk_size
+    )
+
+
+def suggest_chunk_size(
+    n_elements: int,
+    n_timesteps: int,
+    budget_bytes: int,
+    *,
+    n_live_arrays: int = 1,
+    dtype=FIELD_DTYPE,
+    safety_factor: float = DEFAULT_SAFETY_FACTOR,
+) -> int:
+    """Largest window that is expected to fit ``budget_bytes``.
+
+    Clamped to ``[1, n_timesteps]``: never zero (a zero-step window processes
+    nothing) and never more than the series has. See :func:`plan_chunking` when
+    you need to know *whether* it was clamped.
+    """
+    return plan_chunking(
+        n_elements,
+        n_timesteps,
+        budget_bytes=budget_bytes,
+        n_live_arrays=n_live_arrays,
+        dtype=dtype,
+        safety_factor=safety_factor,
+    ).chunk_size
+
+
+def plan_chunking(
+    n_elements: int,
+    n_timesteps: int,
+    *,
+    budget_bytes: int | None = None,
+    chunk_size: int | None = None,
+    n_live_arrays: int = 1,
+    dtype=FIELD_DTYPE,
+    safety_factor: float = DEFAULT_SAFETY_FACTOR,
+) -> ChunkPlan:
+    """Build a :class:`ChunkPlan` from a budget, or price an explicit chunk size.
+
+    Exactly one of ``budget_bytes`` / ``chunk_size`` may be given. With neither,
+    the plan is the whole series in one pass, still carrying a peak estimate --
+    which is useful on its own: it is the number that says whether chunking is
+    worth turning on.
+    """
+    if budget_bytes is not None and chunk_size is not None:
+        raise ValueError("pass budget_bytes or chunk_size, not both")
+    if n_timesteps < 0:
+        raise ValueError(f"n_timesteps must be non-negative; got {n_timesteps}")
+    if not 0 < safety_factor <= 1:
+        raise ValueError(f"safety_factor must be in (0, 1]; got {safety_factor}")
+
+    itemsize = _itemsize(dtype)
+    unit = bytes_per_timestep(n_elements, n_live_arrays=n_live_arrays, dtype=dtype)
+    clamped = False
+
+    if chunk_size is not None:
+        if chunk_size < 1:
+            raise ValueError(f"chunk_size must be positive; got {chunk_size}")
+        resolved = min(int(chunk_size), n_timesteps) if n_timesteps else int(chunk_size)
+        clamped = resolved != int(chunk_size)
+    elif budget_bytes is not None:
+        if budget_bytes <= 0:
+            raise ValueError(f"budget_bytes must be positive; got {budget_bytes}")
+        # unit == 0 only when there are no elements, in which case any window fits.
+        raw = n_timesteps if unit == 0 else int(budget_bytes * safety_factor) // unit
+        resolved = max(1, min(raw, n_timesteps)) if n_timesteps else max(1, raw)
+        clamped = raw != resolved
+    else:
+        resolved = n_timesteps
+
+    return ChunkPlan(
+        chunk_size=resolved,
+        n_timesteps=int(n_timesteps),
+        n_elements=int(n_elements),
+        n_live_arrays=int(n_live_arrays),
+        itemsize=itemsize,
+        estimated_peak_bytes=unit * resolved,
+        budget_bytes=budget_bytes,
+        clamped=clamped,
+    )

--- a/cfdmod/core/pipeline_yaml.py
+++ b/cfdmod/core/pipeline_yaml.py
@@ -83,7 +83,7 @@ __all__ = [
 
 import inspect
 import pathlib
-from typing import Callable, Literal
+from typing import TYPE_CHECKING, Callable, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.json_schema import GenerateJsonSchema
@@ -97,6 +97,9 @@ from cfdmod.core.errors import (
 )
 from cfdmod.core.protocols import Storage
 from cfdmod.utils import read_yaml
+
+if TYPE_CHECKING:
+    from cfdmod.core.memory import ChunkPlan
 
 # ---------------------------------------------------------------------------
 # Op registry
@@ -740,11 +743,145 @@ def _accepts_kind(storage: Storage) -> bool:
     return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
+def _live_time_arrays(template: PipelineTemplate) -> int:
+    """How many time-resolved arrays the pipeline holds at its widest point.
+
+    Used to price a time window. Counting exactly is not possible -- numpy
+    temporaries inside an op are invisible from here -- so this is a floor:
+    every declared input that carries a time axis, plus every step that
+    produces one. That is conservative in the right direction (it over-counts
+    live arrays, so it under-sizes the window) as long as ops do not allocate
+    more than one extra array of their own, which the field ops do not.
+
+    Never returns less than 1, so the caller can divide by it.
+    """
+    _populate_default_registry()
+    # Inputs are assumed time-resolved: an aggregated one costs a single
+    # column regardless of window size, so counting it is the safe error.
+    live = len(template.inputs) + len(template.pipeline)
+    return max(1, live)
+
+
+def _chunkable_step_params(template: PipelineTemplate) -> list[BaseModel]:
+    """Bound params for every step, for :func:`assert_time_chunkable`."""
+    out: list[BaseModel] = []
+    for step in template.pipeline:
+        entry = OP_REGISTRY.get(step.kind)
+        if entry is None:
+            continue
+        out.append(_step_params(step, entry[2], template.root))
+    return out
+
+
+def _plan_for(
+    template: PipelineTemplate,
+    bindings: dict[str, DataSource],
+    chunk_size: int | None,
+    memory_budget: int | None,
+    n_live_arrays: int | None,
+) -> "ChunkPlan":
+    """Size the time window for this run from the loaded inputs.
+
+    The shape comes from the widest time-resolved input: that is what a window
+    of the pipeline actually costs. With no time-resolved input, or a single
+    timestep, the plan is a single pass -- there is nothing to split.
+    """
+    from cfdmod.core.memory import plan_chunking
+
+    resolved_live = n_live_arrays if n_live_arrays is not None else _live_time_arrays(template)
+    timed = [ds for ds in bindings.values() if not ds.time.is_time_aggregated]
+    n_timesteps = max((ds.time.n_timesteps for ds in timed), default=0)
+    n_elements = max((ds.n_elements for ds in timed), default=0)
+
+    if n_timesteps <= 1:
+        return plan_chunking(n_elements, n_timesteps, n_live_arrays=resolved_live)
+    return plan_chunking(
+        n_elements,
+        n_timesteps,
+        budget_bytes=memory_budget,
+        chunk_size=chunk_size,
+        n_live_arrays=resolved_live,
+    )
+
+
+def _retained_bindings(template: PipelineTemplate) -> set[str] | None:
+    """Step ids whose per-window results must be kept, or ``None`` for all.
+
+    Only what the ``outputs:`` block asks for survives a chunked run. That is
+    not a convenience -- it is what makes chunking reduce anything. Keeping
+    every intermediate for every window holds the full-size arrays *plus* the
+    windowed copies, which costs strictly more than not chunking at all
+    (measured: 25.8 MB against 11.4 MB unchunked, on a template whose only
+    real output was a 4-group reduction of 4000 triangles).
+
+    With no declared outputs there is nothing to select on, so everything is
+    kept and chunking bounds transient allocations only.
+    """
+    sources = {out.source for out in template.outputs.values()}
+    return sources or None
+
+
+def _walk_chunked(
+    template: PipelineTemplate,
+    bindings: dict[str, DataSource],
+    needed_steps: set[str] | None,
+    plan: "ChunkPlan",
+) -> dict[str, DataSource]:
+    """Run the step walk once per time window and concatenate the results.
+
+    This is :func:`cfdmod.core.chunked.chunk_map_time` generalised to a
+    multi-input template: every time-resolved binding is sliced to the same
+    window, the whole walk runs on the slice, and the per-window results are
+    concatenated along time. Time-aggregated bindings (a static reference
+    pressure, a mesh) pass through untouched.
+
+    Only the bindings :func:`_retained_bindings` selects are accumulated
+    across windows; the rest go out of scope with their window, which is the
+    entire source of the memory saving. The returned dict therefore carries
+    the inputs (unsliced, as loaded) plus the retained results -- an
+    intermediate that no output depends on is not reconstructed.
+
+    Safe only for a time-length-preserving pipeline -- the caller must have
+    run :func:`~cfdmod.core.chunked.assert_time_chunkable` first. An op that
+    reduces the time axis (``statistics``) does not declare time
+    chunkability precisely because windowed statistics are not the statistics
+    of the whole series.
+    """
+    from cfdmod.core.chunked import concat_time, slice_time, time_windows
+
+    retain = _retained_bindings(template)
+    accumulated: dict[str, list[DataSource]] = {}
+    for sl in time_windows(plan.n_timesteps, plan.chunk_size):
+        window = {
+            name: ds if ds.time.is_time_aggregated else slice_time(ds, sl)
+            for name, ds in bindings.items()
+        }
+        produced = _walk_steps(template, window, needed_steps)
+        for name, ds in produced.items():
+            if retain is not None and name not in retain:
+                continue
+            accumulated.setdefault(name, []).append(ds)
+        # Drop the window's own bindings before allocating the next one.
+        del produced, window
+
+    merged: dict[str, DataSource] = dict(bindings)
+    for name, parts in accumulated.items():
+        if len(parts) == 1 or parts[0].time.is_time_aggregated:
+            merged[name] = parts[0]
+        else:
+            merged[name] = concat_time(parts)
+    return merged
+
+
 def run_template(
     template: PipelineTemplate,
     *,
     storage: Storage,
     skip_fresh: bool = False,
+    chunk_size: int | None = None,
+    memory_budget: int | None = None,
+    n_live_arrays: int | None = None,
+    on_plan: Callable[["ChunkPlan"], None] | None = None,
 ) -> dict[str, DataSource]:
     """Run a parsed template against a :class:`Storage`.
 
@@ -762,6 +899,42 @@ def run_template(
     the inputs those stale outputs depend on -- fresh outputs are neither
     recomputed nor rewritten. If every declared output is already fresh the
     run is a no-op and returns an empty binding dict.
+
+    Time chunking
+    -------------
+    With ``chunk_size`` or ``memory_budget`` the pipeline runs over contiguous
+    windows of the time axis and the per-window results are concatenated, so
+    peak memory is ``O(n_elements * chunk)`` rather than
+    ``O(n_elements * n_timesteps)``. The numbers are unchanged; only the peak
+    is.
+
+    Two things are worth being clear about:
+
+    - **It is not free on every template.** The win is real when the pipeline
+      collapses the element axis before the concatenation (a per-triangle force
+      summed to a per-floor coefficient): the big intermediates then live for
+      one window at a time while the concatenated result stays small. A
+      pipeline that keeps the full element axis still bounds its transient
+      allocations, but its final output is the same size as the unchunked one.
+    - **Not every pipeline may be chunked.** Every op must declare ``"time"``
+      in ``chunkable_along``. ``statistics`` deliberately does not -- the
+      statistics of a window are not the statistics of the series -- so a
+      template containing it raises before any I/O, naming the offending ops,
+      rather than producing plausible wrong numbers.
+
+    Args:
+        chunk_size: Timesteps per window. Mutually exclusive with
+            ``memory_budget``.
+        memory_budget: Bytes the run may spend on time-resolved arrays; the
+            window size is derived from it (see :mod:`cfdmod.core.memory`).
+            Mutually exclusive with ``chunk_size``.
+        n_live_arrays: Override for how many time-resolved arrays the budget
+            arithmetic assumes are live at once. Derived from the template
+            when omitted.
+        on_plan: Called with the :class:`~cfdmod.core.memory.ChunkPlan` before
+            execution starts, whether or not chunking is on. Use it to log or
+            surface what the run decided; ``ChunkPlan.describe()`` renders a
+            line.
     """
     _populate_default_registry()
     # Static validation first: fail on typos/dangling refs before any I/O.
@@ -823,7 +996,39 @@ def run_template(
             )
         bindings[name] = ds
 
-    # 2. Walk pipeline.
+    # 2. Decide whether and how to chunk the time axis, and say so.
+    plan = _plan_for(template, bindings, chunk_size, memory_budget, n_live_arrays)
+    if on_plan is not None:
+        on_plan(plan)
+    if plan.is_chunked:
+        # Fail before any work if an op in the chain cannot be windowed.
+        from cfdmod.core.chunked import assert_time_chunkable
+
+        try:
+            assert_time_chunkable(_chunkable_step_params(template))
+        except ValueError as exc:
+            raise TemplateError(f"cannot run this template chunked over time: {exc}") from exc
+
+    # 3. Walk pipeline, over the whole time axis or one window at a time.
+    if plan.is_chunked:
+        bindings = _walk_chunked(template, bindings, needed_steps, plan)
+    else:
+        bindings = _walk_steps(template, bindings, needed_steps)
+
+    return _write_outputs(template, bindings, storage, stale_outputs, supports_freshness, strategy)
+
+
+def _walk_steps(
+    template: PipelineTemplate,
+    bindings: dict[str, DataSource],
+    needed_steps: set[str] | None,
+) -> dict[str, DataSource]:
+    """Execute the template's steps against ``bindings``, returning them extended.
+
+    Split out of :func:`run_template` so the chunked runner can call it once per
+    time window with windowed inputs. ``bindings`` is not mutated.
+    """
+    bindings = dict(bindings)
     for i, step in enumerate(template.pipeline):
         step_id = step.id or f"step_{i}"
         if needed_steps is not None and step_id not in needed_steps:
@@ -870,8 +1075,18 @@ def run_template(
 
         bindings[step_id] = result
 
-    # 3. Write outputs (skipping fresh ones under skip_fresh) and stamp each
-    #    with its freshness signature when the backend supports it.
+    return bindings
+
+
+def _write_outputs(
+    template: PipelineTemplate,
+    bindings: dict[str, DataSource],
+    storage: Storage,
+    stale_outputs: set[str] | None,
+    supports_freshness: bool,
+    strategy: str,
+) -> dict[str, DataSource]:
+    """Write the ``outputs:`` block, stamping freshness where supported."""
     sign = None
     if supports_freshness and template.outputs:
         from cfdmod.core.freshness import signature as sign

--- a/cfdmod/core/recipes/run_yaml.py
+++ b/cfdmod/core/recipes/run_yaml.py
@@ -42,6 +42,9 @@ def run_yaml(
     output_root: pathlib.Path | str | None = None,
     skip_fresh: bool = False,
     digest: DigestStrategy | None = None,
+    chunk_size: int | None = None,
+    memory_budget: int | None = None,
+    on_plan=None,
 ) -> dict[str, DataSource]:
     """Load and run a v3 pipeline template.
 
@@ -55,6 +58,12 @@ def run_yaml(
         skip_fresh: When True, skip recomputing outputs already up to date
             and run only the steps the stale outputs depend on.
         digest: Optional override of the template's input-digest strategy.
+        chunk_size: Timesteps per window; see :func:`run_template`.
+        memory_budget: Bytes the run may spend on time-resolved arrays. The
+            window size is derived from it. Mutually exclusive with
+            ``chunk_size``.
+        on_plan: Called with the chosen
+            :class:`~cfdmod.core.memory.ChunkPlan` before execution.
 
     Returns:
         The dict of every named binding the runner produced (inputs +
@@ -70,7 +79,14 @@ def run_yaml(
     root = pathlib.Path(output_root) if output_root is not None else pathlib.Path("/")
     storage = XdmfH5Storage(root)
 
-    return run_template(template, storage=storage, skip_fresh=skip_fresh)
+    return run_template(
+        template,
+        storage=storage,
+        skip_fresh=skip_fresh,
+        chunk_size=chunk_size,
+        memory_budget=memory_budget,
+        on_plan=on_plan,
+    )
 
 
 def status_yaml(

--- a/tests/adapters/test_content_hash_memory.py
+++ b/tests/adapters/test_content_hash_memory.py
@@ -1,0 +1,118 @@
+"""The in-RAM content digest must not cost two copies of the data.
+
+``MemoryStorage.digest`` hashes the topology and every field. It did that by
+building ``np.ascontiguousarray(arr, dtype=float64).tobytes()`` in one go -- an
+upcast copy plus a bytes copy -- so digesting a 64 MB float32 field peaked at
+256 MB. That runs on every ``run_template`` with declared outputs, which made it
+the dominant cost of a run whose whole point was bounding memory.
+
+Two properties matter, and the first one is why the fix is safe: the byte
+sequence fed to the hash is unchanged, so signatures written before it still
+match.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import tracemalloc
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.adapters.memory.storage import _update_blockwise
+from cfdmod.core import ElementMeta, SurfaceDataSource, TimeAxis, Topology
+
+pytestmark = pytest.mark.unit
+
+
+def _whole_array_hash(arr: np.ndarray, dtype) -> str:
+    """The pre-fix formulation, kept here as the reference to match."""
+    h = hashlib.blake2b(digest_size=32)
+    h.update(np.ascontiguousarray(arr, dtype=dtype).tobytes())
+    return h.hexdigest()
+
+
+def _blockwise_hash(arr: np.ndarray, dtype) -> str:
+    h = hashlib.blake2b(digest_size=32)
+    _update_blockwise(h, arr, dtype)
+    return h.hexdigest()
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (5000, 300),  # many rows: actually blocks
+        (1, 10),  # single row
+        (10, 1),  # single column
+        (77, 3, 4),  # 3-D, e.g. vertices
+        (0, 5),  # empty
+        (13,),  # 1-D, time-aggregated field
+    ],
+)
+@pytest.mark.parametrize("dtype", [np.float64, np.int64])
+def test_blockwise_hash_is_byte_identical(shape, dtype):
+    """Same bytes in, same digest out -- for every shape, including degenerate."""
+    arr = (np.random.default_rng(0).random(shape) * 100).astype(np.float32)
+    assert _blockwise_hash(arr, dtype) == _whole_array_hash(arr, dtype)
+
+
+def test_blockwise_hash_still_distinguishes_content():
+    """A hash that bounded memory by hashing less would pass the test above."""
+    a = np.arange(6000, dtype=np.float32).reshape(2000, 3)
+    b = a.copy()
+    b[-1, -1] += 1.0  # last element, i.e. in the final block
+    assert _blockwise_hash(a, np.float64) != _blockwise_hash(b, np.float64)
+
+
+def test_digest_peak_is_bounded_not_proportional_to_the_field():
+    """Measured, not argued: the digest must not scale with field size."""
+    n_elements, n_timesteps = 20_000, 400
+    rng = np.random.default_rng(1)
+    verts = rng.random((n_elements * 3, 3))
+    tris = np.arange(n_elements * 3, dtype=np.int32).reshape(n_elements, 3)
+    field_bytes = n_elements * n_timesteps * 4
+    ds = SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=n_timesteps),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"pressure": rng.random((n_elements, n_timesteps)).astype(np.float32)}
+        ),
+    )
+    storage = MemoryStorage()
+    storage.write_data_source("body", ds)
+
+    tracemalloc.start()
+    try:
+        storage.digest("body")
+        peak = tracemalloc.get_traced_memory()[1]
+    finally:
+        tracemalloc.stop()
+
+    # Pre-fix this was ~4x the field (float64 upcast + tobytes, both whole).
+    assert peak < field_bytes, (
+        f"digest peaked at {peak / 1e6:.1f} MB for a {field_bytes / 1e6:.1f} MB field"
+    )
+
+
+def test_digest_still_changes_when_a_field_changes():
+    """The end-to-end property freshness depends on."""
+    verts = np.array([[0, 0, 0], [1, 0, 0], [1, 1, 0]], dtype=np.float64)
+    tris = np.array([[0, 1, 2]], dtype=np.int32)
+
+    def source(value: float) -> SurfaceDataSource:
+        return SurfaceDataSource(
+            time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=2),
+            topology=Topology.triangles(tris, verts),
+            elements=ElementMeta(),
+            fields=MemoryFieldStore({"cp": np.array([[value, 2.0]])}),
+        )
+
+    storage = MemoryStorage()
+    storage.write_data_source("a", source(1.0))
+    storage.write_data_source("b", source(1.0))
+    storage.write_data_source("c", source(1.5))
+
+    assert storage.digest("a") == storage.digest("b")
+    assert storage.digest("a") != storage.digest("c")

--- a/tests/core/test_memory.py
+++ b/tests/core/test_memory.py
@@ -1,0 +1,112 @@
+"""The budget arithmetic that turns RAM into a time-chunk size."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.core.memory import (
+    ChunkPlan,
+    bytes_per_timestep,
+    estimate_peak_bytes,
+    plan_chunking,
+    suggest_chunk_size,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_bytes_per_timestep_counts_every_live_array():
+    # 1000 elements x 4 bytes (float32) x 3 live arrays
+    assert bytes_per_timestep(1000, n_live_arrays=3, dtype=np.float32) == 12_000
+
+
+def test_bytes_per_timestep_follows_the_dtype():
+    assert bytes_per_timestep(1000, dtype=np.float64) == 8_000
+    assert bytes_per_timestep(1000, dtype=np.float32) == 4_000
+
+
+def test_estimate_peak_is_the_unit_times_the_window():
+    assert estimate_peak_bytes(1000, 50, n_live_arrays=2, dtype=np.float32) == 400_000
+
+
+def test_suggest_chunk_size_spends_the_budget_minus_headroom():
+    # unit = 1000 * 4 * 2 = 8000 B/step; 8 MB * 0.8 safety / 8000 = 800 steps
+    assert (
+        suggest_chunk_size(1000, 10_000, budget_bytes=8_000_000, n_live_arrays=2, dtype=np.float32)
+        == 800
+    )
+
+
+def test_suggest_chunk_size_never_exceeds_the_series():
+    assert suggest_chunk_size(10, 25, budget_bytes=10**9, n_live_arrays=1) == 25
+
+
+def test_suggest_chunk_size_never_returns_zero():
+    """A window of zero steps processes nothing; one step over budget is the
+    honest answer, and the plan says so."""
+    plan = plan_chunking(10**7, 1000, budget_bytes=1000, n_live_arrays=4)
+    assert plan.chunk_size == 1
+    assert plan.clamped
+    assert plan.exceeds_budget
+
+
+def test_plan_without_budget_or_chunk_is_a_single_pass():
+    plan = plan_chunking(500, 200, n_live_arrays=2)
+    assert plan.chunk_size == 200
+    assert not plan.is_chunked
+    # Still prices the run -- that number is what says whether to chunk at all.
+    assert plan.estimated_peak_bytes == 500 * 4 * 2 * 200
+
+
+def test_plan_with_explicit_chunk_size_is_clamped_to_the_series():
+    plan = plan_chunking(10, 30, chunk_size=100)
+    assert plan.chunk_size == 30
+    assert plan.clamped
+    assert not plan.is_chunked
+
+
+def test_plan_rejects_both_knobs():
+    with pytest.raises(ValueError, match="not both"):
+        plan_chunking(10, 30, budget_bytes=1000, chunk_size=5)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"budget_bytes": 0}, "budget_bytes must be positive"),
+        ({"chunk_size": 0}, "chunk_size must be positive"),
+        ({"n_live_arrays": 0}, "n_live_arrays must be at least 1"),
+        ({"safety_factor": 0}, "safety_factor must be in"),
+        ({"safety_factor": 1.5}, "safety_factor must be in"),
+    ],
+)
+def test_plan_rejects_degenerate_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        plan_chunking(10, 30, **kwargs)
+
+
+def test_zero_elements_does_not_divide_by_zero():
+    plan = plan_chunking(0, 100, budget_bytes=1000)
+    assert plan.chunk_size == 100
+    assert plan.estimated_peak_bytes == 0
+
+
+def test_describe_says_off_when_not_chunked():
+    assert "off" in plan_chunking(100, 50).describe()
+
+
+def test_describe_reports_windows_and_the_budget_overrun():
+    plan = plan_chunking(1000, 100, chunk_size=30, n_live_arrays=2)
+    text = plan.describe()
+    assert "30 steps x 4 windows" in text
+
+    tight = plan_chunking(10**7, 1000, budget_bytes=1000, n_live_arrays=4)
+    assert "BUDGET EXCEEDED" in tight.describe()
+
+
+def test_chunk_plan_is_frozen():
+    plan = plan_chunking(10, 10)
+    assert isinstance(plan, ChunkPlan)
+    with pytest.raises(Exception):
+        plan.chunk_size = 5  # type: ignore[misc]

--- a/tests/core/test_run_template_chunked.py
+++ b/tests/core/test_run_template_chunked.py
@@ -1,0 +1,291 @@
+"""Running a template over time windows: same numbers, smaller peak.
+
+`cfdmod.core.chunked` has been able to stream a pipeline over the time axis
+since it was written, and nothing called it - so `run_template`, the path a
+service drives, always materialised the full ``(n_elements, n_timesteps)``
+array for every intermediate. These tests cover the wiring, and the two
+properties that make it worth having: the outputs must not move, and the peak
+must fall.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.core import ElementMeta, Grouping, SurfaceDataSource, TimeAxis, Topology
+from cfdmod.core.errors import TemplateError
+from cfdmod.core.memory import ChunkPlan
+from cfdmod.core.pipeline_yaml import PipelineTemplate, run_template
+
+pytestmark = pytest.mark.unit
+
+
+def _surface(n_elements: int, n_timesteps: int, seed: int = 0) -> SurfaceDataSource:
+    rng = np.random.default_rng(seed)
+    verts = rng.random((n_elements * 3, 3))
+    tris = np.arange(n_elements * 3, dtype=np.int32).reshape(n_elements, 3)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=n_timesteps),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"pressure": rng.random((n_elements, n_timesteps)).astype(np.float32)}
+        ),
+    )
+
+
+def _scaling_template(name: str = "chunkable") -> PipelineTemplate:
+    """A time-length-preserving chain: every op declares time chunkability."""
+    return PipelineTemplate.model_validate(
+        {
+            "name": name,
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": "scaled",
+                    "kind": "scale",
+                    "source": "body",
+                    "field": "pressure",
+                    "factor": 2.0,
+                    "out": "cp",
+                },
+                {
+                    "id": "smoothed",
+                    "kind": "scale",
+                    "source": "scaled",
+                    "field": "cp",
+                    "factor": 0.5,
+                    "out": "cp_half",
+                },
+            ],
+            "outputs": {},
+        }
+    )
+
+
+def _storage_with(ds: SurfaceDataSource) -> MemoryStorage:
+    storage = MemoryStorage()
+    storage.write_data_source("body", ds)
+    return storage
+
+
+def test_chunked_and_unchunked_agree_exactly():
+    """The whole point: chunking changes the peak, not the answer."""
+    ds = _surface(40, 96)
+    template = _scaling_template()
+
+    whole = run_template(template, storage=_storage_with(ds))
+    windowed = run_template(template, storage=_storage_with(ds), chunk_size=10)
+
+    for name, field in (("scaled", "cp"), ("smoothed", "cp_half")):
+        np.testing.assert_array_equal(
+            windowed[name].fields.read(field), whole[name].fields.read(field)
+        )
+        assert windowed[name].time.n_timesteps == whole[name].time.n_timesteps
+        np.testing.assert_allclose(windowed[name].time.times(), whole[name].time.times())
+
+
+def test_uneven_final_window_is_handled():
+    """96 is not a multiple of 7; the short last window must not truncate."""
+    ds = _surface(12, 96)
+    template = _scaling_template()
+
+    whole = run_template(template, storage=_storage_with(ds))
+    windowed = run_template(template, storage=_storage_with(ds), chunk_size=7)
+
+    assert windowed["smoothed"].time.n_timesteps == 96
+    np.testing.assert_array_equal(
+        windowed["smoothed"].fields.read("cp_half"), whole["smoothed"].fields.read("cp_half")
+    )
+
+
+def test_memory_budget_derives_the_window_and_reports_it():
+    ds = _surface(1000, 200)
+    plans: list[ChunkPlan] = []
+
+    run_template(
+        _scaling_template(),
+        storage=_storage_with(ds),
+        memory_budget=1_000_000,
+        on_plan=plans.append,
+    )
+
+    (plan,) = plans
+    assert plan.is_chunked
+    # 3 live arrays (1 input + 2 steps) x 1000 elements x 4 bytes = 12 kB/step;
+    # 1 MB x 0.8 / 12 kB = 66 steps.
+    assert plan.n_live_arrays == 3
+    assert plan.chunk_size == 66
+    assert "66 steps" in plan.describe()
+
+
+def test_on_plan_fires_even_when_not_chunking():
+    """A caller logging the plan should not have to special-case the off path."""
+    plans: list[ChunkPlan] = []
+    run_template(_scaling_template(), storage=_storage_with(_surface(8, 16)), on_plan=plans.append)
+
+    (plan,) = plans
+    assert not plan.is_chunked
+    assert plan.estimated_peak_bytes > 0
+
+
+def test_statistics_cannot_be_chunked_and_says_so():
+    """Windowed statistics are not the statistics of the series.
+
+    `statistics` declares chunkability along elements, not time, so asking for
+    a chunked run must fail loudly rather than return plausible wrong numbers.
+    """
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "with_stats",
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": "stats",
+                    "kind": "statistics",
+                    "source": "body",
+                    "field": "pressure",
+                    "kinds": ["mean", "rms"],
+                },
+            ],
+            "outputs": {},
+        }
+    )
+    with pytest.raises(TemplateError, match="cannot run this template chunked"):
+        run_template(template, storage=_storage_with(_surface(8, 64)), chunk_size=8)
+
+
+def test_unchunkable_template_is_rejected_before_any_step_runs():
+    """Fail on the contract, not halfway through the data."""
+    calls: list[str] = []
+
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "with_stats",
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": "stats",
+                    "kind": "statistics",
+                    "source": "body",
+                    "field": "pressure",
+                    "kinds": ["mean"],
+                },
+            ],
+            "outputs": {},
+        }
+    )
+
+    class WatchingStorage(MemoryStorage):
+        def read_data_source(self, key, *, kind=None):
+            calls.append(key)
+            return super().read_data_source(key, kind=kind)
+
+    storage = WatchingStorage()
+    storage.write_data_source("body", _surface(8, 64))
+    with pytest.raises(TemplateError):
+        run_template(template, storage=storage, chunk_size=8)
+    # The input is read once to size the plan; no step ran and nothing was written.
+    assert calls == ["body"]
+
+
+def test_single_timestep_source_is_never_chunked():
+    ds = _surface(8, 1)
+    plans: list[ChunkPlan] = []
+    run_template(
+        _scaling_template(), storage=_storage_with(ds), chunk_size=1, on_plan=plans.append
+    )
+    assert not plans[0].is_chunked
+
+
+def test_chunking_lowers_the_peak_allocation():
+    """The property the whole feature exists for, measured rather than assumed.
+
+    Reducing the element axis is what makes the win show up - here a
+    ``field_series_for_groups`` collapses 4000 triangles onto 4 groups, so the
+    big per-triangle intermediates live for one window at a time while the
+    concatenated result stays small.
+    """
+    n_elements, n_timesteps, n_groups = 20_000, 600, 4
+    rng = np.random.default_rng(3)
+    verts = rng.random((n_elements * 3, 3))
+    tris = np.arange(n_elements * 3, dtype=np.int32).reshape(n_elements, 3)
+    # Attached up front rather than built by a grouping op, so the template
+    # stays about the chunking rather than about mesh ingest.
+    grouping = Grouping(
+        name="floors",
+        indices=np.arange(n_elements) % n_groups,
+        labels=[f"g{i}" for i in range(n_groups)],
+    )
+    ds = SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=n_timesteps),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(area=np.ones(n_elements)),
+        fields=MemoryFieldStore(
+            {"pressure": rng.random((n_elements, n_timesteps)).astype(np.float32)}
+        ),
+    ).with_grouping(grouping)
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "reducing",
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": "scaled",
+                    "kind": "scale",
+                    "source": "body",
+                    "field": "pressure",
+                    "factor": 2.0,
+                    "out": "cp",
+                },
+                {
+                    "id": "per_group",
+                    "kind": "field_series_for_groups",
+                    "source": "scaled",
+                    "grouping": "floors",
+                    "field": "cp",
+                    "agg": "area_weighted_mean",
+                    "out": "cp_group",
+                },
+            ],
+            # Declaring the output is what lets the chunked run drop the
+            # per-triangle intermediate instead of accumulating every window
+            # of it -- see _retained_bindings.
+            "outputs": {"per_floor": {"source": "per_group", "path": "out"}},
+        }
+    )
+
+    def peak_bytes(**kwargs):
+        tracemalloc.start()
+        try:
+            result = run_template(template, storage=_storage_with(ds), **kwargs)
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        return peak, result
+
+    whole_peak, whole = peak_bytes()
+    windowed_peak, windowed = peak_bytes(chunk_size=50)
+
+    np.testing.assert_allclose(
+        windowed["per_group"].fields.read("cp_group"),
+        whole["per_group"].fields.read("cp_group"),
+        rtol=1e-6,
+    )
+    # A bare "lower" would pass on noise. Two claims instead: the chunked run
+    # must be a clear fraction of the unchunked one, and it must stay under the
+    # size of the field itself -- the array an unchunked run has no choice but
+    # to hold whole. Both are loose against the ~7x measured at this size.
+    field_bytes = n_elements * n_timesteps * 4
+    assert windowed_peak < whole_peak / 2, (
+        f"chunked peak {windowed_peak / 1e6:.1f} MB was not well below "
+        f"unchunked {whole_peak / 1e6:.1f} MB"
+    )
+    assert windowed_peak < field_bytes, (
+        f"chunked peak {windowed_peak / 1e6:.1f} MB exceeded the whole field "
+        f"({field_bytes / 1e6:.1f} MB)"
+    )

--- a/tests/test_cli_options.py
+++ b/tests/test_cli_options.py
@@ -1,0 +1,32 @@
+"""Option parsing on the global CLI, exercised without running a pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from cfdmod.__main__ import _parse_size
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("4G", 4 << 30),
+        ("512M", 512 << 20),
+        ("2K", 2048),
+        ("1.5G", int(1.5 * (1 << 30))),
+        ("2000000", 2_000_000),
+        ("4GB", 4 << 30),
+        (" 8g ", 8 << 30),
+        (None, None),
+    ],
+)
+def test_parse_size_accepts_human_units(text, expected):
+    assert _parse_size(text) == expected
+
+
+@pytest.mark.parametrize("text", ["", "G", "abc", "-4G", "0"])
+def test_parse_size_rejects_nonsense(text):
+    with pytest.raises(ValueError):
+        _parse_size(text)

--- a/tests/test_lean_install.py
+++ b/tests/test_lean_install.py
@@ -64,8 +64,16 @@ def extras_absent():
         yield
     finally:
         sys.meta_path.remove(finder)
-        sys.modules.clear()
-        sys.modules.update(saved)
+        # Surgical, not `sys.modules.clear()` + restore. Clearing the whole
+        # table and putting it back breaks C-extension packages that resolve
+        # submodules lazily -- scipy.optimize._highspy._core stops being
+        # importable for the rest of the session, which shows up as an
+        # unrelated ModuleNotFoundError in whatever test runs next.
+        for name in list(sys.modules):
+            if name.split(".", 1)[0] == "cfdmod" and name not in saved:
+                del sys.modules[name]
+        for name, module in saved.items():
+            sys.modules.setdefault(name, module)
 
 
 def test_cli_builds_without_optional_extras():


### PR DESCRIPTION
Closes #222.

## What was wrong

`cfdmod/core/chunked.py` has been able to stream a time-preserving pipeline over windows of the time axis since it was written. Nothing called it. So `run_template` - the path a service and the interface drive - always materialised the full `(n_elements, n_timesteps)` array for every intermediate.

## What this adds

**`cfdmod/core/memory.py`** turns a RAM budget into a window size. One time column costs `n_elements * itemsize`; several intermediates are live at once; so `chunk = budget / (n_elements * itemsize * n_live)`, clamped to `[1, n_timesteps]` with a safety factor. `n_live` is derived from the template rather than asked of the caller.

It returns a **`ChunkPlan`**, not an int. When a run picks `chunk_size=1` the immediate question is why, and an integer cannot answer it. The plan carries the inputs it was derived from, the estimated peak, whether it was clamped, whether it *exceeds* the budget even at one timestep, and a `describe()` line.

**`run_template(..., chunk_size= | memory_budget=, on_plan=)`**. `on_plan` fires whether or not chunking is on, so a caller logging it needs no special case.

**CLI**: `cfdmod run --chunk-size N` / `--memory-budget 4G`, and the plan is echoed - a capped run must not read as an uncapped one.

## Two things kept honest

**Chunking is not free on every template.** The win needs the pipeline to collapse the element axis before concatenation. A pipeline that keeps the full element axis produces the same-sized output; the docstring says so rather than implying a universal speedup.

**Not every pipeline may be chunked.** `statistics` declares chunkability along elements, not time - windowed statistics are not the statistics of the series. A template containing it is rejected *before any step runs*, naming the offending ops, instead of returning plausible wrong numbers. There is a test asserting nothing beyond the input read happens.

## Measured

20 000 triangles x 800 steps reduced onto 4 groups, `tracemalloc` peak:

| | peak | |
|---|---|---|
| unchunked | 112.3 MB | |
| `chunk_size=200` | **28.3 MB** | 4.0x |
| `chunk_size=50` | **16.8 MB** | 6.7x |

Outputs identical to the unchunked run in every case (asserted in the tests, not just here).

## Also fixed: the digest that dominated the runs this exists to bound

Found by measuring instead of assuming - the first benchmark showed a flat 256 MB peak regardless of chunk size, and tracing it put the cost outside the pipeline entirely.

`MemoryStorage`'s content digest built `np.ascontiguousarray(arr, dtype=float64).tobytes()` in one go: an upcast copy plus a bytes copy, so digesting a 64 MB float32 field peaked at 256 MB. It runs on **every** `run_template` with declared outputs. Hashing a row block at a time is byte-identical in C order, so **existing signatures still match** - verified against the old formulation across six shapes including empty, 1-D and 3-D, and with a test that a change in the last element still changes the digest (a memory fix that hashed *less* would have passed the equality test alone).

## Verified

- `uv run pytest --all-extras`: **852 collected, all passed**, exit 0.
- `uv run ruff check` / `format --check` clean.
- `cfdmod run --help` shows both new options.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered.