### PR TITLE
feat(core): progress reporting and cooperative cancellation in run_template

### DIFF
--- a/cfdmod/__init__.py
+++ b/cfdmod/__init__.py
@@ -114,6 +114,15 @@ __all__ = [
     "output_status",
     "OutputStatus",
     "FreshnessConfig",
+    # Memory budgeting / time chunking
+    "ChunkPlan",
+    "plan_chunking",
+    "suggest_chunk_size",
+    "estimate_peak_bytes",
+    "bytes_per_timestep",
+    # Progress / cancellation
+    "RunEvent",
+    "RunCancelled",
     # Errors (issue #147)
     "CfdmodError",
     "TemplateError",
@@ -249,6 +258,13 @@ _SYMBOL_MODULE: dict[str, str] = {
     "output_status": "cfdmod.core",
     "OutputStatus": "cfdmod.core",
     "FreshnessConfig": "cfdmod.core",
+    "ChunkPlan": "cfdmod.core",
+    "plan_chunking": "cfdmod.core",
+    "suggest_chunk_size": "cfdmod.core",
+    "estimate_peak_bytes": "cfdmod.core",
+    "bytes_per_timestep": "cfdmod.core",
+    "RunEvent": "cfdmod.core",
+    "RunCancelled": "cfdmod.core",
     # Errors
     "CfdmodError": "cfdmod.core",
     "TemplateError": "cfdmod.core",

--- a/cfdmod/core/__init__.py
+++ b/cfdmod/core/__init__.py
@@ -40,6 +40,14 @@ from cfdmod.core.freshness import (
     output_status,
     signature,
 )
+from cfdmod.core.memory import (
+    ChunkPlan,
+    bytes_per_timestep,
+    estimate_peak_bytes,
+    plan_chunking,
+    suggest_chunk_size,
+)
+from cfdmod.core.progress import RunCancelled, RunEvent
 from cfdmod.core.pipeline_yaml import (
     OP_REGISTRY,
     DigestStrategy,
@@ -93,6 +101,13 @@ __all__ = [
     "OutputStatus",
     "output_status",
     "signature",
+    "ChunkPlan",
+    "bytes_per_timestep",
+    "estimate_peak_bytes",
+    "plan_chunking",
+    "suggest_chunk_size",
+    "RunCancelled",
+    "RunEvent",
     "CfdmodError",
     "TemplateError",
     "TemplateReferenceError",

--- a/cfdmod/core/pipeline_yaml.py
+++ b/cfdmod/core/pipeline_yaml.py
@@ -100,6 +100,7 @@ from cfdmod.utils import read_yaml
 
 if TYPE_CHECKING:
     from cfdmod.core.memory import ChunkPlan
+    from cfdmod.core.progress import RunEvent
 
 # ---------------------------------------------------------------------------
 # Op registry
@@ -821,11 +822,44 @@ def _retained_bindings(template: PipelineTemplate) -> set[str] | None:
     return sources or None
 
 
+class _Reporter:
+    """Bundles the ``on_progress`` / ``cancel`` seams so the runner takes one
+    argument instead of threading two optionals through four functions.
+
+    Both are optional and the no-op case costs an attribute check, so the
+    unobserved path is unchanged.
+    """
+
+    __slots__ = ("_on_progress", "_cancel")
+
+    def __init__(self, on_progress, cancel) -> None:
+        self._on_progress = on_progress
+        self._cancel = cancel
+
+    def emit(self, phase, name, index, total, **extra) -> None:
+        if self._on_progress is None:
+            return
+        from cfdmod.core.progress import RunEvent
+
+        self._on_progress(RunEvent(phase=phase, name=name, index=index, total=total, **extra))
+
+    def check(self, phase, name) -> None:
+        """Raise :class:`RunCancelled` if the caller asked to stop."""
+        if self._cancel is not None and self._cancel():
+            from cfdmod.core.progress import RunCancelled
+
+            raise RunCancelled(phase, name)
+
+
+_NULL_REPORTER = _Reporter(None, None)
+
+
 def _walk_chunked(
     template: PipelineTemplate,
     bindings: dict[str, DataSource],
     needed_steps: set[str] | None,
     plan: "ChunkPlan",
+    reporter: "_Reporter" = _NULL_REPORTER,
 ) -> dict[str, DataSource]:
     """Run the step walk once per time window and concatenate the results.
 
@@ -850,13 +884,19 @@ def _walk_chunked(
     from cfdmod.core.chunked import concat_time, slice_time, time_windows
 
     retain = _retained_bindings(template)
+    windows = list(time_windows(plan.n_timesteps, plan.chunk_size))
     accumulated: dict[str, list[DataSource]] = {}
-    for sl in time_windows(plan.n_timesteps, plan.chunk_size):
+    for w, sl in enumerate(windows):
+        # Poll per window: that is the unit of work that actually takes time,
+        # so it is the granularity at which cancelling is useful.
+        reporter.check("step", f"window {w + 1}")
         window = {
             name: ds if ds.time.is_time_aggregated else slice_time(ds, sl)
             for name, ds in bindings.items()
         }
-        produced = _walk_steps(template, window, needed_steps)
+        produced = _walk_steps(
+            template, window, needed_steps, reporter, window_index=w, n_windows=len(windows)
+        )
         for name, ds in produced.items():
             if retain is not None and name not in retain:
                 continue
@@ -882,6 +922,8 @@ def run_template(
     memory_budget: int | None = None,
     n_live_arrays: int | None = None,
     on_plan: Callable[["ChunkPlan"], None] | None = None,
+    on_progress: Callable[["RunEvent"], None] | None = None,
+    cancel: Callable[[], bool] | None = None,
 ) -> dict[str, DataSource]:
     """Run a parsed template against a :class:`Storage`.
 
@@ -935,6 +977,13 @@ def run_template(
             execution starts, whether or not chunking is on. Use it to log or
             surface what the run decided; ``ChunkPlan.describe()`` renders a
             line.
+        on_progress: Called with a :class:`~cfdmod.core.progress.RunEvent` as
+            each input is loaded, each step runs, and each output is written.
+        cancel: Polled at those same boundaries; returning True raises
+            :class:`~cfdmod.core.progress.RunCancelled`. cfdmod cannot
+            interrupt a numpy call in flight, so a run stops at the next
+            boundary -- but the check precedes every write, so a cancelled run
+            never leaves a partially written output set.
     """
     _populate_default_registry()
     # Static validation first: fail on typos/dangling refs before any I/O.
@@ -963,11 +1012,15 @@ def run_template(
 
     # 1. Load inputs (all, or -- under skip_fresh -- only those the stale
     #    outputs depend on).
+    reporter = _Reporter(on_progress, cancel)
     accepts_kind = _accepts_kind(storage)
     bindings: dict[str, DataSource] = {}
-    for name, spec in template.inputs.items():
+    n_inputs = len(template.inputs)
+    for i, (name, spec) in enumerate(template.inputs.items()):
         if needed_inputs is not None and name not in needed_inputs:
             continue
+        reporter.check("load", name)
+        reporter.emit("load", name, i, n_inputs)
         # Storage keys are logical names. We treat the resolved path as
         # the storage key so the adapter can map it to its on-disk
         # layout.
@@ -1011,17 +1064,23 @@ def run_template(
 
     # 3. Walk pipeline, over the whole time axis or one window at a time.
     if plan.is_chunked:
-        bindings = _walk_chunked(template, bindings, needed_steps, plan)
+        bindings = _walk_chunked(template, bindings, needed_steps, plan, reporter)
     else:
-        bindings = _walk_steps(template, bindings, needed_steps)
+        bindings = _walk_steps(template, bindings, needed_steps, reporter)
 
-    return _write_outputs(template, bindings, storage, stale_outputs, supports_freshness, strategy)
+    return _write_outputs(
+        template, bindings, storage, stale_outputs, supports_freshness, strategy, reporter
+    )
 
 
 def _walk_steps(
     template: PipelineTemplate,
     bindings: dict[str, DataSource],
     needed_steps: set[str] | None,
+    reporter: "_Reporter" = _NULL_REPORTER,
+    *,
+    window_index: int | None = None,
+    n_windows: int | None = None,
 ) -> dict[str, DataSource]:
     """Execute the template's steps against ``bindings``, returning them extended.
 
@@ -1029,10 +1088,21 @@ def _walk_steps(
     time window with windowed inputs. ``bindings`` is not mutated.
     """
     bindings = dict(bindings)
+    total = len(template.pipeline)
     for i, step in enumerate(template.pipeline):
         step_id = step.id or f"step_{i}"
         if needed_steps is not None and step_id not in needed_steps:
             continue
+        reporter.check("step", step_id)
+        reporter.emit(
+            "step",
+            step_id,
+            i,
+            total,
+            op_kind=step.kind,
+            window=window_index,
+            n_windows=n_windows,
+        )
         if step.kind not in OP_REGISTRY:
             raise TemplateReferenceError(
                 f"unknown op kind {step.kind!r} at step {step_id!r}; "
@@ -1085,15 +1155,23 @@ def _write_outputs(
     stale_outputs: set[str] | None,
     supports_freshness: bool,
     strategy: str,
+    reporter: "_Reporter" = _NULL_REPORTER,
 ) -> dict[str, DataSource]:
-    """Write the ``outputs:`` block, stamping freshness where supported."""
+    """Write the ``outputs:`` block, stamping freshness where supported.
+
+    Cancellation is polled before each write, so a cancelled run never leaves a
+    partially written output set.
+    """
     sign = None
     if supports_freshness and template.outputs:
         from cfdmod.core.freshness import signature as sign
 
-    for out_name, out in template.outputs.items():
+    total = len(template.outputs)
+    for i, (out_name, out) in enumerate(template.outputs.items()):
         if stale_outputs is not None and out_name not in stale_outputs:
             continue
+        reporter.check("write", out_name)
+        reporter.emit("write", out_name, i, total)
         if out.source not in bindings:
             raise TemplateReferenceError(f"output references unknown source {out.source!r}")
         key = _resolve_key(template.root, out.path)

--- a/cfdmod/core/progress.py
+++ b/cfdmod/core/progress.py
@@ -1,0 +1,103 @@
+"""Progress reporting and cooperative cancellation for a template run.
+
+A post-processing run on a real case takes minutes. Without these, a caller --
+the CLI, and above all the interface -- can only block until it returns: no bar,
+no way to kill a job whose user walked away, no way to see which step is slow.
+
+Two separate seams, deliberately:
+
+- :class:`RunEvent` + an ``on_progress`` callback, for reporting.
+- a ``cancel`` predicate, for stopping.
+
+They are not merged into "the progress callback raises to cancel", which reads
+neatly and behaves badly: every exception in a caller's logging code would then
+look like a deliberate abort.
+
+**What cancellation promises.** cfdmod cannot interrupt numpy mid-call and does
+not pretend to. The predicate is polled at boundaries -- between steps, between
+time windows, and before each output is written -- so a cancelled run stops at
+the next boundary and, because the check precedes every write, does not leave a
+half-written output set behind. A single very long op will run to completion
+before the run notices.
+"""
+
+from __future__ import annotations
+
+__all__ = ["RunCancelled", "RunEvent", "RunPhase"]
+
+from dataclasses import dataclass
+from typing import Literal
+
+from cfdmod.core.errors import CfdmodError
+
+RunPhase = Literal["load", "step", "write"]
+"""Which part of the run an event belongs to.
+
+``load`` and ``write`` are included because on a big case they are a real share
+of the wall clock -- a bar that sits at 0% while inputs load and then jumps to
+100% is worse than no bar.
+"""
+
+
+@dataclass(frozen=True)
+class RunEvent:
+    """One unit of progress within a template run.
+
+    A frozen object rather than a tuple so fields can be added later without
+    breaking a caller's unpacking.
+
+    Attributes:
+        phase: ``load``, ``step`` or ``write``.
+        name: The input name, step id, or output name.
+        index: 0-based position within the phase.
+        total: How many units this phase has.
+        op_kind: The op being executed. ``None`` outside the ``step`` phase.
+        window: 0-based time window, when the run is chunked. ``None`` when it
+            is not.
+        n_windows: How many time windows the run has, or ``None`` when
+            unchunked.
+    """
+
+    phase: RunPhase
+    name: str
+    index: int
+    total: int
+    op_kind: str | None = None
+    window: int | None = None
+    n_windows: int | None = None
+
+    @property
+    def fraction(self) -> float:
+        """Progress through this phase, in ``[0, 1]``.
+
+        Deliberately per-phase rather than a whole-run estimate: the runner
+        cannot know how the cost splits between loading, computing and writing
+        without timing it, and a confidently wrong overall percentage is worse
+        than an honest per-phase one.
+        """
+        if self.total <= 0:
+            return 1.0
+        return min(1.0, (self.index + 1) / self.total)
+
+    def describe(self) -> str:
+        """One line for a log or a terminal."""
+        where = f"{self.index + 1}/{self.total}"
+        if self.n_windows:
+            where += f" window {(self.window or 0) + 1}/{self.n_windows}"
+        kind = f" ({self.op_kind})" if self.op_kind else ""
+        return f"[{self.phase}] {where} {self.name}{kind}"
+
+
+class RunCancelled(CfdmodError):
+    """Raised when the caller's ``cancel`` predicate returned True.
+
+    Carries where the run stopped so a consumer can report it without parsing
+    the message. It is a :class:`~cfdmod.core.errors.CfdmodError`, not a bare
+    ``RuntimeError``, so "the user cancelled" is distinguishable from "the run
+    failed" -- they mean very different things to whatever is watching the job.
+    """
+
+    def __init__(self, phase: RunPhase, name: str) -> None:
+        super().__init__(f"run cancelled before {phase} {name!r}")
+        self.phase = phase
+        self.name = name

--- a/cfdmod/core/recipes/run_yaml.py
+++ b/cfdmod/core/recipes/run_yaml.py
@@ -45,6 +45,8 @@ def run_yaml(
     chunk_size: int | None = None,
     memory_budget: int | None = None,
     on_plan=None,
+    on_progress=None,
+    cancel=None,
 ) -> dict[str, DataSource]:
     """Load and run a v3 pipeline template.
 
@@ -64,6 +66,10 @@ def run_yaml(
             ``chunk_size``.
         on_plan: Called with the chosen
             :class:`~cfdmod.core.memory.ChunkPlan` before execution.
+        on_progress: Called with a :class:`~cfdmod.core.progress.RunEvent` per
+            input loaded, step run and output written.
+        cancel: Predicate polled at those boundaries; True raises
+            :class:`~cfdmod.core.progress.RunCancelled`.
 
     Returns:
         The dict of every named binding the runner produced (inputs +
@@ -86,6 +92,8 @@ def run_yaml(
         chunk_size=chunk_size,
         memory_budget=memory_budget,
         on_plan=on_plan,
+        on_progress=on_progress,
+        cancel=cancel,
     )
 
 

--- a/tests/core/test_run_template_progress.py
+++ b/tests/core/test_run_template_progress.py
@@ -1,0 +1,178 @@
+"""Progress reporting and cooperative cancellation on a template run."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.core import ElementMeta, SurfaceDataSource, TimeAxis, Topology
+from cfdmod.core.pipeline_yaml import PipelineTemplate, run_template
+from cfdmod.core.progress import RunCancelled, RunEvent
+
+pytestmark = pytest.mark.unit
+
+
+def _surface(n_elements: int = 6, n_timesteps: int = 32) -> SurfaceDataSource:
+    rng = np.random.default_rng(0)
+    verts = rng.random((n_elements * 3, 3))
+    tris = np.arange(n_elements * 3, dtype=np.int32).reshape(n_elements, 3)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=n_timesteps),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"pressure": rng.random((n_elements, n_timesteps)).astype(np.float32)}
+        ),
+    )
+
+
+def _template() -> PipelineTemplate:
+    return PipelineTemplate.model_validate(
+        {
+            "name": "progress",
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": "scaled",
+                    "kind": "scale",
+                    "source": "body",
+                    "field": "pressure",
+                    "factor": 2.0,
+                    "out": "cp",
+                },
+                {
+                    "id": "halved",
+                    "kind": "scale",
+                    "source": "scaled",
+                    "field": "cp",
+                    "factor": 0.5,
+                    "out": "cp_half",
+                },
+            ],
+            "outputs": {"result": {"source": "halved", "path": "out"}},
+        }
+    )
+
+
+def _storage() -> MemoryStorage:
+    storage = MemoryStorage()
+    storage.write_data_source("body", _surface())
+    return storage
+
+
+def test_every_phase_reports():
+    """Loading and writing are reported too.
+
+    A bar built only from the step phase sits at 0% while inputs load and jumps
+    to 100% before the write - which on a big case is where a real share of the
+    wall clock goes.
+    """
+    events: list[RunEvent] = []
+    run_template(_template(), storage=_storage(), on_progress=events.append)
+
+    assert [e.phase for e in events] == ["load", "step", "step", "write"]
+    assert [e.name for e in events] == ["body", "scaled", "halved", "result"]
+    assert [e.op_kind for e in events] == [None, "scale", "scale", None]
+
+
+def test_event_carries_position_and_fraction():
+    events: list[RunEvent] = []
+    run_template(_template(), storage=_storage(), on_progress=events.append)
+
+    steps = [e for e in events if e.phase == "step"]
+    assert [(e.index, e.total) for e in steps] == [(0, 2), (1, 2)]
+    assert [e.fraction for e in steps] == [0.5, 1.0]
+    assert "[step] 1/2 scaled (scale)" == steps[0].describe()
+
+
+def test_chunked_run_reports_the_window():
+    """Per-step events repeat per window, and say which window they are in."""
+    events: list[RunEvent] = []
+    run_template(_template(), storage=_storage(), chunk_size=8, on_progress=events.append)
+
+    steps = [e for e in events if e.phase == "step"]
+    # 32 timesteps / 8 = 4 windows x 2 steps.
+    assert len(steps) == 8
+    assert [e.window for e in steps[:2]] == [0, 0]
+    assert {e.n_windows for e in steps} == {4}
+    assert "window 1/4" in steps[0].describe()
+
+
+def test_unchunked_events_carry_no_window():
+    events: list[RunEvent] = []
+    run_template(_template(), storage=_storage(), on_progress=events.append)
+    assert all(e.window is None and e.n_windows is None for e in events)
+
+
+def test_cancel_stops_the_run_and_says_where():
+    """Cancelling before the second step must not run it."""
+    seen: list[str] = []
+
+    def cancel() -> bool:
+        return len(seen) >= 2  # after load + first step
+
+    def on_progress(event: RunEvent) -> None:
+        seen.append(event.name)
+
+    with pytest.raises(RunCancelled) as excinfo:
+        run_template(_template(), storage=_storage(), on_progress=on_progress, cancel=cancel)
+
+    assert excinfo.value.phase == "step"
+    assert excinfo.value.name == "halved"
+    assert seen == ["body", "scaled"]
+
+
+def test_cancel_before_a_write_leaves_nothing_written():
+    """The property that makes cancellation safe rather than merely fast."""
+    storage = _storage()
+    written_before = set(storage.keys())
+
+    with pytest.raises(RunCancelled) as excinfo:
+        run_template(
+            _template(),
+            storage=storage,
+            # Let everything compute, then refuse at the write boundary.
+            cancel=lambda: True,
+        )
+
+    assert excinfo.value.phase == "load"
+    assert set(storage.keys()) == written_before
+
+
+def test_cancel_is_polled_between_windows():
+    calls = {"n": 0}
+
+    def cancel() -> bool:
+        calls["n"] += 1
+        return calls["n"] > 3
+
+    with pytest.raises(RunCancelled):
+        run_template(_template(), storage=_storage(), chunk_size=8, cancel=cancel)
+
+
+def test_cancelled_is_a_cfdmod_error_not_a_bare_runtime_error():
+    """A service must be able to tell "user cancelled" from "run failed"."""
+    from cfdmod.core.errors import CfdmodError
+
+    assert issubclass(RunCancelled, CfdmodError)
+
+
+def test_no_callbacks_is_the_unchanged_path():
+    result = run_template(_template(), storage=_storage())
+    assert set(result) >= {"body", "scaled", "halved"}
+
+
+def test_progress_callback_raising_is_not_swallowed_as_cancellation():
+    """An exception in the caller's logging is a bug, not an abort."""
+
+    def boom(event: RunEvent) -> None:
+        raise KeyError("logging blew up")
+
+    with pytest.raises(KeyError):
+        run_template(_template(), storage=_storage(), on_progress=boom)
+
+
+@pytest.mark.parametrize(("index", "total", "expected"), [(0, 0, 1.0), (5, 3, 1.0), (0, 4, 0.25)])
+def test_fraction_is_bounded(index, total, expected):
+    assert RunEvent(phase="step", name="x", index=index, total=total).fraction == expected


### PR DESCRIPTION
Closes #223.

There was no progress or cancellation seam anywhere in the library. A post-processing run takes minutes; a caller - the CLI, and above all the interface - could only block.

## Two seams, kept separate

`run_template(..., on_progress=..., cancel=...)`.

Merging them ("the progress callback raises to cancel") reads neatly and behaves badly: any exception in a caller's logging code would then be indistinguishable from a deliberate abort. There is a test pinning that a raising `on_progress` propagates as itself.

## `RunEvent`

A frozen object, not a tuple, so fields can be added without breaking a caller's unpacking.

- Covers **`load`, `step` and `write`**. On a big case loading and writing are a real share of the wall clock; a bar built from the step phase alone sits at 0% through them and then jumps to 100%.
- Carries `window` / `n_windows` on a chunked run, so per-step events repeating once per window read as progress rather than as a bug.
- `fraction` is **per phase**, not whole-run. The runner cannot know how cost splits across loading, computing and writing without timing it, and a confidently wrong overall percentage is worse than an honest partial one.

## Cancellation

A predicate polled at boundaries: between steps, between time windows, and **before each write**. That last one is what makes it safe rather than merely fast - a cancelled run never leaves a partially written output set, and there is a test asserting storage is untouched.

cfdmod cannot interrupt a numpy call in flight and the docstring says so plainly rather than implying otherwise: a single very long op runs to completion before the run notices. Polling per *window* rather than per element is deliberate - a window is the unit of work that actually takes time.

`RunCancelled` subclasses `CfdmodError`, so a service can tell "the user cancelled" from "the run failed". Those mean very different things to whatever is watching the job.

## Also

The memory-budget symbols from the previous change (`ChunkPlan`, `plan_chunking`, `suggest_chunk_size`, ...) landed without being reachable from the public API. Exported here alongside the new ones, and `run_yaml` forwards all of them.

## Verified

- `uv run pytest --all-extras`: **865 collected, all passed**, exit 0. Includes `tests/test_import_weight.py`, so the new modules do not drag the heavy stack into `import cfdmod`.
- `uv run ruff check` / `format --check` clean.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered.