### PR TITLE
feat(core): release intermediates and declare persist/hold per output

### DIFF
--- a/cfdmod/core/pipeline_yaml.py
+++ b/cfdmod/core/pipeline_yaml.py
@@ -431,8 +431,17 @@ class OutputSpec(BaseModel):
         path: Destination path, resolved against the template root.
         format: Storage format tag. Only ``xdmf_h5`` is currently
             supported (the sole built-in :class:`Storage`).
+        persist: Whether to write this output through the storage.
+            ``False`` computes it and hands it back without touching disk --
+            what a service wants when it will serialise the result itself.
+        hold: Whether to keep this output in the dict ``run_template``
+            returns. ``False`` lets its arrays be released as soon as it has
+            been written, which is what a batch job wants.
         extras: Free-form fields forwarded to the storage adapter
             (e.g. ``group`` name for the H5 timeseries layout).
+
+    Setting both to ``False`` would compute an output and throw it away, so it
+    is rejected at validation.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -440,6 +449,8 @@ class OutputSpec(BaseModel):
     source: str
     path: str
     format: Literal["xdmf_h5"] = "xdmf_h5"
+    persist: bool = True
+    hold: bool = True
 
 
 class OpSpec(BaseModel):
@@ -668,6 +679,11 @@ def validate_template(template: PipelineTemplate) -> None:
                 f"output {out_name!r} references unknown source {out.source!r}; "
                 f"known: {sorted(known)}"
             )
+        if not out.persist and not out.hold:
+            raise TemplateError(
+                f"output {out_name!r} sets both persist and hold to false, so it would "
+                "be computed and discarded; drop the output instead"
+            )
 
 
 def _resolve_key(template_root: str | None, path: str) -> str:
@@ -805,6 +821,29 @@ def _plan_for(
     )
 
 
+def _last_use(template: PipelineTemplate) -> dict[str, int]:
+    """Step index after which each binding is no longer read.
+
+    A binding is live until the last step that names it as ``source`` or
+    ``rhs``; anything an output depends on is live to the end (represented by
+    an index past the last step). Used to drop the runner's reference to an
+    intermediate as soon as nothing downstream can ask for it -- the arrays
+    then go when Python's refcount hits zero, which is the only safe way to
+    release them: bindings share field arrays by reference, so the runner must
+    never reach in and mutate a store.
+    """
+    end = len(template.pipeline)
+    last: dict[str, int] = {}
+    for i, step in enumerate(template.pipeline):
+        for ref in (step.source, step.rhs):
+            if ref:
+                last[ref] = i
+        last[step.id or f"step_{i}"] = last.get(step.id or f"step_{i}", i)
+    for out in template.outputs.values():
+        last[out.source] = end
+    return last
+
+
 def _retained_bindings(template: PipelineTemplate) -> set[str] | None:
     """Step ids whose per-window results must be kept, or ``None`` for all.
 
@@ -860,6 +899,7 @@ def _walk_chunked(
     needed_steps: set[str] | None,
     plan: "ChunkPlan",
     reporter: "_Reporter" = _NULL_REPORTER,
+    last_use: dict[str, int] | None = None,
 ) -> dict[str, DataSource]:
     """Run the step walk once per time window and concatenate the results.
 
@@ -895,7 +935,13 @@ def _walk_chunked(
             for name, ds in bindings.items()
         }
         produced = _walk_steps(
-            template, window, needed_steps, reporter, window_index=w, n_windows=len(windows)
+            template,
+            window,
+            needed_steps,
+            reporter,
+            window_index=w,
+            n_windows=len(windows),
+            last_use=last_use,
         )
         for name, ds in produced.items():
             if retain is not None and name not in retain:
@@ -924,6 +970,7 @@ def run_template(
     on_plan: Callable[["ChunkPlan"], None] | None = None,
     on_progress: Callable[["RunEvent"], None] | None = None,
     cancel: Callable[[], bool] | None = None,
+    return_all: bool = False,
 ) -> dict[str, DataSource]:
     """Run a parsed template against a :class:`Storage`.
 
@@ -984,6 +1031,15 @@ def run_template(
             interrupt a numpy call in flight, so a run stops at the next
             boundary -- but the check precedes every write, so a cancelled run
             never leaves a partially written output set.
+        return_all: Keep every intermediate binding alive and return it. Off by
+            default: the runner otherwise drops each binding once no remaining
+            step or output reads it, so the peak of a run is its widest live
+            set rather than the sum of everything it ever computed. Turn it on
+            for notebook work where inspecting intermediates is the point.
+
+    Returns:
+        The inputs, plus the outputs declared with ``hold: true`` (the
+        default), plus -- with ``return_all`` -- every intermediate.
     """
     _populate_default_registry()
     # Static validation first: fail on typos/dangling refs before any I/O.
