### PR TITLE
fix(logger): stop configuring logging at import

### DIFF
--- a/cfdmod/__main__.py
+++ b/cfdmod/__main__.py
@@ -11,6 +11,29 @@ from cfdmod.regroup.cli import app as regroup_app
 from cfdmod.roughness.cli import app as roughness_app
 
 app = typer.Typer()
+
+
+@app.callback()
+def _main(
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Show DEBUG-level logs."),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Show warnings and errors only."),
+) -> None:
+    """Post-processing and geometry preparation for CFD wind tunnel simulations."""
+    # The library configures no logging at import (that is an application's
+    # job); the CLI *is* the application, so it opts in here. Diagnostics go to
+    # stderr so a command's real output stays pipeable, and colour follows
+    # isatty so a redirected run does not collect escape codes.
+    import logging
+
+    from cfdmod.logger import configure_logging
+
+    if verbose and quiet:
+        typer.echo("error: pass --verbose or --quiet, not both", err=True)
+        raise typer.Exit(code=1)
+    level = logging.DEBUG if verbose else logging.WARNING if quiet else logging.INFO
+    configure_logging(level)
+
+
 app.add_typer(altimetry_app, name="altimetry")
 app.add_typer(dynamics_app, name="dynamics", help="Convert TQS/Eberick structural exports.")
 app.add_typer(loft_app, name="loft", help="Generate terrain loft surfaces.")

--- a/cfdmod/core/protocols.py
+++ b/cfdmod/core/protocols.py
@@ -18,9 +18,11 @@ Three protocols matter most:
   layer never imports ``h5py``.
 - :class:`Storage` -- whole-:class:`DataSource` round-trips. Pairs
   with one ``FieldStore`` per data source.
-- :class:`Logger` and :class:`Pool` -- bundled in the shell
-  ``Context`` and passed explicitly to recipes. Default to the
-  no-op stubs in the memory adapter when not supplied.
+- :class:`Logger` -- the structured-log seam. Ops and recipes stay pure
+  and log nothing; the shell that drives them (CLI, notebook, service)
+  owns logging. A component that does need to report progress takes a
+  :class:`Logger` explicitly rather than importing a global.
+- :class:`Pool` -- parallel-fanout seam for :class:`Container.map_values`.
 """
 
 from __future__ import annotations
@@ -249,12 +251,16 @@ class BlobStore(Protocol):
 
 @runtime_checkable
 class Logger(Protocol):
-    """Minimal structured-log seam used by the shell.
+    """Minimal structured-log seam.
 
-    The core package never imports ``loguru`` directly; instead it
-    receives a :class:`Logger` via :class:`Context`. Tests pass a no-op
-    or a list-collector for assertions. Production CLIs adapt
-    ``loguru`` into this protocol.
+    Anything in the core that needs to report takes one of these as an
+    argument rather than importing a module-level logger, so a caller can
+    pass a per-job logger and a test can pass a list-collector and assert
+    on it. ``logging.Logger`` satisfies the protocol structurally, so
+    ``cfdmod.logger.logger`` is a valid value with no adapter.
+
+    The core does not configure logging and neither does importing cfdmod:
+    see :mod:`cfdmod.logger`.
     """
 
     def info(self, message: str, /, **fields: Any) -> None: ...

--- a/cfdmod/logger.py
+++ b/cfdmod/logger.py
@@ -1,36 +1,110 @@
+"""The library's logger, and the opt-in console configuration for the CLI.
+
+A library gets a named logger and a ``NullHandler``; the application decides
+level, destination and format. This module used to do the opposite -- at import
+it set ``DEBUG`` on the ``cfdmod`` logger and attached a colour
+``StreamHandler`` to stdout -- which took over logging for anything that
+imported cfdmod. A service got unfiltered, ANSI-wrapped DEBUG in its job log
+and no way to redirect it without reaching in and mutating the logger object.
+
+So: importing cfdmod now configures nothing. The colour formatter is still
+here, behind :func:`configure_logging`, which the CLI calls -- the terminal
+experience is unchanged, it is just a choice now. Colour follows ``isatty``
+rather than being emitted unconditionally, so a redirected run gets plain text
+instead of escape codes in the file.
+"""
+
+from __future__ import annotations
+
+__all__ = ["logger", "configure_logging", "CustomFormatter", "LOGGER_NAME"]
+
 import logging
 import sys
 
-from colorama import Fore
+LOGGER_NAME = "cfdmod"
 
-__all__ = ["logger"]
+_FMT = "[%(asctime)s] [%(levelname)s] - %(name)s - %(message)s"
+
+# Marks the handler configure_logging installed, so a second call replaces it
+# instead of stacking another one and printing everything twice.
+_CONSOLE_FLAG = "_cfdmod_console"
 
 
 class CustomFormatter(logging.Formatter):
-    fmt_str = "[%(asctime)s] [%(levelname)s] - %(name)s - %(message)s"
+    """Level-coloured console formatter.
 
-    FORMATS = {
-        logging.DEBUG: f"{Fore.LIGHTMAGENTA_EX}{fmt_str}{Fore.RESET}",
-        logging.INFO: f"{Fore.WHITE}{fmt_str}{Fore.RESET}",
-        logging.WARNING: f"{Fore.YELLOW}{fmt_str}{Fore.RESET}",
-        logging.ERROR: f"{Fore.LIGHTRED_EX}{fmt_str}{Fore.RESET}",
-        logging.CRITICAL: f"{Fore.RED}{fmt_str}{Fore.RESET}",
-    }
+    Colour is a constructor argument rather than always-on: writing escape
+    codes into a redirected log file helps nobody.
+    """
 
-    def format(self, record):
-        log_fmt = self.FORMATS.get(record.levelno)
-        formatter = logging.Formatter(log_fmt)
+    fmt_str = _FMT
+
+    def __init__(self, *, color: bool = True) -> None:
+        super().__init__(_FMT)
+        self.color = color
+        self._by_level: dict[int, logging.Formatter] = {}
+        if not color:
+            return
+        from colorama import Fore
+
+        for level, shade in (
+            (logging.DEBUG, Fore.LIGHTMAGENTA_EX),
+            (logging.INFO, Fore.WHITE),
+            (logging.WARNING, Fore.YELLOW),
+            (logging.ERROR, Fore.LIGHTRED_EX),
+            (logging.CRITICAL, Fore.RED),
+        ):
+            self._by_level[level] = logging.Formatter(f"{shade}{_FMT}{Fore.RESET}")
+
+    def format(self, record: logging.LogRecord) -> str:
+        formatter = self._by_level.get(record.levelno)
+        if formatter is None:
+            return super().format(record)
         return formatter.format(record)
 
 
-# create logger with 'spam_application'
-logger = logging.getLogger("cfdmod")
-logger.setLevel(logging.DEBUG)
+# The library's logger. No level and no real handler: whatever imports cfdmod
+# decides those. NullHandler exists only to suppress the "no handlers" warning.
+logger = logging.getLogger(LOGGER_NAME)
+logger.addHandler(logging.NullHandler())
 
-# create console handler with a higher log level
-ch = logging.StreamHandler(sys.stdout)
-ch.setLevel(logging.DEBUG)
 
-ch.setFormatter(CustomFormatter())
+def configure_logging(
+    level: int | str = logging.INFO,
+    *,
+    stream=None,
+    color: bool | None = None,
+) -> logging.Handler:
+    """Attach a console handler to the ``cfdmod`` logger. **Applications only.**
 
-logger.addHandler(ch)
+    Library code must never call this. The CLI does, which is why the terminal
+    output is unchanged; anything embedding cfdmod configures logging its own
+    way and is not overridden.
+
+    Idempotent: a second call replaces the handler the first one installed.
+
+    Args:
+        level: Level to set on the ``cfdmod`` logger.
+        stream: Destination, default ``sys.stderr``. Logs are diagnostics, and
+            keeping them off stdout is what lets a command's real output be
+            piped. (The old import-time handler wrote to stdout, mixing the
+            two.)
+        color: Force colour on or off. ``None`` auto-detects ``isatty``.
+
+    Returns:
+        The installed handler, so a caller can tune or remove it.
+    """
+    destination = sys.stderr if stream is None else stream
+    if color is None:
+        color = bool(getattr(destination, "isatty", lambda: False)())
+
+    for existing in list(logger.handlers):
+        if getattr(existing, _CONSOLE_FLAG, False):
+            logger.removeHandler(existing)
+
+    handler = logging.StreamHandler(destination)
+    handler.setFormatter(CustomFormatter(color=color))
+    setattr(handler, _CONSOLE_FLAG, True)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+    return handler

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,119 @@
+"""Importing cfdmod must not configure logging; the CLI opts in.
+
+`cfdmod/logger.py` used to set DEBUG on the `cfdmod` logger and attach a colour
+StreamHandler to stdout at import. A library doing that takes over logging for
+whatever imports it: a service got unfiltered ANSI-wrapped DEBUG in its job log
+with no way to redirect it, and a notebook got the same chatter.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from cfdmod.logger import LOGGER_NAME, CustomFormatter, configure_logging, logger
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def restore_logger_state():
+    """Leave the ``cfdmod`` logger exactly as found."""
+    handlers = list(logger.handlers)
+    level = logger.level
+    yield
+    logger.handlers[:] = handlers
+    logger.setLevel(level)
+
+
+def test_importing_cfdmod_installs_only_a_null_handler():
+    """Run in a fresh interpreter: a test that already imported cfdmod would
+    not notice a handler added at import time."""
+    code = textwrap.dedent(
+        """
+        import logging, sys
+        import cfdmod
+        import cfdmod.logger  # the module that used to configure at import
+        lg = logging.getLogger("cfdmod")
+        real = [h for h in lg.handlers if not isinstance(h, logging.NullHandler)]
+        print(f"handlers={len(real)} level={lg.level} root={len(logging.root.handlers)}")
+        """
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], check=True, capture_output=True, text=True
+    ).stdout.strip()
+    # level 0 == NOTSET: the library states no opinion.
+    assert out == "handlers=0 level=0 root=0"
+
+
+def test_configure_logging_attaches_a_handler_and_sets_the_level():
+    stream = io.StringIO()
+    configure_logging(logging.DEBUG, stream=stream, color=False)
+
+    logger.debug("hello")
+    assert "hello" in stream.getvalue()
+    assert logger.level == logging.DEBUG
+
+
+def test_configure_logging_is_idempotent():
+    """A second call must replace, not stack -- otherwise output doubles."""
+    stream = io.StringIO()
+    configure_logging(logging.INFO, stream=stream, color=False)
+    configure_logging(logging.INFO, stream=stream, color=False)
+
+    logger.info("once")
+    assert stream.getvalue().count("once") == 1
+
+
+def test_configure_logging_defaults_to_stderr():
+    """Diagnostics off stdout, so a command's real output stays pipeable."""
+    handler = configure_logging(logging.INFO)
+    assert handler.stream is sys.stderr
+
+
+def test_colour_follows_isatty_by_default():
+    """A redirected run must not collect escape codes."""
+    not_a_tty = io.StringIO()
+    configure_logging(logging.INFO, stream=not_a_tty)
+    logger.info("plain")
+    assert "\x1b[" not in not_a_tty.getvalue()
+
+
+def test_colour_can_be_forced_on():
+    stream = io.StringIO()
+    configure_logging(logging.INFO, stream=stream, color=True)
+    logger.info("bright")
+    assert "\x1b[" in stream.getvalue()
+
+
+def test_formatter_without_colour_emits_no_escape_codes():
+    record = logging.LogRecord(LOGGER_NAME, logging.WARNING, __file__, 1, "msg", None, None)
+    assert "\x1b[" not in CustomFormatter(color=False).format(record)
+
+
+def test_an_unconfigured_library_logger_emits_nothing():
+    """The state an embedding application starts from."""
+    logger.handlers[:] = [logging.NullHandler()]
+    logger.setLevel(logging.NOTSET)
+
+    stream = io.StringIO()
+    captured = logging.StreamHandler(stream)
+    logging.getLogger().addHandler(captured)
+    try:
+        logger.debug("should not appear anywhere")
+    finally:
+        logging.getLogger().removeHandler(captured)
+
+    assert stream.getvalue() == ""
+
+
+def test_logging_logger_satisfies_the_logger_protocol():
+    """`Logger` is structural, so no adapter is needed to inject the real one."""
+    from cfdmod.core.protocols import Logger
+
+    assert isinstance(logger, Logger)


### PR DESCRIPTION
Closes #226.

`cfdmod/logger.py` ran this at import:

```python
logger.setLevel(logging.DEBUG)
ch = logging.StreamHandler(sys.stdout)
ch.setFormatter(CustomFormatter())   # unconditional ANSI colour
logger.addHandler(ch)
```

A library that attaches a handler and forces a level takes over logging for whatever imports it. A service got unfiltered, colour-wrapped DEBUG in its job log and could not lower, redirect or reformat it without mutating cfdmod's logger object.

## The fix

Importing cfdmod configures **nothing** - a named logger plus `NullHandler`, per the stdlib convention. The colour formatter stays, behind `configure_logging()`, which the CLI calls. The terminal experience is unchanged; it is now a choice.

Two deliberate changes inside that opt-in:

- **stderr, not stdout.** Logs are diagnostics; keeping them off stdout is what lets a command's real output be piped.
- **Colour follows `isatty`** unless forced, so `cfdmod run > log.txt` gets plain text rather than escape codes in the file.

`configure_logging` is idempotent - a second call replaces its handler instead of stacking one and printing everything twice.

`cfdmod --verbose` / `--quiet` select the level.

## The other half of the issue

The `Logger` protocol's docstring said it was "bundled in the shell `Context` and passed explicitly to recipes". **There is no `Context` class in the repo** - the seam was documented against something that was never written.

Rather than invent one: `logging.Logger` already satisfies `Logger` structurally, so injecting a per-job logger needs no adapter and no new type. The docstring now says that, and there is a test asserting `isinstance(logger, Logger)` so the claim cannot rot. Ops and recipes remain pure and log nothing, which is the design - a component that does need to report takes a `Logger` argument rather than importing a global.

## Tests

`tests/test_logging.py`. The import check runs in a **fresh interpreter** - a test that had already imported cfdmod could not observe a handler added at import time. It asserts zero non-null handlers, level `NOTSET`, and an untouched root logger.

## Verified

- `uv run pytest --all-extras`: **884 collected, all passed**, exit 0.
- `uv run ruff check` / `format --check` clean.
- `cfdmod --help` shows `--verbose` / `--quiet`.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered.