### PR TITLE
fix(building): make the fan-out solve_fn picklable so a real Pool works

### DIFF
--- a/cfdmod/building/__init__.py
+++ b/cfdmod/building/__init__.py
@@ -36,6 +36,7 @@ from cfdmod.building.modes_report import (
 from cfdmod.building.fanout import (
     FanoutPlan,
     StaticCaseKey,
+    StaticSolveFn,
     build_static_keys,
     build_static_solve_fn,
     default_storage_key,
@@ -97,6 +98,7 @@ __all__ = [
     "save_load_case_tables",
     "FanoutPlan",
     "StaticCaseKey",
+    "StaticSolveFn",
     "build_static_keys",
     "build_static_solve_fn",
     "default_storage_key",

--- a/cfdmod/building/fanout.py
+++ b/cfdmod/building/fanout.py
@@ -24,7 +24,10 @@ Design notes / best-guess calls (flagged for review):
   future refinement); provenance (region info + config) is written once.
 - With a real multiprocessing ``Pool`` the ``solve_fn`` must be picklable, so it
   re-reads its inputs from ``storage`` inside the worker rather than closing over
-  large in-RAM DataSources.
+  large in-RAM DataSources. It is a :class:`StaticSolveFn` -- a module-level
+  callable object -- and not a closure, because pickle refuses a function
+  defined inside another function and the fan-out would fail on its first
+  dispatch.
 """
 
 from __future__ import annotations
@@ -35,6 +38,7 @@ __all__ = [
     "build_static_keys",
     "default_storage_key",
     "build_static_solve_fn",
+    "StaticSolveFn",
     "run_fanout",
     "dump_provenance",
 ]
@@ -163,6 +167,89 @@ def default_storage_key(kind: str, key: StaticCaseKey) -> str:
     raise ValueError(f"unknown storage key kind {kind!r}")
 
 
+class StaticSolveFn:
+    """The default per-key pipeline, as a picklable callable.
+
+    A closure would read better and cannot cross a process boundary: pickle
+    refuses a function defined inside another function, so
+    ``run_fanout(pool=multiprocessing.Pool())`` failed on the very first
+    dispatch. A module-level class with picklable attributes is the shape that
+    actually survives the trip.
+
+    It holds no data source. Its state is the case, the storage handle, the
+    mesh path and the scalar options; each call re-reads its body and reference
+    pressure from ``storage`` inside the worker, so nothing large is shipped
+    per task.
+
+    A custom ``key_for`` must itself be picklable for pool use -- a module-level
+    function or a callable object, not a lambda. The default template path has
+    no such constraint.
+    """
+
+    def __init__(
+        self,
+        *,
+        case: BuildingCase,
+        storage,
+        mesh_path: str,
+        structure=None,
+        method: str = "face_cut",
+        damping_ratio: float = 0.02,
+        check_sampling: bool = True,
+        point: tuple[float, float] = (0.0, 0.0),
+        cp_statistics: list[str] | None = None,
+        body_key_template: str = DEFAULT_BODY_KEY,
+        pref_key_template: str = DEFAULT_PREF_KEY,
+        key_for: Callable[[str, StaticCaseKey], str] | None = None,
+    ) -> None:
+        self.case = case
+        self.storage = storage
+        self.mesh_path = mesh_path
+        self.structure = structure
+        self.method = method
+        self.damping_ratio = damping_ratio
+        self.check_sampling = check_sampling
+        self.point = point
+        self.cp_statistics = cp_statistics
+        self.body_key_template = body_key_template
+        self.pref_key_template = pref_key_template
+        self.key_for = key_for
+
+    def storage_key(self, kind: str, key: StaticCaseKey) -> str:
+        if self.key_for is not None:
+            return self.key_for(kind, key)
+        template = self.body_key_template if kind == "body" else self.pref_key_template
+        return template.format(direction=key.direction, body=key.body, cp_config=key.cp_config)
+
+    def __call__(self, key: StaticCaseKey) -> PointsDataSource:
+        case = self.case
+        body = self.storage.read_data_source(self.storage_key("body", key))
+        p_ref = self.storage.read_data_source(self.storage_key("p_ref", key))
+        cp = cp_from_pressure(body, p_ref, case, statistics=self.cp_statistics)
+        cf = cf_per_floor(cp, self.mesh_path, case, method=self.method)
+        cm = cm_per_floor(cp, self.mesh_path, case, method=self.method)
+        load = floor_load_source(cf, cm, case)
+        struct = (
+            self.structure
+            if self.structure is not None
+            else example_building_structure(case, load.n_elements)
+        )
+        response = solve_building_response(
+            load,
+            struct,
+            damping_ratio=self.damping_ratio,
+            check_sampling=self.check_sampling,
+        )
+        result = floor_accelerations(response, struct, point=self.point)
+        # attach the applied-static floor loads so get_stats_forces_effective /
+        # effective_load_stats combine them with the dynamic static-equivalent
+        return (
+            result.with_field("fs_x", load.fields.read("cf_x"))
+            .with_field("fs_y", load.fields.read("cf_y"))
+            .with_field("ms_z", load.fields.read("cm_z"))
+        )
+
+
 def build_static_solve_fn(
     case: BuildingCase,
     storage,
@@ -180,48 +267,33 @@ def build_static_solve_fn(
 ) -> Callable[[StaticCaseKey], PointsDataSource]:
     """Build the default per-key pipeline: storage -> Cp -> Cf/Cm -> response.
 
-    Returns a ``solve_fn(key) -> response`` (a floor ``PointsDataSource`` carrying
+    Returns a :class:`StaticSolveFn` -- a callable ``solve_fn(key) -> response``
+    (a floor ``PointsDataSource`` carrying
     ``feq_*`` / ``meq_z``, ``acc_*`` / ``acc_mag`` and the applied-static floor
     loads ``fs_x`` / ``fs_y`` / ``ms_z`` so downstream *effective* stats can
     combine them). Reads its body / reference pressure from ``storage`` inside the
-    call so it stays picklable for a multiprocessing ``Pool``.
+    call, and is a module-level callable object rather than a closure, so it
+    pickles and can cross a process boundary into a multiprocessing ``Pool``.
 
     The ``(direction, body)`` -> storage-key mapping is case-specific: pass
     ``body_key_template`` / ``pref_key_template`` (``str.format`` templates with
     ``{direction}`` / ``{body}`` / ``{cp_config}`` placeholders) or a full
     ``key_for(kind, key)`` override.
     """
-    if key_for is None:
-
-        def key_for(kind: str, key: StaticCaseKey) -> str:
-            template = body_key_template if kind == "body" else pref_key_template
-            return template.format(direction=key.direction, body=key.body, cp_config=key.cp_config)
-
-    def solve_fn(key: StaticCaseKey) -> PointsDataSource:
-        body = storage.read_data_source(key_for("body", key))
-        p_ref = storage.read_data_source(key_for("p_ref", key))
-        cp = cp_from_pressure(body, p_ref, case, statistics=cp_statistics)
-        cf = cf_per_floor(cp, mesh_path, case, method=method)
-        cm = cm_per_floor(cp, mesh_path, case, method=method)
-        load = floor_load_source(cf, cm, case)
-        struct = (
-            structure
-            if structure is not None
-            else example_building_structure(case, load.n_elements)
-        )
-        response = solve_building_response(
-            load, struct, damping_ratio=damping_ratio, check_sampling=check_sampling
-        )
-        result = floor_accelerations(response, struct, point=point)
-        # attach the applied-static floor loads so get_stats_forces_effective /
-        # effective_load_stats combine them with the dynamic static-equivalent
-        return (
-            result.with_field("fs_x", load.fields.read("cf_x"))
-            .with_field("fs_y", load.fields.read("cf_y"))
-            .with_field("ms_z", load.fields.read("cm_z"))
-        )
-
-    return solve_fn
+    return StaticSolveFn(
+        case=case,
+        storage=storage,
+        mesh_path=mesh_path,
+        structure=structure,
+        method=method,
+        damping_ratio=damping_ratio,
+        check_sampling=check_sampling,
+        point=point,
+        cp_statistics=cp_statistics,
+        body_key_template=body_key_template,
+        pref_key_template=pref_key_template,
+        key_for=key_for,
+    )
 
 
 def run_fanout(

--- a/tests/building/test_fanout.py
+++ b/tests/building/test_fanout.py
@@ -129,3 +129,56 @@ def test_run_fanout_pool_seam(tmp_path):
     assert len(container) == 1
     (response,) = container.values()
     assert np.all(np.isfinite(np.asarray(response.fields.read("feq_x"))))
+
+
+def _template_solve_fn(check_sampling: bool = False):
+    """A solve_fn built from key *templates*, so it carries no local closure."""
+    from cfdmod.adapters.xdmf_h5 import XdmfH5Storage
+
+    return build_static_solve_fn(
+        example_building_case(MESH, n_floors=3),
+        XdmfH5Storage(DATA),
+        MESH,
+        body_key_template="bodies.{body}",
+        pref_key_template="points.static_pressure",
+        check_sampling=check_sampling,
+    )
+
+
+@pytest.mark.unit
+def test_solve_fn_pickles():
+    """The property a real Pool needs, and the one SyncPool cannot check.
+
+    `build_static_solve_fn` returned a closure, which pickle refuses, so
+    `run_fanout(pool=multiprocessing.Pool())` died on its first dispatch. The
+    existing pool test uses an in-process SyncPool, which never pickles
+    anything and so could not see it.
+    """
+    import pickle
+
+    solve_fn = _template_solve_fn()
+    restored = pickle.loads(pickle.dumps(solve_fn))
+
+    assert restored.mesh_path == solve_fn.mesh_path
+    assert restored.storage_key("body", StaticCaseKey(direction="0", body="galpao")) == (
+        "bodies.galpao"
+    )
+
+
+@pytest.mark.integration
+def test_run_fanout_with_a_real_process_pool():
+    """End to end across a process boundary, not a stand-in for one."""
+    import multiprocessing
+
+    plan = FanoutPlan(directions_by_category={"": ["0"]}, bodies=["galpao"])
+    solve_fn = _template_solve_fn()
+
+    sequential = run_fanout(plan, solve_fn)
+    with multiprocessing.get_context("spawn").Pool(1) as pool:
+        parallel = run_fanout(plan, solve_fn, pool=pool)
+
+    assert len(parallel) == len(sequential) == 1
+    np.testing.assert_allclose(
+        np.asarray(next(iter(parallel.values())).fields.read("feq_x")),
+        np.asarray(next(iter(sequential.values())).fields.read("feq_x")),
+    )


### PR DESCRIPTION
Closes #227.

## The issue's premise was wrong; the bug behind it is real

#227 was filed to **remove** `Pool` as an unused abstraction. It is not unused: `cfdmod/building/fanout.py` and `cfdmod/dynamics/cases.py` both accept one, `run_fanout` dispatches through `pool.map`, and there is a test. My original grep only looked for call sites *inside* the library, and there are none by design - the caller supplies the pool. The seam is deliberate and its unit of parallelism (a whole case / direction per worker) is the right one.

What is broken is that the seam does not work:

```
>>> pickle.dumps(build_static_solve_fn(case, storage, mesh))
AttributeError: Can't pickle local object 'build_static_solve_fn.<locals>.solve_fn'
```

`build_static_solve_fn` returned a closure. `run_fanout(pool=multiprocessing.Pool())` therefore failed on its first dispatch - despite the module docstring claiming the solve_fn "must be picklable, so it re-reads its inputs from `storage` inside the worker". The re-reading half was implemented. The picklable half was not.

**Why no test caught it:** the only pool test passes a `SyncPool` that calls the function in-process. A synchronous stand-in never pickles anything, so it cannot fail the way a real pool does. This is the interesting part of the bug - the test existed and was shaped so that it could not fail.

## The fix

`StaticSolveFn`, a module-level callable object with the same behaviour. It holds no data source - case, storage handle, mesh path and scalar options - so nothing large ships per task and each call still re-reads its body and reference pressure from storage inside the worker.

A custom `key_for` must itself be picklable for pool use (a module-level function or callable object, not a lambda). Documented, and the new tests use the key *templates* rather than a nested function.

## Tests

- `test_solve_fn_pickles` - the round trip, plus that the restored object resolves storage keys identically.
- `test_run_fanout_with_a_real_process_pool` - `multiprocessing.get_context("spawn").Pool`, asserting the parallel result equals the sequential one. A real process boundary, not a stand-in for one.

Verified `XdmfH5Storage` and `MemoryStorage` both survive the round trip, since the storage handle travels with the callable.

## Verified

- `uv run pytest --all-extras`: **886 collected, all passed**, exit 0.
- `uv run ruff check` / `format --check` clean.

**Not run:** `dagger call --source=. check`, so the Sphinx docs build is not covered.