@@ -1013,6 +1069,9 @@ def run_template(
     # 1. Load inputs (all, or -- under skip_fresh -- only those the stale
     #    outputs depend on).
     reporter = _Reporter(on_progress, cancel)
+    # With no declared outputs there is nothing to select on, so keep
+    # everything -- that template is being run for its intermediates.
+    last_use = None if (return_all or not template.outputs) else _last_use(template)
     accepts_kind = _accepts_kind(storage)
     bindings: dict[str, DataSource] = {}
     n_inputs = len(template.inputs)
@@ -1064,12 +1123,19 @@ def run_template(
 
     # 3. Walk pipeline, over the whole time axis or one window at a time.
     if plan.is_chunked:
-        bindings = _walk_chunked(template, bindings, needed_steps, plan, reporter)
+        bindings = _walk_chunked(template, bindings, needed_steps, plan, reporter, last_use)
     else:
-        bindings = _walk_steps(template, bindings, needed_steps, reporter)
+        bindings = _walk_steps(template, bindings, needed_steps, reporter, last_use=last_use)
 
     return _write_outputs(
-        template, bindings, storage, stale_outputs, supports_freshness, strategy, reporter
+        template,
+        bindings,
+        storage,
+        stale_outputs,
+        supports_freshness,
+        strategy,
+        reporter,
+        return_all,
     )
 
 
@@ -1081,6 +1147,7 @@ def _walk_steps(
     *,
     window_index: int | None = None,
     n_windows: int | None = None,
+    last_use: dict[str, int] | None = None,
 ) -> dict[str, DataSource]:
     """Execute the template's steps against ``bindings``, returning them extended.
 
@@ -1145,6 +1212,13 @@ def _walk_steps(
 
         bindings[step_id] = result
 
+        # Drop our reference to anything no downstream step or output reads.
+        # Refcounting frees the arrays; we never mutate a store, because
+        # bindings share field arrays and another binding may still hold one.
+        if last_use is not None:
+            for name in [n for n, last in last_use.items() if last <= i and n in bindings]:
+                del bindings[name]
+
     return bindings
 
 
@@ -1156,28 +1230,43 @@ def _write_outputs(
     supports_freshness: bool,
     strategy: str,
     reporter: "_Reporter" = _NULL_REPORTER,
+    return_all: bool = False,
 ) -> dict[str, DataSource]:
     """Write the ``outputs:`` block, stamping freshness where supported.
+
+    Honours each output's ``persist`` / ``hold``: ``persist: false`` computes it
+    without touching storage, ``hold: false`` drops it from the returned dict
+    once written.
 
     Cancellation is polled before each write, so a cancelled run never leaves a
     partially written output set.
     """
     sign = None
-    if supports_freshness and template.outputs:
+    if supports_freshness and any(o.persist for o in template.outputs.values()):
         from cfdmod.core.freshness import signature as sign
 
     total = len(template.outputs)
+    dropped: set[str] = set()
     for i, (out_name, out) in enumerate(template.outputs.items()):
         if stale_outputs is not None and out_name not in stale_outputs:
             continue
-        reporter.check("write", out_name)
-        reporter.emit("write", out_name, i, total)
         if out.source not in bindings:
             raise TemplateReferenceError(f"output references unknown source {out.source!r}")
-        key = _resolve_key(template.root, out.path)
-        storage.write_data_source(key, bindings[out.source])
-        if sign is not None:
-            storage.write_signature(key, sign(template, out_name, storage, strategy))
+        if out.persist:
+            reporter.check("write", out_name)
+            reporter.emit("write", out_name, i, total)
+            key = _resolve_key(template.root, out.path)
+            storage.write_data_source(key, bindings[out.source])
+            if sign is not None:
+                storage.write_signature(key, sign(template, out_name, storage, strategy))
+        if not out.hold:
+            dropped.add(out.source)
+
+    # An output source is only released if *no* output that holds shares it.
+    if not return_all:
+        kept = {o.source for o in template.outputs.values() if o.hold}
+        for name in dropped - kept:
+            bindings.pop(name, None)
 
     return bindings
 

--- a/tests/core/test_run_template_outputs.py
+++ b/tests/core/test_run_template_outputs.py
@@ -1,0 +1,208 @@
+"""What a run keeps, what it writes, and what it lets go.
+
+`run_template` used to return every binding it ever computed - inputs and all
+intermediates - and each kept its field arrays reachable. In a notebook that is
+a feature; in a service job it means the peak of a run is the sum of everything
+it computed rather than its widest live set.
+"""
+
+from __future__ import annotations
+
+import gc
+import tracemalloc
+import weakref
+
+import numpy as np
+import pytest
+
+from cfdmod.adapters.memory import MemoryFieldStore, MemoryStorage
+from cfdmod.core import ElementMeta, SurfaceDataSource, TimeAxis, Topology
+from cfdmod.core.errors import TemplateError
+from cfdmod.core.pipeline_yaml import PipelineTemplate, run_template, validate_template
+
+pytestmark = pytest.mark.unit
+
+
+def _surface(n_elements: int = 6, n_timesteps: int = 8) -> SurfaceDataSource:
+    rng = np.random.default_rng(0)
+    verts = rng.random((n_elements * 3, 3))
+    tris = np.arange(n_elements * 3, dtype=np.int32).reshape(n_elements, 3)
+    return SurfaceDataSource(
+        time=TimeAxis(initial_time=0.0, timestep_size=0.1, n_timesteps=n_timesteps),
+        topology=Topology.triangles(tris, verts),
+        elements=ElementMeta(),
+        fields=MemoryFieldStore(
+            {"pressure": rng.random((n_elements, n_timesteps)).astype(np.float32)}
+        ),
+    )
+
+
+def _template(outputs: dict) -> PipelineTemplate:
+    return PipelineTemplate.model_validate(
+        {
+            "name": "outputs",
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": "a",
+                    "kind": "scale",
+                    "source": "body",
+                    "field": "pressure",
+                    "factor": 2.0,
+                    "out": "cp",
+                },
+                {
+                    "id": "b",
+                    "kind": "scale",
+                    "source": "a",
+                    "field": "cp",
+                    "factor": 0.5,
+                    "out": "cp_half",
+                },
+            ],
+            "outputs": outputs,
+        }
+    )
+
+
+def _storage(n_elements: int = 6, n_timesteps: int = 8) -> MemoryStorage:
+    storage = MemoryStorage()
+    storage.write_data_source("body", _surface(n_elements, n_timesteps))
+    return storage
+
+
+def test_intermediates_are_not_returned_by_default():
+    """`a` is read only by `b`; nothing downstream can ask for it again."""
+    result = run_template(_template({"o": {"source": "b", "path": "out"}}), storage=_storage())
+
+    assert "b" in result
+    assert "a" not in result
+
+
+def test_return_all_keeps_them():
+    result = run_template(
+        _template({"o": {"source": "b", "path": "out"}}), storage=_storage(), return_all=True
+    )
+    assert {"a", "b"} <= set(result)
+
+
+def test_a_template_with_no_outputs_keeps_everything():
+    """Nothing to select on -- that template is being run for its intermediates."""
+    result = run_template(_template({}), storage=_storage())
+    assert {"a", "b"} <= set(result)
+
+
+def test_a_released_intermediate_is_actually_unreachable():
+    """A weakref, not an absent dict key.
+
+    Dropping the name while something else still holds the object would look
+    identical from the outside and free nothing.
+    """
+    storage = _storage()
+    full = run_template(
+        _template({"o": {"source": "b", "path": "out"}}), storage=storage, return_all=True
+    )
+    ref = weakref.ref(full["a"])
+    del full
+    gc.collect()
+    assert ref() is None
+
+
+def test_persist_false_computes_without_writing():
+    storage = _storage()
+    before = set(storage.keys())
+    result = run_template(
+        _template({"o": {"source": "b", "path": "out", "persist": False}}), storage=storage
+    )
+
+    assert set(storage.keys()) == before
+    assert "b" in result  # it was still computed and handed back
+
+
+def test_hold_false_writes_and_drops():
+    storage = _storage()
+    result = run_template(
+        _template({"o": {"source": "b", "path": "out", "hold": False}}), storage=storage
+    )
+
+    assert "out" in set(storage.keys())
+    assert "b" not in result
+
+
+def test_hold_false_is_ignored_when_another_output_holds_the_same_source():
+    """Two outputs, one source: dropping it would break the one that holds."""
+    storage = _storage()
+    result = run_template(
+        _template(
+            {
+                "written": {"source": "b", "path": "out", "hold": False},
+                "kept": {"source": "b", "path": "out2"},
+            }
+        ),
+        storage=storage,
+    )
+    assert "b" in result
+
+
+def test_persist_and_hold_both_false_is_rejected():
+    """Computing something and throwing it away is a template bug, not a mode."""
+    template = _template({"o": {"source": "b", "path": "out", "persist": False, "hold": False}})
+    with pytest.raises(TemplateError, match="computed and discarded"):
+        validate_template(template)
+
+
+def test_defaults_are_unchanged_behaviour():
+    storage = _storage()
+    result = run_template(_template({"o": {"source": "b", "path": "out"}}), storage=storage)
+    assert "out" in set(storage.keys())
+    assert "b" in result
+
+
+def test_releasing_intermediates_lowers_the_peak():
+    """Measured. A four-step chain over a large input holds one stage, not four.
+
+    The steps rewrite ``pressure`` in place rather than using ``out:``. That is
+    not incidental: an op given ``out:`` *adds* a field, so every later stage
+    keeps the earlier ones reachable through its own store and dropping the
+    binding frees nothing. Releasing intermediates only recovers memory for
+    ops that replace rather than accumulate -- which is the common shape
+    (Cp -> per-floor Cf/Cm) but is worth knowing.
+    """
+    n_elements, n_timesteps = 20_000, 400
+    template = PipelineTemplate.model_validate(
+        {
+            "name": "chain",
+            "inputs": {"body": {"kind": "surface", "path": "body", "field": "pressure"}},
+            "pipeline": [
+                {
+                    "id": f"s{i}",
+                    "kind": "scale",
+                    "source": "body" if i == 0 else f"s{i - 1}",
+                    "field": "pressure",
+                    "factor": 1.5,
+                }
+                for i in range(4)
+            ],
+            "outputs": {"o": {"source": "s3", "path": "out", "persist": False}},
+        }
+    )
+
+    def peak(**kwargs) -> int:
+        storage = _storage(n_elements, n_timesteps)
+        tracemalloc.start()
+        try:
+            run_template(template, storage=storage, **kwargs)
+            return tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+
+    all_kept = peak(return_all=True)
+    released = peak()
+
+    field_bytes = n_elements * n_timesteps * 4
+    assert released < all_kept, (
+        f"releasing intermediates peaked at {released / 1e6:.1f} MB, "
+        f"not below {all_kept / 1e6:.1f} MB with everything kept"
+    )
+    # Four stages kept is roughly four copies; releasing should stay near one.
+    assert released < all_kept - field_bytes

--- a/tests/core/test_run_template_progress.py
+++ b/tests/core/test_run_template_progress.py
@@ -159,7 +159,9 @@ def test_cancelled_is_a_cfdmod_error_not_a_bare_runtime_error():
 
 
 def test_no_callbacks_is_the_unchanged_path():
-    result = run_template(_template(), storage=_storage())
+    # Intermediates are released once nothing downstream reads them, so the
+    # notebook view needs return_all -- see test_run_template_outputs.py.
+    result = run_template(_template(), storage=_storage(), return_all=True)
     assert set(result) >= {"body", "scaled", "halved"}
 
 


### PR DESCRIPTION
Closes #224.

`run_template` returned **every** binding it ever computed - inputs and all intermediates - each keeping its field arrays reachable. So the peak of a run was the sum of everything it computed, not its widest live set, and nothing could be freed early.

## Three changes

**`OutputSpec.persist` / `OutputSpec.hold`**, both defaulting to `true`, so existing templates behave identically.

```yaml
outputs:
  cp:    { source: cp,    path: cp.h5 }                  # write and return
  stats: { source: stats, path: -, persist: false }      # return only
  bulk:  { source: bulk,  path: bulk.h5, hold: false }   # write and let go
```

Both `false` is **rejected at validation** - computing an output in order to discard it is a template bug, not a mode.

**Intermediates are released once no remaining step or output reads them.** No new syntax: the step DAG already says when a binding's last reader is done. The runner drops its own reference and lets refcounting free the arrays - it never reaches into a store, because bindings share field arrays by reference and another binding may still hold one.

**`return_all=True`** restores the old behaviour for notebook work.

A template with **no declared outputs keeps everything**, since there is nothing to select on - that template is being run for its intermediates. This keeps most existing tests and tutorials working unchanged.

## Measured

Four-stage chain over 20 000 elements x 400 timesteps, `tracemalloc` peak:

| | peak |
|---|---|
| `return_all=True` | 128.0 MB |
| default (released) | **64.0 MB** |

## One caveat the tests document

This only recovers memory for ops that **replace** fields rather than accumulate them. An op given `out:` *adds* a field, so every later stage keeps the earlier arrays reachable through its own store and dropping the binding frees nothing. Found by measuring: my first version of the peak test used `out:` at each stage and showed 128 MB both ways. The common shape (Cp -> per-floor Cf/Cm) replaces, so the win is real there, but the docstring says it rather than implying a universal saving.

## Behaviour change

Undeclared intermediates are no longer returned when a template declares outputs. That is the point of the issue. `return_all=True` is the way back; one test from the previous PR was updated to use it.

## Verified

- `uv run pytest --all-extras`: **875 collected, all passed**, exit 0.
- `uv run ruff check` / `format --check` clean.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered.